### PR TITLE
Implement benchmarking using Criterion

### DIFF
--- a/safetensors/Cargo.toml
+++ b/safetensors/Cargo.toml
@@ -8,3 +8,10 @@ edition = "2021"
 [dependencies]
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "benchmark"
+harness = false

--- a/safetensors/benches/benchmark.rs
+++ b/safetensors/benches/benchmark.rs
@@ -1,0 +1,55 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use safetensors::tensor::*;
+use std::collections::HashMap;
+
+// Returns a sample data of size 2_MB
+fn get_sample_data() -> (Vec<u8>, Vec<usize>, Dtype) {
+    let shape = vec![1000, 500];
+    let dtype = Dtype::F32;
+    let n: usize = shape.iter().product::<usize>() * dtype.size(); // 4
+    let data = vec![0; n];
+
+    (data, shape, dtype)
+}
+
+pub fn bench_serialize(c: &mut Criterion) {
+    let (data, shape, dtype) = get_sample_data();
+    let n_layers = 5;
+
+    let mut metadata: HashMap<String, TensorView> = HashMap::new();
+    // 2_MB x 5 = 10_MB
+    for i in 0..n_layers {
+        let tensor = TensorView::new(dtype, shape.clone(), &data[..]).unwrap();
+        metadata.insert(format!("weight{}", i), tensor);
+    }
+
+    c.bench_function("Serlialize 10_MB", |b| {
+        b.iter(|| {
+            let _serialized = serialize(black_box(&metadata), black_box(&None));
+        })
+    });
+}
+
+pub fn bench_deserialize(c: &mut Criterion) {
+    let (data, shape, dtype) = get_sample_data();
+    let n_layers = 5;
+
+    let mut metadata: HashMap<String, TensorView> = HashMap::new();
+    // 2_MB x 5 = 10_MB
+    for i in 0..n_layers {
+        let tensor = TensorView::new(dtype, shape.clone(), &data[..]).unwrap();
+        metadata.insert(format!("weight{}", i), tensor);
+    }
+
+    let out = serialize(&metadata, &None);
+
+    c.bench_function("Deserlialize 10_MB", |b| {
+        b.iter(|| {
+            let _deserialized = SafeTensors::deserialize(black_box(&out)).unwrap();
+        })
+    });
+}
+
+criterion_group!(bench_ser, bench_serialize);
+criterion_group!(bench_de, bench_deserialize);
+criterion_main!(bench_ser, bench_de);


### PR DESCRIPTION
### TLDR: add benchmarking for `serialization` & `deserialziation`

Not sure if we will do parallelization https://github.com/huggingface/safetensors/issues/15
But either way, I thought it is probably a good idea to add some benchmarking.

I'm using [criterion](https://github.com/bheisler/criterion.rs), which is a popular rust benchmarking framework (also used on [tokenizers](https://github.com/huggingface/tokenizers/blob/0f20b0823a41de7aa918e90e58a3398b024f4b73/tokenizers/Cargo.toml#L76)).

Can be run as:
```
cargo bench
```
Produces output as:
```
Serlialize 10_MB
time:   [427.15 µs 436.21 µs 446.56 µs]                             
change: [-0.3956% +0.7567% +1.9834%] (p = 0.32 > 0.05)
No change in performance detected.

Deserlialize 10_MB                     
time:   [5.5303 µs 5.5634 µs 5.5997 µs]                                
change: [-0.4513% +0.5147% +1.5265%] (p = 0.32 > 0.05)
No change in performance detected.
```
Read more about [cargo bench here](https://doc.rust-lang.org/cargo/commands/cargo-bench.html).
Note: since criterion is a dev-dependency, it does not get added in the prod build
