### PR TITLE
Support for Python 3.7

### DIFF
--- a/bindings/python/py_src/safetensors/numpy.py
+++ b/bindings/python/py_src/safetensors/numpy.py
@@ -1,9 +1,15 @@
-from importlib.metadata import metadata
+import sys
 from typing import Dict, Optional
 
 import numpy as np
 
 from .safetensors_rust import deserialize, safe_open, serialize, serialize_file
+
+# The package importlib_metadata is in a different place, depending on the python version.
+if sys.version_info < (3, 8):
+    from importlib_metadata import metadata
+else:
+    from importlib.metadata import metadata
 
 
 def save(tensor_dict: Dict[str, np.ndarray], metadata: Optional[Dict[str, str]] = None) -> bytes:

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -20,6 +20,7 @@ setup(
     url="https://github.com/huggingface/safetensors",
     license="Apache License 2.0",
     rust_extensions=[RustExtension("safetensors.safetensors_rust", binding=Binding.PyO3, debug=False)],
+    install_require=["importlib_metadata;python_version<'3.8'"],
     extras_require=extras,
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
`importlib.metadata` only exists in Python 3.8 and higher, this PR fixes the package for Python 3.7 (note that a new release will be necessary).