### PR TITLE
Use np.prod for compatibility with Python 3.7

### DIFF
--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -84,7 +84,7 @@ def _tobytes(tensor: torch.Tensor) -> bytes:
     import ctypes
     import numpy as np
 
-    length = math.prod(tensor.shape)
+    length = np.prod(tensor.shape).item()
     bytes_per_item = _SIZE[tensor.dtype]
 
     total_bytes = length * bytes_per_item


### PR DESCRIPTION
`math.prod` was only introduced in Python 3.8, so using it constrains `safetensors` to that min version. This PR provides an alternative.