### PR TITLE
Moving tensor validation (length wise) directly in validate.

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -49,13 +49,7 @@ fn prepare(tensor_dict: HashMap<String, &PyDict>) -> PyResult<HashMap<String, Te
                 _ => println!("Ignored unknown kwarg option {}", key),
             };
         }
-
-        let tensor = TensorView::new(dtype, shape, data).map_err(|e| {
-            exceptions::PyException::new_err(format!(
-                "Error while processing tensor {tensor_name:?} {:?}",
-                e
-            ))
-        })?;
+        let tensor = TensorView::new(dtype, shape, data);
         tensors.insert(tensor_name, tensor);
     }
     Ok(tensors)
@@ -328,10 +322,7 @@ impl PySafeSlice {
         let data = &self.mmap
             [self.info.data_offsets.0 + self.offset..self.info.data_offsets.1 + self.offset];
 
-        let tensor =
-            TensorView::new(self.info.dtype, self.info.shape.clone(), data).map_err(|e| {
-                exceptions::PyException::new_err(format!("Error when creating TensorView {:?}", e))
-            })?;
+        let tensor = TensorView::new(self.info.dtype, self.info.shape.clone(), data);
         let slices: Vec<TensorIndexer> = slices
             .into_iter()
             .map(slice_to_indexer)

--- a/safetensors/benches/benchmark.rs
+++ b/safetensors/benches/benchmark.rs
@@ -19,7 +19,7 @@ pub fn bench_serialize(c: &mut Criterion) {
     let mut metadata: HashMap<String, TensorView> = HashMap::new();
     // 2_MB x 5 = 10_MB
     for i in 0..n_layers {
-        let tensor = TensorView::new(dtype, shape.clone(), &data[..]).unwrap();
+        let tensor = TensorView::new(dtype, shape.clone(), &data[..]);
         metadata.insert(format!("weight{}", i), tensor);
     }
 
@@ -37,7 +37,7 @@ pub fn bench_deserialize(c: &mut Criterion) {
     let mut metadata: HashMap<String, TensorView> = HashMap::new();
     // 2_MB x 5 = 10_MB
     for i in 0..n_layers {
-        let tensor = TensorView::new(dtype, shape.clone(), &data[..]).unwrap();
+        let tensor = TensorView::new(dtype, shape.clone(), &data[..]);
         metadata.insert(format!("weight{}", i), tensor);
     }
 


### PR DESCRIPTION
That way we have a single point of validation.

Either when you create `Metadata` when you are serializing. Or when we deserialize the JSON we have to use `validate()` and will validate all edge cases.