### PR TITLE
PoC for additional metadata

### DIFF
--- a/bindings/python/py_src/safetensors/flax.py
+++ b/bindings/python/py_src/safetensors/flax.py
@@ -1,6 +1,6 @@
 from safetensors import numpy
 import numpy as np
-from typing import Dict
+from typing import Dict, Optional
 import jax.numpy as jnp
 
 
@@ -16,14 +16,22 @@ def jnp2np(jnp_dict: Dict[str, jnp.DeviceArray]) -> Dict[str, np.array]:
     return jnp_dict
 
 
-def save(tensors: Dict[str, jnp.DeviceArray]) -> bytes:
+def save(tensors: Dict[str, jnp.DeviceArray], metadata: Optional[Dict[str, str]] = None) -> bytes:
     np_tensors = jnp2np(tensors)
-    return numpy.save(np_tensors)
+    if metadata is None:
+        metadata = {}
+    if "format" not in metadata:
+        metadata["format"] = "flax"
+    return numpy.save(np_tensors, metadata=metadata)
 
 
-def save_file(tensors: Dict[str, jnp.DeviceArray], filename: str):
+def save_file(tensors: Dict[str, jnp.DeviceArray], filename: str, metadata: Optional[Dict[str, str]] = None):
     np_tensors = jnp2np(tensors)
-    return numpy.save_file(np_tensors, filename)
+    if metadata is None:
+        metadata = {}
+    if "format" not in metadata:
+        metadata["format"] = "flax"
+    return numpy.save_file(np_tensors, filename, metadata=metadata)
 
 
 def load(buffer: bytes) -> Dict[str, jnp.DeviceArray]:
@@ -34,3 +42,7 @@ def load(buffer: bytes) -> Dict[str, jnp.DeviceArray]:
 def load_file(filename: str) -> Dict[str, jnp.DeviceArray]:
     flat = numpy.load_file(filename)
     return np2jnp(flat)
+
+
+def read_metadata_in_file(filename: str) -> Dict[str, str]:
+    return numpy.read_metadata(filename)

--- a/bindings/python/py_src/safetensors/flax.py
+++ b/bindings/python/py_src/safetensors/flax.py
@@ -18,19 +18,11 @@ def jnp2np(jnp_dict: Dict[str, jnp.DeviceArray]) -> Dict[str, np.array]:
 
 def save(tensors: Dict[str, jnp.DeviceArray], metadata: Optional[Dict[str, str]] = None) -> bytes:
     np_tensors = jnp2np(tensors)
-    if metadata is None:
-        metadata = {}
-    if "format" not in metadata:
-        metadata["format"] = "flax"
     return numpy.save(np_tensors, metadata=metadata)
 
 
 def save_file(tensors: Dict[str, jnp.DeviceArray], filename: str, metadata: Optional[Dict[str, str]] = None):
     np_tensors = jnp2np(tensors)
-    if metadata is None:
-        metadata = {}
-    if "format" not in metadata:
-        metadata["format"] = "flax"
     return numpy.save_file(np_tensors, filename, metadata=metadata)
 
 

--- a/bindings/python/py_src/safetensors/numpy.py
+++ b/bindings/python/py_src/safetensors/numpy.py
@@ -8,10 +8,6 @@ def save(tensor_dict: Dict[str, np.ndarray], metadata: Optional[Dict[str, str]] 
         k: {"dtype": v.dtype.name, "shape": v.shape, "data": v.tobytes()}
         for k, v in tensor_dict.items()
     }
-    if metadata is None:
-        metadata = {}
-    if "format" not in metadata:
-        metadata["format"] = "np"
     serialized = serialize(flattened, metadata=metadata)
     result = bytes(serialized)
     return result
@@ -61,10 +57,6 @@ def save_file(tensor_dict: Dict[str, np.ndarray], filename: str, metadata: Optio
         k: {"dtype": v.dtype.name, "shape": v.shape, "data": v.tobytes()}
         for k, v in tensor_dict.items()
     }
-    if metadata is None:
-        metadata = {}
-    if "format" not in metadata:
-        metadata["format"] = "np"
     serialize_file(flattened, metadata, filename)
 
 

--- a/bindings/python/py_src/safetensors/numpy.py
+++ b/bindings/python/py_src/safetensors/numpy.py
@@ -1,14 +1,18 @@
 import numpy as np
-from .safetensors_rust import deserialize, serialize, deserialize_file, serialize_file
-from typing import Dict
+from .safetensors_rust import deserialize, serialize, deserialize_file, serialize_file, read_metadata
+from typing import Dict, Optional
 
 
-def save(tensor_dict: Dict[str, np.ndarray]) -> bytes:
+def save(tensor_dict: Dict[str, np.ndarray], metadata: Optional[Dict[str, str]] = None) -> bytes:
     flattened = {
         k: {"dtype": v.dtype.name, "shape": v.shape, "data": v.tobytes()}
         for k, v in tensor_dict.items()
     }
-    serialized = serialize(flattened)
+    if metadata is None:
+        metadata = {}
+    if "format" not in metadata:
+        metadata["format"] = "np"
+    serialized = serialize(flattened, metadata=metadata)
     result = bytes(serialized)
     return result
 
@@ -52,9 +56,17 @@ def view2np(safeview):
     return result
 
 
-def save_file(tensor_dict: Dict[str, np.ndarray], filename: str):
+def save_file(tensor_dict: Dict[str, np.ndarray], filename: str, metadata: Optional[Dict[str, str]] = None):
     flattened = {
         k: {"dtype": v.dtype.name, "shape": v.shape, "data": v.tobytes()}
         for k, v in tensor_dict.items()
     }
-    serialize_file(flattened, filename)
+    if metadata is None:
+        metadata = {}
+    if "format" not in metadata:
+        metadata["format"] = "np"
+    serialize_file(flattened, metadata, filename)
+
+
+def read_metadata_in_file(filename: str) -> Dict[str, str]:
+    return read_metadata(filename)

--- a/bindings/python/py_src/safetensors/tensorflow.py
+++ b/bindings/python/py_src/safetensors/tensorflow.py
@@ -1,6 +1,6 @@
 from safetensors import numpy
 import numpy as np
-from typing import Dict
+from typing import Dict, Optional
 import tensorflow as tf
 
 
@@ -16,14 +16,22 @@ def tf2np(tf_dict: Dict[str, tf.DeviceArray]) -> Dict[str, np.array]:
     return tf_dict
 
 
-def save(tensors: Dict[str, tf.DeviceArray]) -> bytes:
+def save(tensors: Dict[str, tf.DeviceArray], metadata: Optional[Dict[str, str]] = None) -> bytes:
     np_tensors = tf2np(tensors)
-    return numpy.save(np_tensors)
+    if metadata is None:
+        metadata = {}
+    if "format" not in metadata:
+        metadata["format"] = "tf"
+    return numpy.save(np_tensors, metadata=metadata)
 
 
-def save_file(tensors: Dict[str, tf.DeviceArray], filename: str):
+def save_file(tensors: Dict[str, tf.DeviceArray], filename: str, metadata: Optional[Dict[str, str]] = None):
     np_tensors = tf2np(tensors)
-    return numpy.save_file(np_tensors, filename)
+    if metadata is None:
+        metadata = {}
+    if "format" not in metadata:
+        metadata["format"] = "tf"
+    return numpy.save_file(np_tensors, filename, metadata=metadata)
 
 
 def load(buffer: bytes) -> Dict[str, tf.DeviceArray]:
@@ -34,3 +42,6 @@ def load(buffer: bytes) -> Dict[str, tf.DeviceArray]:
 def load_file(filename: str) -> Dict[str, tf.DeviceArray]:
     flat = numpy.load_file(filename)
     return np2tf(flat)
+
+def read_metadata_in_file(filename: str) -> Dict[str, str]:
+    return numpy.read_metadata(filename)

--- a/bindings/python/py_src/safetensors/tensorflow.py
+++ b/bindings/python/py_src/safetensors/tensorflow.py
@@ -18,19 +18,11 @@ def tf2np(tf_dict: Dict[str, tf.DeviceArray]) -> Dict[str, np.array]:
 
 def save(tensors: Dict[str, tf.DeviceArray], metadata: Optional[Dict[str, str]] = None) -> bytes:
     np_tensors = tf2np(tensors)
-    if metadata is None:
-        metadata = {}
-    if "format" not in metadata:
-        metadata["format"] = "tf"
     return numpy.save(np_tensors, metadata=metadata)
 
 
 def save_file(tensors: Dict[str, tf.DeviceArray], filename: str, metadata: Optional[Dict[str, str]] = None):
     np_tensors = tf2np(tensors)
-    if metadata is None:
-        metadata = {}
-    if "format" not in metadata:
-        metadata["format"] = "tf"
     return numpy.save_file(np_tensors, filename, metadata=metadata)
 
 

--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -19,10 +19,6 @@ def pt2np(torch_dict: Dict[str, torch.Tensor]) -> Dict[str, np.array]:
 
 def save(tensors: Dict[str, torch.Tensor], metadata: Optional[Dict[str, str]] = None) -> bytes:
     np_tensors = pt2np(tensors)
-    if metadata is None:
-        metadata = {}
-    if "format" not in metadata:
-        metadata["format"] = "pt"
     return numpy.save(np_tensors, metadata=metadata)
 
 
@@ -59,10 +55,6 @@ def save_file(tensors: Dict[str, torch.Tensor], filename: str, metadata: Optiona
         k: {"dtype": str(v.dtype).split(".")[-1], "shape": v.shape, "data": tobytes(v)}
         for k, v in tensors.items()
     }
-    if metadata is None:
-        metadata = {}
-    if "format" not in metadata:
-        metadata["format"] = "pt"
     serialize_file(flattened, metadata, filename)
 
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -63,7 +63,11 @@ fn serialize<'a, 'b>(
 }
 
 #[pyfunction]
-fn serialize_file<'a>(tensor_dict: HashMap<String, &'a PyDict>, metadata: HashMap<String, String>, filename: &str) -> PyResult<()> {
+fn serialize_file<'a>(
+    tensor_dict: HashMap<String, &'a PyDict>,
+    metadata: HashMap<String, String>,
+    filename: &str,
+) -> PyResult<()> {
     let tensors = prepare(tensor_dict)?;
     safetensors::serialize_to_file(&tensors, &metadata, filename)?;
     Ok(())
@@ -109,9 +113,7 @@ fn deserialize_file(
 }
 
 #[pyfunction]
-fn read_metadata(
-    filename: &str,
-) -> PyResult<HashMap<String, String>> {
+fn read_metadata(filename: &str) -> PyResult<HashMap<String, String>> {
     let file = File::open(filename)?;
 
     // SAFETY: Mmap is used to prevent allocating in Rust

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -54,7 +54,7 @@ fn prepare<'a>(tensor_dict: HashMap<String, &'a PyDict>) -> PyResult<HashMap<Str
 fn serialize<'a, 'b>(
     py: Python<'b>,
     tensor_dict: HashMap<String, &'a PyDict>,
-    metadata: HashMap<String, String>,
+    metadata: Option<HashMap<String, String>>,
 ) -> PyResult<&'b PyBytes> {
     let tensors = prepare(tensor_dict)?;
     let out = safetensors::serialize(&tensors, &metadata);
@@ -65,7 +65,7 @@ fn serialize<'a, 'b>(
 #[pyfunction]
 fn serialize_file<'a>(
     tensor_dict: HashMap<String, &'a PyDict>,
-    metadata: HashMap<String, String>,
+    metadata: Option<HashMap<String, String>>,
     filename: &str,
 ) -> PyResult<()> {
     let tensors = prepare(tensor_dict)?;
@@ -113,7 +113,7 @@ fn deserialize_file(
 }
 
 #[pyfunction]
-fn read_metadata(filename: &str) -> PyResult<HashMap<String, String>> {
+fn read_metadata(filename: &str) -> PyResult<Option<HashMap<String, String>>> {
     let file = File::open(filename)?;
 
     // SAFETY: Mmap is used to prevent allocating in Rust

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -54,17 +54,18 @@ fn prepare<'a>(tensor_dict: HashMap<String, &'a PyDict>) -> PyResult<HashMap<Str
 fn serialize<'a, 'b>(
     py: Python<'b>,
     tensor_dict: HashMap<String, &'a PyDict>,
+    metadata: HashMap<String, String>,
 ) -> PyResult<&'b PyBytes> {
     let tensors = prepare(tensor_dict)?;
-    let out = safetensors::serialize(&tensors);
+    let out = safetensors::serialize(&tensors, &metadata);
     let pybytes = PyBytes::new(py, &out);
     Ok(pybytes)
 }
 
 #[pyfunction]
-fn serialize_file<'a>(tensor_dict: HashMap<String, &'a PyDict>, filename: &str) -> PyResult<()> {
+fn serialize_file<'a>(tensor_dict: HashMap<String, &'a PyDict>, metadata: HashMap<String, String>, filename: &str) -> PyResult<()> {
     let tensors = prepare(tensor_dict)?;
-    safetensors::serialize_to_file(&tensors, filename)?;
+    safetensors::serialize_to_file(&tensors, &metadata, filename)?;
     Ok(())
 }
 
@@ -107,6 +108,24 @@ fn deserialize_file(
     deserialized
 }
 
+#[pyfunction]
+fn read_metadata(
+    filename: &str,
+) -> PyResult<HashMap<String, String>> {
+    let file = File::open(filename)?;
+
+    // SAFETY: Mmap is used to prevent allocating in Rust
+    // before making a copy within Python.
+    let mmap = unsafe { MmapOptions::new().map(&file)? };
+    let safetensor = SafeTensors::deserialize(&mmap).map_err(|e| {
+        exceptions::PyException::new_err(format!("Error while deserializing: {:?}", e))
+    })?;
+    let metadata = safetensor.get_metadata();
+    // Make sure mmap does not leak.
+    drop(mmap);
+    Ok(metadata)
+}
+
 /// A Python module implemented in Rust.
 #[pymodule]
 fn safetensors_rust(_py: Python, m: &PyModule) -> PyResult<()> {
@@ -114,5 +133,6 @@ fn safetensors_rust(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(serialize_file, m)?)?;
     m.add_function(wrap_pyfunction!(deserialize, m)?)?;
     m.add_function(wrap_pyfunction!(deserialize_file, m)?)?;
+    m.add_function(wrap_pyfunction!(read_metadata, m)?)?;
     Ok(())
 }

--- a/bindings/python/tests/test_simple.py
+++ b/bindings/python/tests/test_simple.py
@@ -1,5 +1,5 @@
 import unittest
-from safetensors.numpy import save, load, save_file, load_file, read_metadata_in_file
+from safetensors.numpy import save, load, save_file, load_file
 from safetensors.torch import load_file as load_file_pt, save_file as save_file_pt
 import numpy as np
 from huggingface_hub import hf_hub_download
@@ -14,16 +14,15 @@ class TestCase(unittest.TestCase):
 
         self.assertEqual(
             out,
-            b"""[\x00\x00\x00\x00\x00\x00\x00{"__metadata__":{"format":"np"},"test":{"dtype":"I32","shape":[2,2],"data_offsets":[0,16]}}\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00""",
+            b"""<\x00\x00\x00\x00\x00\x00\x00{"test":{"dtype":"I32","shape":[2,2],"data_offsets":[0,16]}}\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00""",
         )
 
         data[1, 1] = 1
         out = save({"test": data})
-        print(out)
 
         self.assertEqual(
             out,
-            b"""[\x00\x00\x00\x00\x00\x00\x00{"__metadata__":{"format":"np"},"test":{"dtype":"I32","shape":[2,2],"data_offsets":[0,16]}}\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00""",
+            b"""<\x00\x00\x00\x00\x00\x00\x00{"test":{"dtype":"I32","shape":[2,2],"data_offsets":[0,16]}}\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\00""",
         )
 
     def test_deserialization(self):
@@ -52,8 +51,7 @@ class ReadmeTestCase(unittest.TestCase):
         loaded = load_file("./out.bin")
         self.assertTensorEqual(tensors, loaded, np.allclose)
 
-        metadata = read_metadata_in_file("./out.bin")
-        self.assertDictEqual(metadata, {"format": "np"})
+        metadata = 
 
     def test_torch_example(self):
         tensors = {
@@ -69,6 +67,3 @@ class ReadmeTestCase(unittest.TestCase):
         # Now loading
         loaded = load_file_pt("./out.bin")
         self.assertTensorEqual(tensors2, loaded, torch.allclose)
-
-        metadata = read_metadata_in_file("./out.bin")
-        self.assertDictEqual(metadata, {"format": "pt"})


### PR DESCRIPTION
This adds a new `Dict[str, str]` to the metadata in a `SafeTensors` objects, that can save any user metadata associated to some weight file in this format.

The main use right now is to save the format used when saving a model (PyTorch, TensorFlow etc) so I know on the Transformers side if a conversion of weights should be applied or not.