### PR TITLE
Less GIL locks speeds things up apparently ?

### DIFF
--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -30,9 +30,9 @@ def save_file(
     serialize_file(_flatten(tensors), filename, metadata=metadata)
 
 
-def load_file(filename: str) -> Dict[str, torch.Tensor]:
+def load_file(filename: str, device="cpu") -> Dict[str, torch.Tensor]:
     result = {}
-    with safe_open(filename, framework="pt") as f:
+    with safe_open(filename, framework="pt", device=device) as f:
         for k in f.keys():
             result[k] = f.get_tensor(k)
     return result

--- a/bindings/python/tests/test_flax_comparison.py
+++ b/bindings/python/tests/test_flax_comparison.py
@@ -76,5 +76,4 @@ class SafeTestCase(unittest.TestCase):
         flax_time = datetime.datetime.now() - start
         print()
         print(f"Serialization (safe) took {safe_time}")
-        print("Serialization (flax) took ", datetime.datetime.now() - start)
-        print(f"Deserialization (flax) took {flax_time} (Safe is {flax_time/safe_time} faster)")
+        print(f"Serialization (flax) took {flax_time} (Safe is {flax_time/safe_time} faster)")

--- a/bindings/python/tests/test_pt_comparison.py
+++ b/bindings/python/tests/test_pt_comparison.py
@@ -19,7 +19,7 @@ class TorchTestCase(unittest.TestCase):
             "test2": torch.zeros((2, 2), dtype=torch.float16),
             "test3": torch.zeros((2, 2), dtype=torch.bool),
         }
-        local = "./tests/data/out_safe_pt_mmap.safetensors"
+        local = "./tests/data/out_safe_pt_mmap_small.safetensors"
         save_file(data, local)
         reloaded = load_file(local)
         self.assertTrue(torch.equal(data["test"], reloaded["test"]))
@@ -31,7 +31,7 @@ class TorchTestCase(unittest.TestCase):
         data = {
             "test": torch.arange(4).view((2, 2)).to("cuda:0"),
         }
-        local = "./tests/data/out_safe_pt_mmap.safetensors"
+        local = "./tests/data/out_safe_pt_mmap_small.safetensors"
         save_file(data, local)
         reloaded = load_file(local)
         self.assertTrue(torch.equal(torch.arange(4).view((2, 2)), reloaded["test"]))

--- a/bindings/python/tests/test_pt_comparison.py
+++ b/bindings/python/tests/test_pt_comparison.py
@@ -102,7 +102,7 @@ class SpeedTestCase(unittest.TestCase):
 
         start = datetime.datetime.now()
         with open("./tests/data/out_pt.safetensors", "wb") as f:
-            torch.save(self.data, f)
+            torch.save(data, f)
         pt_time = datetime.datetime.now() - start
 
         print()

--- a/bindings/python/tests/test_pt_comparison.py
+++ b/bindings/python/tests/test_pt_comparison.py
@@ -72,6 +72,7 @@ class SpeedTestCase(unittest.TestCase):
             self.assertTrue(torch.allclose(v, tv))
             self.assertEqual(v.device, torch.device("cpu"))
 
+    @unittest.skipIf(not torch.cuda.is_available(), "Cuda is not available")
     def test_deserialization_safe_gpu(self):
         # First time to hit disk
         load_file(self.local, device="cuda:0")

--- a/bindings/python/tests/test_pt_comparison.py
+++ b/bindings/python/tests/test_pt_comparison.py
@@ -46,10 +46,11 @@ class TorchTestCase(unittest.TestCase):
 class SpeedTestCase(unittest.TestCase):
     def setUp(self):
         self.filename = hf_hub_download(MODEL_ID, filename="pytorch_model.bin")
-        # self.data = torch.load(self.filename, map_location="cpu")
         self.local = "./tests/data/out_safe_pt_mmap.safetensors"
-        # Need to copy since that call mutates the tensors to numpy
-        # save_file(self.data.copy(), self.local)
+        if not os.path.exists(self.local):
+            data = torch.load(self.filename, map_location="cpu")
+            # Need to copy since that call mutates the tensors to numpy
+            save_file(data.copy(), self.local)
 
     def test_deserialization_safe(self):
         start = datetime.datetime.now()
@@ -93,9 +94,10 @@ class SpeedTestCase(unittest.TestCase):
             self.assertEqual(v.device, torch.device("cuda:0"))
 
     def test_serialization_safe(self):
+        data = torch.load(self.filename, map_location="cpu")
         start = datetime.datetime.now()
         outfilename = "./tests/data/out_safe.safetensors"
-        save_file(self.data, outfilename)
+        save_file(data, outfilename)
         safe_time = datetime.datetime.now() - start
 
         start = datetime.datetime.now()


### PR DESCRIPTION
This PR reduces the locations where the GIL is taken, which at least in appearance speeds up significantly the load speed for PT.
I am now on my local computer ~3x faster to load on CPU.

The PR stems from realizing that trying to load on GPU directly, was consuming a LOT of CPU (it still does).
GPU loading was much slower to load everything on CPU then moving to GPU than directly loading on GPU (tensor per tensor).

GIL definitely seems at play here.

So `safe_open` now receives a `device` argument to that the various functons can return tensors directly on the correct location.

No check or concern for TF or Flax has been taken yet (numpy cannot allocate on GPU).
When we do we'll probably have to make `Device` uniform across library.

