### PR TITLE
For torch `load_file`, directly use python mmap

### DIFF
--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -34,7 +34,7 @@ def save_file(
 def load_file(filename: str) -> Dict[str, torch.Tensor]:
     result = {}
     with safe_open(filename, framework="pt") as f:
-        with open(filename, mode="r+", encoding="utf8") as file_obj:
+        with open(filename, mode="w+", encoding="utf8") as file_obj:
             with mmap.mmap(file_obj.fileno(), length=0, access=mmap.ACCESS_WRITE) as mmap_obj:
                 for k in f.keys():
                     tensor_info = f.get_tensor_info(k)
@@ -44,7 +44,7 @@ def load_file(filename: str) -> Dict[str, torch.Tensor]:
                         tensor_info["dtype"],
                     )
                     idx_start, idx_end = data_offsets
-                    dtype = _TYPES[dtype_str]
+                    dtype = _getdtype(dtype_str)
                     mmap_slice = mmap_obj[idx_start:idx_end]
                     result[k] = torch.frombuffer(mmap_slice, dtype=dtype).reshape(shape)
     return result

--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -34,8 +34,8 @@ def save_file(
 def load_file(filename: str) -> Dict[str, torch.Tensor]:
     result = {}
     with safe_open(filename, framework="pt") as f:
-        with open(filename, mode="r", encoding="utf8") as file_obj:
-            with mmap.mmap(file_obj.fileno(), length=0, access=mmap.ACCESS_READ) as mmap_obj:
+        with open(filename, mode="r+", encoding="utf8") as file_obj:
+            with mmap.mmap(file_obj.fileno(), length=0, access=mmap.ACCESS_WRITE) as mmap_obj:
                 for k in f.keys():
                     tensor_info = f.get_tensor_info(k)
                     data_offsets, shape, dtype_str = (

--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -1,6 +1,6 @@
+import mmap
 from typing import Any, Dict, Optional
 
-import mmap
 import torch
 
 from .safetensors_rust import deserialize, safe_open, serialize, serialize_file
@@ -38,7 +38,11 @@ def load_file(filename: str) -> Dict[str, torch.Tensor]:
             with mmap.mmap(file_obj.fileno(), length=0, access=mmap.ACCESS_READ) as mmap_obj:
                 for k in f.keys():
                     tensor_info = f.get_tensor_info(k)
-                    data_offsets, shape, dtype_str = tensor_info['data_offsets'], tensor_info['shape'], tensor_info['dtype']
+                    data_offsets, shape, dtype_str = (
+                        tensor_info["data_offsets"],
+                        tensor_info["shape"],
+                        tensor_info["dtype"],
+                    )
                     idx_start, idx_end = data_offsets
                     dtype = _TYPES[dtype_str]
                     mmap_slice = mmap_obj[idx_start:idx_end]

--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -34,7 +34,7 @@ def save_file(
 def load_file(filename: str) -> Dict[str, torch.Tensor]:
     result = {}
     with safe_open(filename, framework="pt") as f:
-        with open(filename, mode="w+", encoding="utf8") as file_obj:
+        with open(filename, mode="r+", encoding="utf8") as file_obj:
             with mmap.mmap(file_obj.fileno(), length=0, access=mmap.ACCESS_WRITE) as mmap_obj:
                 for k in f.keys():
                     tensor_info = f.get_tensor_info(k)

--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, Optional
 
+import mmap
 import torch
 
 from .safetensors_rust import deserialize, safe_open, serialize, serialize_file
@@ -33,8 +34,15 @@ def save_file(
 def load_file(filename: str) -> Dict[str, torch.Tensor]:
     result = {}
     with safe_open(filename, framework="pt") as f:
-        for k in f.keys():
-            result[k] = f.get_tensor(k)
+        with open(filename, mode="r", encoding="utf8") as file_obj:
+            with mmap.mmap(file_obj.fileno(), length=0, access=mmap.ACCESS_READ) as mmap_obj:
+                for k in f.keys():
+                    tensor_info = f.get_tensor_info(k)
+                    data_offsets, shape, dtype_str = tensor_info['data_offsets'], tensor_info['shape'], tensor_info['dtype']
+                    idx_start, idx_end = data_offsets
+                    dtype = _TYPES[dtype_str]
+                    mmap_slice = mmap_obj[idx_start:idx_end]
+                    result[k] = torch.frombuffer(mmap_slice, dtype=dtype).reshape(shape)
     return result
 
 

--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -293,6 +293,26 @@ impl Dtype {
     }
 }
 
+impl std::fmt::Display for Dtype {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Dtype::BOOL => write!(f, "BOOL"),
+            Dtype::U8 => write!(f, "U8"),
+            Dtype::I8 => write!(f, "I8"),
+            Dtype::I16 => write!(f, "I16"),
+            Dtype::U16 => write!(f, "U16"),
+            Dtype::I32 => write!(f, "I32"),
+            Dtype::U32 => write!(f, "U32"),
+            Dtype::I64 => write!(f, "I64"),
+            Dtype::U64 => write!(f, "U64"),
+            Dtype::F16 => write!(f, "F16"),
+            Dtype::BF16 => write!(f, "BF16"),
+            Dtype::F32 => write!(f, "F32"),
+            Dtype::F64 => write!(f, "F64"),
+        }
+    }
+}
+
 // /// A struct representing a Tensor, the byte-buffer is not owned
 // /// but dtype a shape are.
 // pub struct Tensor<'data> {


### PR DESCRIPTION
Following @Narsil suggestions, for torch [load_file](https://github.com/huggingface/safetensors/blob/b21c83b3bc3d5cd874c0d2b58d5aac72574b0248/bindings/python/py_src/safetensors/torch.py#L34), directly use [python mmap](https://realpython.com/python-mmap/)