### PR TITLE
Fix SIZES for torch tensors

### DIFF
--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -25,8 +25,12 @@ def save(tensors: Dict[str, torch.Tensor]) -> bytes:
 SIZE = {
     torch.bfloat16: 2,
     torch.float16: 2,
+    torch.float32: 4,
+    torch.uint8: 1,
+    torch.int8: 1,
+    torch.int16: 2,
     torch.int32: 4,
-    torch.int64: 4,
+    torch.int64: 8,
 }
 
 


### PR DESCRIPTION
This PR fixes the SIZE in bytes of `torch.int64` and adds a few other dtypes. With it I can serialize and deserialize a classic BERT model.