### PR TITLE
Python slice API proposition

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = { version = "0.17.1", features = ["extension-module"] }
 memmap = "0.7"
+serde_json = "1.0"
 
 [dependencies.safetensors]
 version = "*"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -9,7 +9,7 @@ name = "safetensors_rust"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.15.1", features = ["extension-module"] }
+pyo3 = { version = "0.17.1", features = ["extension-module"] }
 memmap = "0.7"
 
 [dependencies.safetensors]

--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -33,6 +33,21 @@ SIZE = {
     torch.int64: 8,
 }
 
+DTYPES = {
+    "F32": torch.float32,
+    "BF16": torch.bfloat16,
+    "F16": torch.float16,
+    "U8": torch.uint8,
+    "I8": torch.int8,
+    "I16": torch.int16,
+    "I32": torch.int32,
+    "I64": torch.int64,
+}
+
+
+def to_dtype(dtype_str: str) -> torch.dtype:
+    return DTYPES[dtype_str]
+
 
 def tobytes(tensor: torch.Tensor) -> bytes:
     import ctypes

--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -33,21 +33,6 @@ SIZE = {
     torch.int64: 8,
 }
 
-DTYPES = {
-    "F32": torch.float32,
-    "BF16": torch.bfloat16,
-    "F16": torch.float16,
-    "U8": torch.uint8,
-    "I8": torch.int8,
-    "I16": torch.int16,
-    "I32": torch.int32,
-    "I64": torch.int64,
-}
-
-
-def to_dtype(dtype_str: str) -> torch.dtype:
-    return DTYPES[dtype_str]
-
 
 def tobytes(tensor: torch.Tensor) -> bytes:
     import ctypes

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -8,7 +8,7 @@ use safetensors::{Dtype, SafeTensors, Tensor};
 use std::collections::HashMap;
 use std::fs::File;
 
-fn prepare<'a>(tensor_dict: HashMap<String, &'a PyDict>) -> PyResult<HashMap<String, Tensor<'a>>> {
+fn prepare(tensor_dict: HashMap<String, &PyDict>) -> PyResult<HashMap<String, Tensor<'_>>> {
     let mut tensors = HashMap::new();
     for (tensor_name, tensor_desc) in tensor_dict {
         let mut shape: Vec<usize> = vec![];
@@ -62,7 +62,7 @@ fn serialize<'a, 'b>(
 }
 
 #[pyfunction]
-fn serialize_file<'a>(tensor_dict: HashMap<String, &'a PyDict>, filename: &str) -> PyResult<()> {
+fn serialize_file(tensor_dict: HashMap<String, &PyDict>, filename: &str) -> PyResult<()> {
     let tensors = prepare(tensor_dict)?;
     safetensors::serialize_to_file(&tensors, filename)?;
     Ok(())
@@ -78,7 +78,7 @@ fn deserialize(py: Python, bytes: &[u8]) -> PyResult<Vec<(String, HashMap<String
     for (tensor_name, tensor) in safetensor.tensors() {
         let mut map = HashMap::new();
 
-        let pyshape: PyObject = PyList::new(py, tensor.get_shape().into_iter()).into();
+        let pyshape: PyObject = PyList::new(py, tensor.get_shape().iter()).into();
         let pydtype: PyObject = format!("{:?}", tensor.get_dtype()).into_py(py);
 
         let pydata: PyObject = PyByteArray::new(py, tensor.get_data()).into();

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,12 +1,13 @@
 #![deny(missing_docs)]
 //! Dummy doc
-use memmap::MmapOptions;
+use memmap::{Mmap, MmapOptions};
 use pyo3::exceptions;
 use pyo3::prelude::*;
 use pyo3::types::{PyByteArray, PyBytes, PyDict, PyList};
 use safetensors::{Dtype, SafeTensors, Tensor};
 use std::collections::HashMap;
 use std::fs::File;
+use std::sync::Arc;
 
 fn prepare(tensor_dict: HashMap<String, &PyDict>) -> PyResult<HashMap<String, Tensor<'_>>> {
     let mut tensors = HashMap::new();
@@ -132,55 +133,143 @@ fn slice_to_indexer(slice: &PySlice) -> Result<TensorIndexer, PyErr> {
     Ok(TensorIndexer::Narrow(start, stop))
 }
 
-#[pyfunction]
-fn deserialize_file_slice(
-    py: Python,
-    filename: &str,
-    tensor_name: &str,
-    slices: Vec<&PySlice>,
-) -> PyResult<HashMap<String, PyObject>> {
-    let file = File::open(filename)?;
+use pyo3::types::IntoPyDict;
+use safetensors::{Metadata, TensorInfo, TensorView};
 
-    // SAFETY: Mmap is used to prevent allocating in Rust
-    // before making a copy within Python.
-    let mmap = unsafe { MmapOptions::new().map(&file)? };
-    let safetensor = SafeTensors::deserialize(&mmap).map_err(|e| {
-        exceptions::PyException::new_err(format!("Error while deserializing: {:?}", e))
-    })?;
-    let tensor = safetensor
-        .tensor(tensor_name)
-        .map_err(|e| exceptions::PyException::new_err(format!("Tensor not found {:?}", e)))?;
-    let mut map = HashMap::new();
+#[derive(Clone)]
+enum Framework {
+    Pytorch,
+    Numpy,
+    Tensorflow,
+    Jax,
+}
 
-    let pyshape: PyObject = PyList::new(py, tensor.get_shape().iter()).into();
-    let pydtype: PyObject = format!("{:?}", tensor.get_dtype()).into_py(py);
+impl<'source> FromPyObject<'source> for Framework {
+    fn extract(ob: &'source PyAny) -> PyResult<Self> {
+        let name: String = ob.extract()?;
+        match &name[..] {
+            "pt" => Ok(Framework::Pytorch),
+            "np" => Ok(Framework::Numpy),
+            "tf" => Ok(Framework::Tensorflow),
+            "jax" => Ok(Framework::Jax),
+            name => Err(exceptions::PyException::new_err(format!(
+                "framework {name} is invalid"
+            ))),
+        }
+    }
+}
 
-    let slices: Vec<TensorIndexer> = slices
-        .into_iter()
-        .map(slice_to_indexer)
-        .collect::<Result<_, _>>()?;
-    let iterator = tensor
-        .get_sliced_data(slices)
-        .map_err(|e| exceptions::PyException::new_err(format!("Erro during slicing {:?}", e)))?;
+#[pyclass]
+struct PySafeFile {
+    metadata: Metadata,
+    offset: usize,
+    framework: Framework,
+    mmap: Arc<Mmap>,
+}
+#[pymethods]
+impl PySafeFile {
+    #[new]
+    fn new(filename: &str, framework: Framework) -> PyResult<Self> {
+        let file = File::open(filename)?;
 
-    let mut offset = 0;
-    let pydata: PyObject =
-        PyByteArray::new_with(py, iterator.remaining_byte_len(), |bytes: &mut [u8]| {
-            for slice in iterator {
-                let len = slice.len();
-                bytes[offset..offset + slice.len()].copy_from_slice(slice);
-                offset += len
+        // SAFETY: Mmap is used to prevent allocating in Rust
+        // before making a copy within Python.
+        let buffer = unsafe { MmapOptions::new().map(&file)? };
+
+        let arr: [u8; 8] = [
+            buffer[0], buffer[1], buffer[2], buffer[3], buffer[4], buffer[5], buffer[6], buffer[7],
+        ];
+        let n = u64::from_le_bytes(arr) as usize;
+        let string = std::str::from_utf8(&buffer[8..8 + n]).map_err(|e| {
+            exceptions::PyException::new_err(format!("Error while deserializing header: {:?}", e))
+        })?;
+        let metadata: Metadata = serde_json::from_str(string).map_err(|e| {
+            exceptions::PyException::new_err(format!("Error while deserializing metadata: {:?}", e))
+        })?;
+
+        let offset = n + 8;
+
+        Ok(Self {
+            metadata,
+            offset,
+            framework,
+            mmap: Arc::new(buffer),
+        })
+    }
+
+    pub fn __getitem__(&self, name: &str) -> PyResult<PySafeTensor> {
+        if let Some(info) = self.metadata.0.get(name) {
+            Ok(PySafeTensor {
+                info: info.clone(),
+                framework: self.framework.clone(),
+                offset: self.offset,
+                mmap: self.mmap.clone(),
+            })
+        } else {
+            Err(exceptions::PyException::new_err(format!(
+                "File does not contain tensor {name}",
+            )))
+        }
+    }
+
+    pub fn __enter__(slf: Py<Self>) -> Py<Self> {
+        slf
+    }
+
+    pub fn __exit__(&mut self, _exc_type: PyObject, _exc_value: PyObject, _traceback: PyObject) {}
+}
+
+#[pyclass]
+struct PySafeTensor {
+    info: TensorInfo,
+    framework: Framework,
+    offset: usize,
+    mmap: Arc<Mmap>,
+}
+
+#[pymethods]
+impl PySafeTensor {
+    pub fn __getitem__(&self, py: Python, slices: Vec<&PySlice>) -> PyResult<PyObject> {
+        let data = &self.mmap
+            [self.info.data_offsets.0 + self.offset..self.info.data_offsets.1 + self.offset];
+        let tensor = TensorView::new(&self.info.dtype, &self.info.shape, &data);
+        let slices: Vec<TensorIndexer> = slices
+            .into_iter()
+            .map(slice_to_indexer)
+            .collect::<Result<_, _>>()?;
+        let iterator = tensor.get_sliced_data(slices).map_err(|e| {
+            exceptions::PyException::new_err(format!("Erro during slicing {:?}", e))
+        })?;
+        let newshape = iterator.newshape();
+
+        let mut offset = 0;
+        let array: PyObject =
+            PyByteArray::new_with(py, iterator.remaining_byte_len(), |bytes: &mut [u8]| {
+                for slice in iterator {
+                    let len = slice.len();
+                    bytes[offset..offset + slice.len()].copy_from_slice(slice);
+                    offset += len
+                }
+                Ok(())
+            })?
+            .into_py(py);
+        match self.framework {
+            Framework::Pytorch => {
+                let module = PyModule::import(py, "torch")?;
+                let frombuffer = module.getattr("frombuffer")?;
+                let dtype: PyObject = match self.info.dtype {
+                    Dtype::F32 => module.getattr("float32")?.into(),
+                    _ => todo!("Pytorch dtypes"),
+                };
+                let kwargs = [("buffer", array), ("dtype", dtype)].into_py_dict(py);
+                let tensor = frombuffer.call((), Some(kwargs))?;
+                let newshape: PyObject = newshape.into_py(py);
+                let tensor: PyObject = tensor.getattr("view")?.call1((newshape,))?.into();
+                Ok(tensor)
             }
-            Ok(())
-        })?
-        .into();
-
-    map.insert("shape".to_string(), pyshape);
-    map.insert("dtype".to_string(), pydtype);
-    map.insert("data".to_string(), pydata);
-    // Make sure mmap does not leak.
-    drop(mmap);
-    Ok(map)
+            _ => todo!(),
+        }
+    }
 }
 
 /// A Python module implemented in Rust.
@@ -190,6 +279,6 @@ fn safetensors_rust(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(serialize_file, m)?)?;
     m.add_function(wrap_pyfunction!(deserialize, m)?)?;
     m.add_function(wrap_pyfunction!(deserialize_file, m)?)?;
-    m.add_function(wrap_pyfunction!(deserialize_file_slice, m)?)?;
+    m.add_class::<PySafeFile>()?;
     Ok(())
 }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -198,6 +198,10 @@ impl safe_open {
         })
     }
 
+    pub fn get_keys(&self) -> PyResult<Vec<String>> {
+        Ok(self.metadata.0.keys().cloned().collect())
+    }
+
     pub fn get_tensor(&self, py: Python, name: &str) -> PyResult<PyObject> {
         if let Some(info) = self.metadata.0.get(name) {
             let data =

--- a/bindings/python/tests/test_pt_comparison.py
+++ b/bindings/python/tests/test_pt_comparison.py
@@ -41,18 +41,16 @@ class SliceTestCase(unittest.TestCase):
         save_file(self.data.copy(), self.local)
 
     def test_deserialization_slice(self):
-        from safetensors.safetensors_rust import deserialize_file_slice
+        from safetensors.safetensors_rust import PySafeFile
 
-        slices = (slice(None), slice(None), slice(1, 2))
+        with PySafeFile(self.local, framework="pt") as f:
+            tensor = f["test"][:, :, 1:2]
 
-        item = deserialize_file_slice(self.local, "test", slices)
         self.assertEqual(
-            item["data"],
+            tensor.numpy().tobytes(),
             b"\x00\x00\x80?\x00\x00\x80@",
         )
 
-        dtype = to_dtype(item["dtype"])
-        tensor = torch.frombuffer(item["data"], dtype=dtype).view(1, 2, 1)
         self.assertTrue(torch.equal(tensor, torch.Tensor([[[1.0], [4.0]]])))
         self.assertTrue(torch.equal(tensor, self.tensor[:, :, 1:2]))
 

--- a/bindings/python/tests/test_pt_comparison.py
+++ b/bindings/python/tests/test_pt_comparison.py
@@ -1,5 +1,6 @@
 import unittest
-from safetensors.torch import save_file, load_file, load, to_dtype
+from safetensors.torch import save_file, load_file, load
+from safetensors.safetensors_rust import safe_open
 from huggingface_hub import hf_hub_download
 import torch
 import datetime
@@ -41,10 +42,9 @@ class SliceTestCase(unittest.TestCase):
         save_file(self.data.copy(), self.local)
 
     def test_deserialization_slice(self):
-        from safetensors.safetensors_rust import PySafeFile
 
-        with PySafeFile(self.local, framework="pt") as f:
-            tensor = f["test"][:, :, 1:2]
+        with safe_open(self.local, framework="pt") as f:
+            tensor = f.get_slice("test")[:, :, 1:2]
 
         self.assertEqual(
             tensor.numpy().tobytes(),

--- a/safetensors/src/lib.rs
+++ b/safetensors/src/lib.rs
@@ -66,7 +66,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 
-mod slice;
+pub mod slice;
 use crate::slice::{InvalidSlice, SliceIterator, TensorIndexer};
 
 /// Possible errors that could occur while reading

--- a/safetensors/src/lib.rs
+++ b/safetensors/src/lib.rs
@@ -217,7 +217,7 @@ impl<'data> SafeTensors<'data> {
 /// The stuct representing the header of safetensor files which allow
 /// indexing into the raw byte-buffer array and how to interpret it.
 #[derive(Debug, Deserialize, Serialize)]
-struct Metadata(HashMap<String, TensorInfo>);
+pub struct Metadata(pub HashMap<String, TensorInfo>);
 
 /// A view of a Tensor within the file.
 /// Contains references to data within the full byte-buffer
@@ -230,6 +230,10 @@ pub struct TensorView<'data> {
 }
 
 impl<'data> TensorView<'data> {
+    /// Create new tensor view
+    pub fn new(dtype: &'data Dtype, shape: &'data [usize], data: &'data [u8]) -> Self {
+        Self { dtype, shape, data }
+    }
     /// The current tensor dtype
     pub fn get_dtype(&self) -> &'data Dtype {
         self.dtype
@@ -260,13 +264,13 @@ impl<'data> TensorView<'data> {
 /// Endianness is assumed to be little endian
 /// Ordering is assumed to be 'C'.
 #[derive(Debug, Deserialize, Serialize, Clone)]
-struct TensorInfo {
+pub struct TensorInfo {
     /// The type of each element of the tensor
-    dtype: Dtype,
+    pub dtype: Dtype,
     /// The shape of the tensor
-    shape: Vec<usize>,
+    pub shape: Vec<usize>,
     /// The offsets to find the data within the byte-buffer array.
-    data_offsets: (usize, usize),
+    pub data_offsets: (usize, usize),
 }
 
 /// The various available dtypes

--- a/safetensors/src/lib.rs
+++ b/safetensors/src/lib.rs
@@ -252,7 +252,7 @@ impl<'data> TensorView<'data> {
         &'data self,
         slices: Vec<TensorIndexer>,
     ) -> Result<SliceIterator<'data>, InvalidSlice> {
-        SliceIterator::new(&self, slices)
+        SliceIterator::new(self, slices)
     }
 }
 
@@ -382,8 +382,7 @@ mod tests {
             .unwrap()
             .i((.., ..1))
             .unwrap()
-            .map(|b| b.to_vec())
-            .flatten()
+            .flat_map(|b| b.to_vec())
             .collect();
         assert_eq!(out_buffer, vec![0u8, 0, 0, 0, 0, 0, 128, 63, 0, 0, 0, 64]);
         assert_eq!(
@@ -398,8 +397,7 @@ mod tests {
             .unwrap()
             .i((.., .., ..1))
             .unwrap()
-            .map(|b| b.to_vec())
-            .flatten()
+            .flat_map(|b| b.to_vec())
             .collect();
         assert_eq!(out_buffer, vec![0u8, 0, 0, 0, 0, 0, 64, 64]);
         assert_eq!(

--- a/safetensors/src/slice.rs
+++ b/safetensors/src/slice.rs
@@ -9,7 +9,7 @@ pub enum InvalidSlice {
     TooManySlices,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum TensorIndexer {
     //Select(usize),
     Narrow(Bound<usize>, Bound<usize>),
@@ -295,7 +295,7 @@ mod tests {
 
         let attn_0 = TensorView {
             dtype: &Dtype::F32,
-            shape: &vec![1, 2, 3],
+            shape: &[1, 2, 3],
             data: &data,
         };
 
@@ -362,7 +362,7 @@ mod tests {
 
         let attn_0 = TensorView {
             dtype: &Dtype::F32,
-            shape: &vec![1, 2, 3],
+            shape: &[1, 2, 3],
             data: &data,
         };
 

--- a/safetensors/src/slice.rs
+++ b/safetensors/src/slice.rs
@@ -275,7 +275,9 @@ impl<'data> Iterator for SliceIterator<'data> {
     type Item = &'data [u8];
 
     fn next(&mut self) -> Option<Self::Item> {
-        // TODO
+        // TODO We might want to move the logic from `new`
+        // here actually to remove the need to get all the indices
+        // upfront.
         let (start, stop) = self.indices.pop()?;
         Some(&self.view.data[start..stop])
     }

--- a/safetensors/src/slice.rs
+++ b/safetensors/src/slice.rs
@@ -1,0 +1,416 @@
+use crate::TensorView;
+use std::ops::{
+    Bound, Range, RangeBounds, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
+};
+
+/// Error representing invalid slicing attempt
+#[derive(Debug)]
+pub enum InvalidSlice {
+    TooManySlices,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum TensorIndexer {
+    //Select(usize),
+    Narrow(Bound<usize>, Bound<usize>),
+    //IndexSelect(Tensor),
+}
+
+// impl From<usize> for TensorIndexer {
+//     fn from(index: usize) -> Self {
+//         TensorIndexer::Select(index)
+//     }
+// }
+
+// impl From<&[usize]> for TensorIndexer {
+//     fn from(index: &[usize]) -> Self {
+//         let tensor = index.into();
+//         TensorIndexer::IndexSelect(tensor)
+//     }
+// }
+//
+// impl From<Vec<usize>> for TensorIndexer {
+//     fn from(index: Vec<usize>) -> Self {
+//         let tensor = Tensor::of_slice(&index);
+//         TensorIndexer::IndexSelect(tensor)
+//     }
+// }
+
+macro_rules! impl_from_range {
+    ($range_type:ty) => {
+        impl From<$range_type> for TensorIndexer {
+            fn from(range: $range_type) -> Self {
+                use std::ops::Bound::*;
+
+                let start = match range.start_bound() {
+                    Included(idx) => Included(*idx),
+                    Excluded(idx) => Excluded(*idx),
+                    Unbounded => Unbounded,
+                };
+
+                let end = match range.end_bound() {
+                    Included(idx) => Included(*idx),
+                    Excluded(idx) => Excluded(*idx),
+                    Unbounded => Unbounded,
+                };
+
+                TensorIndexer::Narrow(start, end)
+            }
+        }
+    };
+}
+
+impl_from_range!(Range<usize>);
+impl_from_range!(RangeFrom<usize>);
+impl_from_range!(RangeFull);
+impl_from_range!(RangeInclusive<usize>);
+impl_from_range!(RangeTo<usize>);
+impl_from_range!(RangeToInclusive<usize>);
+
+pub trait IndexOp<'data, T> {
+    fn i(&'data self, index: T) -> Result<SliceIterator<'data>, InvalidSlice>;
+}
+
+impl<'data, A> IndexOp<'data, A> for TensorView<'data>
+where
+    A: Into<TensorIndexer>,
+{
+    fn i(&'data self, index: A) -> Result<SliceIterator<'data>, InvalidSlice> {
+        self.get_sliced_data(vec![index.into()])
+    }
+}
+
+impl<'data, A> IndexOp<'data, (A,)> for TensorView<'data>
+where
+    A: Into<TensorIndexer>,
+{
+    fn i(&'data self, index: (A,)) -> Result<SliceIterator<'data>, InvalidSlice> {
+        let idx_a = index.0.into();
+        self.get_sliced_data(vec![idx_a])
+    }
+}
+
+impl<'data, A, B> IndexOp<'data, (A, B)> for TensorView<'data>
+where
+    A: Into<TensorIndexer>,
+    B: Into<TensorIndexer>,
+{
+    fn i(&'data self, index: (A, B)) -> Result<SliceIterator<'data>, InvalidSlice> {
+        let idx_a = index.0.into();
+        let idx_b = index.1.into();
+        self.get_sliced_data(vec![idx_a, idx_b])
+    }
+}
+
+impl<'data, A, B, C> IndexOp<'data, (A, B, C)> for TensorView<'data>
+where
+    A: Into<TensorIndexer>,
+    B: Into<TensorIndexer>,
+    C: Into<TensorIndexer>,
+{
+    fn i(&'data self, index: (A, B, C)) -> Result<SliceIterator<'data>, InvalidSlice> {
+        let idx_a = index.0.into();
+        let idx_b = index.1.into();
+        let idx_c = index.2.into();
+        self.get_sliced_data(vec![idx_a, idx_b, idx_c])
+    }
+}
+
+// impl<A, B, C, D> IndexOp<(A, B, C, D)> for TensorView<'data>
+// where
+//     A: Into<TensorIndexer>,
+//     B: Into<TensorIndexer>,
+//     C: Into<TensorIndexer>,
+//     D: Into<TensorIndexer>,
+// {
+//     fn i(&self, index: (A, B, C, D)) -> TensorView<'data> {
+//         let idx_a = index.0.into();
+//         let idx_b = index.1.into();
+//         let idx_c = index.2.into();
+//         let idx_d = index.3.into();
+//         self.get_sliced_data(&[idx_a, idx_b, idx_c, idx_d])
+//     }
+// }
+//
+// impl<A, B, C, D, E> IndexOp<(A, B, C, D, E)> for TensorView<'data>
+// where
+//     A: Into<TensorIndexer>,
+//     B: Into<TensorIndexer>,
+//     C: Into<TensorIndexer>,
+//     D: Into<TensorIndexer>,
+//     E: Into<TensorIndexer>,
+// {
+//     fn i(&self, index: (A, B, C, D, E)) -> TensorView<'data> {
+//         let idx_a = index.0.into();
+//         let idx_b = index.1.into();
+//         let idx_c = index.2.into();
+//         let idx_d = index.3.into();
+//         let idx_e = index.4.into();
+//         self.get_sliced_data(&[idx_a, idx_b, idx_c, idx_d, idx_e])
+//     }
+// }
+//
+// impl<A, B, C, D, E, F> IndexOp<(A, B, C, D, E, F)> for TensorView<'data>
+// where
+//     A: Into<TensorIndexer>,
+//     B: Into<TensorIndexer>,
+//     C: Into<TensorIndexer>,
+//     D: Into<TensorIndexer>,
+//     E: Into<TensorIndexer>,
+//     F: Into<TensorIndexer>,
+// {
+//     fn i(&self, index: (A, B, C, D, E, F)) -> TensorView<'data> {
+//         let idx_a = index.0.into();
+//         let idx_b = index.1.into();
+//         let idx_c = index.2.into();
+//         let idx_d = index.3.into();
+//         let idx_e = index.4.into();
+//         let idx_f = index.5.into();
+//         self.get_sliced_data(&[idx_a, idx_b, idx_c, idx_d, idx_e, idx_f])
+//     }
+// }
+//
+// impl<A, B, C, D, E, F, G> IndexOp<(A, B, C, D, E, F, G)> for TensorView<'data>
+// where
+//     A: Into<TensorIndexer>,
+//     B: Into<TensorIndexer>,
+//     C: Into<TensorIndexer>,
+//     D: Into<TensorIndexer>,
+//     E: Into<TensorIndexer>,
+//     F: Into<TensorIndexer>,
+//     G: Into<TensorIndexer>,
+// {
+//     fn i(&self, index: (A, B, C, D, E, F, G)) -> TensorView<'data> {
+//         let idx_a = index.0.into();
+//         let idx_b = index.1.into();
+//         let idx_c = index.2.into();
+//         let idx_d = index.3.into();
+//         let idx_e = index.4.into();
+//         let idx_f = index.5.into();
+//         let idx_g = index.6.into();
+//         self.get_sliced_data(&[idx_a, idx_b, idx_c, idx_d, idx_e, idx_f, idx_g])
+//     }
+// }
+
+/// Iterator used to return the bits of the overall tensor buffer
+/// when client asks for a slice of the original tensor.
+pub struct SliceIterator<'data> {
+    view: &'data TensorView<'data>,
+    indices: Vec<(usize, usize)>,
+}
+
+impl<'data> SliceIterator<'data> {
+    pub(crate) fn new(
+        view: &'data TensorView<'data>,
+        slices: Vec<TensorIndexer>,
+    ) -> Result<Self, InvalidSlice> {
+        // Make sure n. axis does not exceed n. of dimensions
+        let n_slice = slices.len();
+        let n_shape = view.shape.len();
+        if n_slice > n_shape {
+            return Err(InvalidSlice::TooManySlices);
+        }
+
+        // Minimum span is the span of 1 item;
+        let mut span = view.dtype.size();
+        let mut indices = vec![];
+        // Everything is row major.
+        for (i, &shape) in view.shape.iter().enumerate().rev() {
+            if i >= slices.len() {
+                // We are  not slicing yet, just increase the local span
+                span *= shape;
+            } else {
+                let slice = &slices[i];
+                let (start, stop) = match slice {
+                    TensorIndexer::Narrow(Bound::Unbounded, Bound::Unbounded) => (0, shape),
+                    TensorIndexer::Narrow(Bound::Unbounded, Bound::Excluded(stop)) => (0, *stop),
+                    TensorIndexer::Narrow(Bound::Unbounded, Bound::Included(stop)) => {
+                        (0, *stop + 1)
+                    }
+                    TensorIndexer::Narrow(Bound::Included(s), Bound::Unbounded) => (*s, shape),
+                    TensorIndexer::Narrow(Bound::Included(s), Bound::Excluded(stop)) => (*s, *stop),
+                    TensorIndexer::Narrow(Bound::Included(s), Bound::Included(stop)) => {
+                        (*s, *stop + 1)
+                    }
+                    TensorIndexer::Narrow(Bound::Excluded(s), Bound::Unbounded) => (*s + 1, shape),
+                    TensorIndexer::Narrow(Bound::Excluded(s), Bound::Excluded(stop)) => {
+                        (*s + 1, *stop)
+                    }
+                    TensorIndexer::Narrow(Bound::Excluded(s), Bound::Included(stop)) => {
+                        (*s + 1, *stop + 1)
+                    }
+                };
+                if indices.is_empty() {
+                    if start == 0 && stop == shape {
+                        // We haven't started to slice yet, just increase the span
+                        span *= shape;
+                    } else {
+                        let offset = start * span;
+                        span = stop * span - offset;
+                        indices.push((offset, offset + span));
+                        span *= shape;
+                    }
+                } else {
+                    let mut newindices = vec![];
+                    for n in start..stop {
+                        let offset = n * span;
+                        for (old_start, old_stop) in &indices {
+                            newindices.push((old_start + offset, old_stop + offset));
+                        }
+                    }
+                    indices = newindices;
+                }
+            }
+        }
+        if indices.is_empty() {
+            indices.push((0, view.data.len()));
+        }
+        // Reversing so we can pop faster while iterating on the slice
+        let indices = indices.into_iter().rev().collect();
+        Ok(Self { view, indices })
+    }
+}
+
+impl<'data> Iterator for SliceIterator<'data> {
+    type Item = &'data [u8];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // TODO
+        let (start, stop) = self.indices.pop()?;
+        Some(&self.view.data[start..stop])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Dtype, TensorView};
+
+    #[test]
+    fn test_dummy() {
+        let data: Vec<u8> = vec![0.0f32, 1.0, 2.0, 3.0, 4.0, 5.0]
+            .into_iter()
+            .flat_map(|f| f.to_le_bytes())
+            .collect();
+
+        let attn_0 = TensorView {
+            dtype: &Dtype::F32,
+            shape: &vec![1, 2, 3],
+            data: &data,
+        };
+
+        let mut iterator = SliceIterator::new(
+            &attn_0,
+            vec![TensorIndexer::Narrow(Bound::Unbounded, Bound::Unbounded)],
+        )
+        .unwrap();
+        assert_eq!(iterator.next(), Some(&data[0..24]));
+        assert_eq!(iterator.next(), None);
+
+        let mut iterator = SliceIterator::new(
+            &attn_0,
+            vec![
+                TensorIndexer::Narrow(Bound::Unbounded, Bound::Unbounded),
+                TensorIndexer::Narrow(Bound::Unbounded, Bound::Unbounded),
+            ],
+        )
+        .unwrap();
+        assert_eq!(iterator.next(), Some(&data[0..24]));
+        assert_eq!(iterator.next(), None);
+
+        let mut iterator = SliceIterator::new(
+            &attn_0,
+            vec![
+                TensorIndexer::Narrow(Bound::Unbounded, Bound::Unbounded),
+                TensorIndexer::Narrow(Bound::Unbounded, Bound::Unbounded),
+            ],
+        )
+        .unwrap();
+        assert_eq!(iterator.next(), Some(&data[0..24]));
+        assert_eq!(iterator.next(), None);
+
+        let mut iterator = SliceIterator::new(
+            &attn_0,
+            vec![
+                TensorIndexer::Narrow(Bound::Unbounded, Bound::Unbounded),
+                TensorIndexer::Narrow(Bound::Unbounded, Bound::Unbounded),
+                TensorIndexer::Narrow(Bound::Unbounded, Bound::Unbounded),
+            ],
+        )
+        .unwrap();
+        assert_eq!(iterator.next(), Some(&data[0..24]));
+        assert_eq!(iterator.next(), None);
+
+        assert!(SliceIterator::new(
+            &attn_0,
+            vec![
+                TensorIndexer::Narrow(Bound::Unbounded, Bound::Unbounded),
+                TensorIndexer::Narrow(Bound::Unbounded, Bound::Unbounded),
+                TensorIndexer::Narrow(Bound::Unbounded, Bound::Unbounded),
+                TensorIndexer::Narrow(Bound::Unbounded, Bound::Unbounded),
+            ],
+        )
+        .is_err(),);
+    }
+
+    #[test]
+    fn test_slice_variety() {
+        let data: Vec<u8> = vec![0.0f32, 1.0, 2.0, 3.0, 4.0, 5.0]
+            .into_iter()
+            .flat_map(|f| f.to_le_bytes())
+            .collect();
+
+        let attn_0 = TensorView {
+            dtype: &Dtype::F32,
+            shape: &vec![1, 2, 3],
+            data: &data,
+        };
+
+        let mut iterator = SliceIterator::new(
+            &attn_0,
+            vec![TensorIndexer::Narrow(
+                Bound::Included(0),
+                Bound::Excluded(1),
+            )],
+        )
+        .unwrap();
+        assert_eq!(iterator.next(), Some(&data[0..24]));
+        assert_eq!(iterator.next(), None);
+
+        let mut iterator = SliceIterator::new(
+            &attn_0,
+            vec![
+                TensorIndexer::Narrow(Bound::Unbounded, Bound::Unbounded),
+                TensorIndexer::Narrow(Bound::Included(0), Bound::Excluded(1)),
+            ],
+        )
+        .unwrap();
+        assert_eq!(iterator.next(), Some(&data[0..12]));
+        assert_eq!(iterator.next(), None);
+
+        let mut iterator = SliceIterator::new(
+            &attn_0,
+            vec![
+                TensorIndexer::Narrow(Bound::Unbounded, Bound::Unbounded),
+                TensorIndexer::Narrow(Bound::Unbounded, Bound::Unbounded),
+                TensorIndexer::Narrow(Bound::Included(0), Bound::Excluded(1)),
+            ],
+        )
+        .unwrap();
+        assert_eq!(iterator.next(), Some(&data[0..4]));
+        assert_eq!(iterator.next(), Some(&data[12..16]));
+        assert_eq!(iterator.next(), None);
+
+        let mut iterator = SliceIterator::new(
+            &attn_0,
+            vec![
+                TensorIndexer::Narrow(Bound::Unbounded, Bound::Unbounded),
+                TensorIndexer::Narrow(Bound::Included(1), Bound::Excluded(2)),
+                TensorIndexer::Narrow(Bound::Included(0), Bound::Excluded(1)),
+            ],
+        )
+        .unwrap();
+        assert_eq!(iterator.next(), Some(&data[12..16]));
+        assert_eq!(iterator.next(), None);
+    }
+}


### PR DESCRIPTION
Much better API:

```python
with PySafeFile(self.local, framework="pt") as f:
      tensor = f["test"][:, :, 1:2]
```
Design:
- **Context manager**
This is meant to open a file, we need to close it, and this is the Python way (lazy load on a real buffer instead of a file doesn't have real advantages since torch is already able to not copy a single thing with striding in the first place)
- **Framework arg**:
I played with other ideas, as if the code was framework agnostic it would be easier on users on any kind of failure and to adapt directly within Python.
However, `memoryview` doesn't handle dtype, and `bfloat16` is only handled by pytorch, so using it as intermediary is not really as viable as I thought.
-  **f["test"]**
This object is ~equivalent to `TensorView<'data>` except we cannot have a lifetime on it, so it owns the Mmap instead.
This is *not* as `torch.Tensor` at this point, only when you slice into does it become `torch.Tensor`.
- **[:, :, 1:2]**
This is where we can calculate how to slice into the data, creating the buffer iteratively (so only once) as `PyByteArray` so we do actually avoid allocating the entire buffer here (hopefully). In order to avoid shape shenanigans, we simply return the `torch.Tensor` directly.

Pros:
- handles a lot of boilerplate for caller.
- Feels more pythonesque

Cons:
- Unsure about soundness of keeping Mmap struct (in PySafeFile), it's meant to be used as context manager, so it should clean up after itself.
- Lots more boilerplate in the binding code.

