### PR TITLE
Adding docs

### DIFF
--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -1,0 +1,18 @@
+name: Build PR Documentation
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@safetensors
+    with:
+      commit_sha: ${{ github.event.pull_request.head.sha }}
+      pr_number: ${{ github.event.number }}
+      package: safetensors
+      package_path: safetensors/bindings/python/
+      install_rust: true

--- a/bindings/python/py_src/safetensors/__init__.pyi
+++ b/bindings/python/py_src/safetensors/__init__.pyi
@@ -1,0 +1,73 @@
+# Generated content DO NOT EDIT
+@staticmethod
+def deserialize(bytes):
+    """
+    Opens a safetensors lazily and returns tensors as asked
+
+    Args:
+        data (:obj:`bytes`):
+            The byte content of a file
+
+    Returns:
+        (:obj:`List[str, Dict[str, Dict[str, any]]]`):
+            The deserialized content is like:
+                [("tensor_name", {"shape": [2, 3], "dtype": "F32", "data": b"\0\0.." }), (...)]
+    """
+    pass
+
+@staticmethod
+def serialize(tensor_dict, metadata=None):
+    """
+    Serializes raw data.
+
+    Args:
+        tensor_dict (:obj:`Dict[str, Dict[Any]]`):
+            The tensor dict is like:
+                {"tensor_name": {"dtype": "F32", "shape": [2, 3], "data": b"\0\0"}}
+        metadata (:obj:`Dict[str, str]`, *optional*):
+            The optional purely text annotations
+
+    Returns:
+        (:obj:`bytes`):
+            The serialized content.
+    """
+    pass
+
+@staticmethod
+def serialize_file(tensor_dict, filename, metadata=None):
+    """
+    Serializes raw data.
+
+    Args:
+        tensor_dict (:obj:`Dict[str, Dict[Any]]`):
+            The tensor dict is like:
+                {"tensor_name": {"dtype": "F32", "shape": [2, 3], "data": b"\0\0"}}
+        filename (:obj:`str`):
+            The name of the file to write into.
+        metadata (:obj:`Dict[str, str]`, *optional*):
+            The optional purely text annotations
+
+    Returns:
+        (:obj:`bytes`):
+            The serialized content.
+    """
+    pass
+
+class safe_open:
+    """
+    Opens a safetensors lazily and returns tensors as asked
+
+    Args:
+        filename (:obj:`str`):
+            The filename to open
+
+        framework (:obj:`str`):
+            The framework you want you tensors in. Supported values:
+            `pt`, `tf`, `flax`, `numpy`.
+
+        device (:obj:`str`, defaults to :obj:`"cpu"`):
+            The device on which you want the tensors.
+    """
+
+    def __init__(self, filename, framework, device="cpu"):
+        pass

--- a/bindings/python/py_src/safetensors/flax.py
+++ b/bindings/python/py_src/safetensors/flax.py
@@ -6,6 +6,124 @@ import jax.numpy as jnp
 from safetensors import numpy
 
 
+def save(tensors: Dict[str, jnp.DeviceArray], metadata: Optional[Dict[str, str]] = None) -> bytes:
+    """
+    Saves a dictionnary of tensors into raw bytes in safetensors format.
+
+    Args:
+        tensors (`Dict[str, jnp.DeviceArray]`):
+            The incoming tensors. Tensors need to be contiguous and dense.
+        metadata (`Dict[str, str]`, *optional*, defaults to `None`):
+            Optional text only metadata you might want to save in your header.
+            For instance it can be useful to specify more about the underlying
+            tensors. This is purely informative and does not affect tensor loading.
+
+    Returns:
+        `bytes`: The raw bytes representing the format
+
+    Example:
+
+    ```python
+    from safetensors.flax import save
+    import flax
+
+    tensors = {"embedding": jnp.zeros((512, 1024)), "attention": jnp.zeros((256, 256))}
+    byte_data = save(tensors)
+    ```
+    """
+    np_tensors = _jnp2np(tensors)
+    return numpy.save(np_tensors, metadata=metadata)
+
+
+def save_file(
+    tensors: Dict[str, jnp.DeviceArray],
+    filename: str,
+    metadata: Optional[Dict[str, str]] = None,
+):
+    """
+    Saves a dictionnary of tensors into raw bytes in safetensors format.
+
+    Args:
+        tensors (`Dict[str, jnp.DeviceArray]`):
+            The incoming tensors. Tensors need to be contiguous and dense.
+        filename (`str`):
+            The filename we're saving into.
+        metadata (`Dict[str, str]`, *optional*, defaults to `None`):
+            Optional text only metadata you might want to save in your header.
+            For instance it can be useful to specify more about the underlying
+            tensors. This is purely informative and does not affect tensor loading.
+
+    Returns:
+        `None`
+
+    Example:
+
+    ```python
+    from safetensors.flax import save_file
+    import flax
+
+    tensors = {"embedding": jnp.zeros((512, 1024)), "attention": jnp.zeros((256, 256))}
+    save(tensors, "model.safetensors")
+    ```
+    """
+    np_tensors = _jnp2np(tensors)
+    return numpy.save_file(np_tensors, filename, metadata=metadata)
+
+
+def load(data: bytes) -> Dict[str, jnp.DeviceArray]:
+    """
+    Loads a safetensors file into flax format from pure bytes.
+
+    Args:
+        data (`bytes`):
+            The content of a safetensors file
+
+    Returns:
+        `Dict[str, jnp.DeviceArray]`: dictionary that contains name as key, value as `jnp.DeviceArray` on cpu
+
+    Example:
+
+    ```python
+    from safetensors.flax import load
+
+    file_path = "./my_folder/bert.safetensors"
+    with open(file_path, "rb") as f:
+        data = f.read()
+
+    loaded = load(data)
+    ```
+    """
+    flat = numpy.load(data)
+    return _np2jnp(flat)
+
+
+def load_file(filename: str) -> Dict[str, jnp.DeviceArray]:
+    """
+    Loads a safetensors file into flax format.
+
+    Args:
+        filename (`str`):
+            The name of the file which contains the tensors
+        device (`Dict[str, any]`, *optional*, defaults to `cpu`):
+            The device where the tensors need to be located after load.
+            available options are all regular flax device locations
+
+    Returns:
+        `Dict[str, jnp.DeviceArray]`: dictionary that contains name as key, value as `jnp.DeviceArray`
+
+    Example:
+
+    ```python
+    from safetensors.flax import load_file
+
+    file_path = "./my_folder/bert.safetensors"
+    loaded = load_file(file_path)
+    ```
+    """
+    flat = numpy.load_file(filename)
+    return _np2jnp(flat)
+
+
 def _np2jnp(numpy_dict: Dict[str, np.ndarray]) -> Dict[str, jnp.DeviceArray]:
     for k, v in numpy_dict.items():
         numpy_dict[k] = jnp.array(v)
@@ -16,27 +134,3 @@ def _jnp2np(jnp_dict: Dict[str, jnp.DeviceArray]) -> Dict[str, np.array]:
     for k, v in jnp_dict.items():
         jnp_dict[k] = np.asarray(v)
     return jnp_dict
-
-
-def save(tensors: Dict[str, jnp.DeviceArray], metadata: Optional[Dict[str, str]] = None) -> bytes:
-    np_tensors = _jnp2np(tensors)
-    return numpy.save(np_tensors, metadata=metadata)
-
-
-def save_file(
-    tensors: Dict[str, jnp.DeviceArray],
-    filename: str,
-    metadata: Optional[Dict[str, str]] = None,
-):
-    np_tensors = _jnp2np(tensors)
-    return numpy.save_file(np_tensors, filename, metadata=metadata)
-
-
-def load(buffer: bytes) -> Dict[str, jnp.DeviceArray]:
-    flat = numpy.load(buffer)
-    return _np2jnp(flat)
-
-
-def load_file(filename: str) -> Dict[str, jnp.DeviceArray]:
-    flat = numpy.load_file(filename)
-    return _np2jnp(flat)

--- a/bindings/python/py_src/safetensors/numpy.py
+++ b/bindings/python/py_src/safetensors/numpy.py
@@ -6,28 +6,122 @@ from .safetensors_rust import deserialize, safe_open, serialize, serialize_file
 
 
 def save(tensor_dict: Dict[str, np.ndarray], metadata: Optional[Dict[str, str]] = None) -> bytes:
+    """
+    Saves a dictionnary of tensors into raw bytes in safetensors format.
+
+    Args:
+        tensors (`Dict[str, np.ndarray]`):
+            The incoming tensors. Tensors need to be contiguous and dense.
+        metadata (`Dict[str, str]`, *optional*, defaults to `None`):
+            Optional text only metadata you might want to save in your header.
+            For instance it can be useful to specify more about the underlying
+            tensors. This is purely informative and does not affect tensor loading.
+
+    Returns:
+        `bytes`: The raw bytes representing the format
+
+    Example:
+
+    ```python
+    from safetensors.numpy import save
+    import numpy as np
+
+    tensors = {"embedding": np.zeros((512, 1024)), "attention": np.zeros((256, 256))}
+    byte_data = save(tensors)
+    ```
+    """
     flattened = {k: {"dtype": v.dtype.name, "shape": v.shape, "data": v.tobytes()} for k, v in tensor_dict.items()}
     serialized = serialize(flattened, metadata=metadata)
     result = bytes(serialized)
     return result
 
 
-def load(filename: str) -> Dict[str, np.ndarray]:
-    flat = deserialize(filename)
+def save_file(tensor_dict: Dict[str, np.ndarray], filename: str, metadata: Optional[Dict[str, str]] = None):
+    """
+    Saves a dictionnary of tensors into raw bytes in safetensors format.
+
+    Args:
+        tensors (`Dict[str, np.ndarray]`):
+            The incoming tensors. Tensors need to be contiguous and dense.
+        filename (`str`):
+            The filename we're saving into.
+        metadata (`Dict[str, str]`, *optional*, defaults to `None`):
+            Optional text only metadata you might want to save in your header.
+            For instance it can be useful to specify more about the underlying
+            tensors. This is purely informative and does not affect tensor loading.
+
+    Returns:
+        `None`
+
+    Example:
+
+    ```python
+    from safetensors.numpy import save_file
+    import numpy as np
+
+    tensors = {"embedding": np.zeros((512, 1024)), "attention": np.zeros((256, 256))}
+    save(tensors, "model.safetensors")
+    ```
+    """
+    flattened = {k: {"dtype": v.dtype.name, "shape": v.shape, "data": v.tobytes()} for k, v in tensor_dict.items()}
+    serialize_file(flattened, filename, metadata=metadata)
+
+
+def load(data: bytes) -> Dict[str, np.ndarray]:
+    """
+    Loads a safetensors file into numpy format from pure bytes.
+
+    Args:
+        data (`bytes`):
+            The content of a safetensors file
+
+    Returns:
+        `Dict[str, np.ndarray]`: dictionary that contains name as key, value as `np.ndarray` on cpu
+
+    Example:
+
+    ```python
+    from safetensors.numpy import load
+
+    file_path = "./my_folder/bert.safetensors"
+    with open(file_path, "rb") as f:
+        data = f.read()
+
+    loaded = load(data)
+    ```
+    """
+    flat = deserialize(data)
     return _view2np(flat)
 
 
 def load_file(filename: str) -> Dict[str, np.ndarray]:
+    """
+    Loads a safetensors file into numpy format.
+
+    Args:
+        filename (`str`):
+            The name of the file which contains the tensors
+        device (`Dict[str, any]`, *optional*, defaults to `cpu`):
+            The device where the tensors need to be located after load.
+            available options are all regular numpy device locations
+
+    Returns:
+        `Dict[str, np.ndarray]`: dictionary that contains name as key, value as `np.ndarray`
+
+    Example:
+
+    ```python
+    from safetensors.numpy import load_file
+
+    file_path = "./my_folder/bert.safetensors"
+    loaded = load_file(file_path)
+    ```
+    """
     result = {}
     with safe_open(filename, framework="np") as f:
         for k in f.keys():
             result[k] = f.get_tensor(k)
     return result
-
-
-def save_file(tensor_dict: Dict[str, np.ndarray], filename: str, metadata: Optional[Dict[str, str]] = None):
-    flattened = {k: {"dtype": v.dtype.name, "shape": v.shape, "data": v.tobytes()} for k, v in tensor_dict.items()}
-    serialize_file(flattened, filename, metadata=metadata)
 
 
 _TYPES = {

--- a/bindings/python/py_src/safetensors/tensorflow.py
+++ b/bindings/python/py_src/safetensors/tensorflow.py
@@ -6,6 +6,124 @@ import tensorflow as tf
 from safetensors import numpy
 
 
+def save(tensors: Dict[str, tf.Tensor], metadata: Optional[Dict[str, str]] = None) -> bytes:
+    """
+    Saves a dictionnary of tensors into raw bytes in safetensors format.
+
+    Args:
+        tensors (`Dict[str, tf.Tensor]`):
+            The incoming tensors. Tensors need to be contiguous and dense.
+        metadata (`Dict[str, str]`, *optional*, defaults to `None`):
+            Optional text only metadata you might want to save in your header.
+            For instance it can be useful to specify more about the underlying
+            tensors. This is purely informative and does not affect tensor loading.
+
+    Returns:
+        `bytes`: The raw bytes representing the format
+
+    Example:
+
+    ```python
+    from safetensors.tensorflow import save
+    import tensorflow as tf
+
+    tensors = {"embedding": tf.zeros((512, 1024)), "attention": tf.zeros((256, 256))}
+    byte_data = save(tensors)
+    ```
+    """
+    np_tensors = _tf2np(tensors)
+    return numpy.save(np_tensors, metadata=metadata)
+
+
+def save_file(
+    tensors: Dict[str, tf.Tensor],
+    filename: str,
+    metadata: Optional[Dict[str, str]] = None,
+):
+    """
+    Saves a dictionnary of tensors into raw bytes in safetensors format.
+
+    Args:
+        tensors (`Dict[str, tf.Tensor]`):
+            The incoming tensors. Tensors need to be contiguous and dense.
+        filename (`str`):
+            The filename we're saving into.
+        metadata (`Dict[str, str]`, *optional*, defaults to `None`):
+            Optional text only metadata you might want to save in your header.
+            For instance it can be useful to specify more about the underlying
+            tensors. This is purely informative and does not affect tensor loading.
+
+    Returns:
+        `None`
+
+    Example:
+
+    ```python
+    from safetensors.tensorflow import save_file
+    import tensorflow as tf
+
+    tensors = {"embedding": tf.zeros((512, 1024)), "attention": tf.zeros((256, 256))}
+    save(tensors, "model.safetensors")
+    ```
+    """
+    np_tensors = _tf2np(tensors)
+    return numpy.save_file(np_tensors, filename, metadata=metadata)
+
+
+def load(data: bytes) -> Dict[str, tf.Tensor]:
+    """
+    Loads a safetensors file into tensorflow format from pure bytes.
+
+    Args:
+        data (`bytes`):
+            The content of a safetensors file
+
+    Returns:
+        `Dict[str, tf.Tensor]`: dictionary that contains name as key, value as `tf.Tensor` on cpu
+
+    Example:
+
+    ```python
+    from safetensors.tensorflow import load
+
+    file_path = "./my_folder/bert.safetensors"
+    with open(file_path, "rb") as f:
+        data = f.read()
+
+    loaded = load(data)
+    ```
+    """
+    flat = numpy.load(data)
+    return _np2tf(flat)
+
+
+def load_file(filename: str) -> Dict[str, tf.Tensor]:
+    """
+    Loads a safetensors file into tensorflow format.
+
+    Args:
+        filename (`str`):
+            The name of the file which contains the tensors
+        device (`Dict[str, any]`, *optional*, defaults to `cpu`):
+            The device where the tensors need to be located after load.
+            available options are all regular tensorflow device locations
+
+    Returns:
+        `Dict[str, tf.Tensor]`: dictionary that contains name as key, value as `tf.Tensor`
+
+    Example:
+
+    ```python
+    from safetensors.tensorflow import load_file
+
+    file_path = "./my_folder/bert.safetensors"
+    loaded = load_file(file_path)
+    ```
+    """
+    flat = numpy.load_file(filename)
+    return _np2tf(flat)
+
+
 def _np2tf(numpy_dict: Dict[str, np.ndarray]) -> Dict[str, tf.Tensor]:
     for k, v in numpy_dict.items():
         numpy_dict[k] = tf.convert_to_tensor(v)
@@ -16,27 +134,3 @@ def _tf2np(tf_dict: Dict[str, tf.Tensor]) -> Dict[str, np.array]:
     for k, v in tf_dict.items():
         tf_dict[k] = v.numpy()
     return tf_dict
-
-
-def save(tensors: Dict[str, tf.Tensor], metadata: Optional[Dict[str, str]] = None) -> bytes:
-    np_tensors = _tf2np(tensors)
-    return numpy.save(np_tensors, metadata=metadata)
-
-
-def save_file(
-    tensors: Dict[str, tf.Tensor],
-    filename: str,
-    metadata: Optional[Dict[str, str]] = None,
-):
-    np_tensors = _tf2np(tensors)
-    return numpy.save_file(np_tensors, filename, metadata=metadata)
-
-
-def load(buffer: bytes) -> Dict[str, tf.Tensor]:
-    flat = numpy.load(buffer)
-    return _np2tf(flat)
-
-
-def load_file(filename: str) -> Dict[str, tf.Tensor]:
-    flat = numpy.load_file(filename)
-    return _np2tf(flat)

--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -47,6 +47,28 @@ def save_file(
 
 
 def load_file(filename: str, device="cpu") -> Dict[str, torch.Tensor]:
+    """
+    Loads a safetensors file into torch format. Etc. more descriptions
+
+    Args:
+        filename (`str`):
+            Total loss as the sum of the masked language modeling loss and the next sequence prediction
+            (classification) loss.
+        device (`Dict[str, any]`, *optional*, defaults to `cpu`):
+            Prediction scores of the language modeling head (scores for each vocabulary token before SoftMax).
+    
+    Returns:
+        `Dict[str, torch.Tensor]`: dictionary that contains name as key, value as `torch.Tensor`
+
+    Example:
+
+    ```python
+    from from safetensors.torch import load_file
+
+    file_path = "./my_folder/bert.safetensors"
+    loaded = load_file(file_path)
+    ```
+    """
     result = {}
     with safe_open(filename, framework="pt", device=device) as f:
         for k in f.keys():

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -7,6 +7,7 @@ with open("requirements-dev.txt", "r") as f:
 
 extras = {}
 extras["testing"] = testing
+extras["dev"] = testing
 
 setup(
     name="safetensors",

--- a/bindings/python/stub.py
+++ b/bindings/python/stub.py
@@ -1,0 +1,187 @@
+import argparse
+import inspect
+import os
+
+import black
+
+
+INDENT = " " * 4
+GENERATED_COMMENT = "# Generated content DO NOT EDIT\n"
+
+
+def do_indent(text: str, indent: str):
+    return text.replace("\n", f"\n{indent}")
+
+
+def function(obj, indent, text_signature=None):
+    if text_signature is None:
+        text_signature = obj.__text_signature__
+    string = ""
+    string += f"{indent}def {obj.__name__}{text_signature}:\n"
+    indent += INDENT
+    string += f'{indent}"""\n'
+    string += f"{indent}{do_indent(obj.__doc__, indent)}\n"
+    string += f'{indent}"""\n'
+    string += f"{indent}pass\n"
+    string += "\n"
+    string += "\n"
+    return string
+
+
+def member_sort(member):
+    if inspect.isclass(member):
+        value = 10 + len(inspect.getmro(member))
+    else:
+        value = 1
+    return value
+
+
+def fn_predicate(obj):
+    value = inspect.ismethoddescriptor(obj) or inspect.isbuiltin(obj)
+    if value:
+        return obj.__doc__ and obj.__text_signature__ and not obj.__name__.startswith("_")
+    if inspect.isgetsetdescriptor(obj):
+        return obj.__doc__ and not obj.__name__.startswith("_")
+    return False
+
+
+def get_module_members(module):
+    members = [
+        member
+        for name, member in inspect.getmembers(module)
+        if not name.startswith("_") and not inspect.ismodule(member)
+    ]
+    members.sort(key=member_sort)
+    return members
+
+
+def pyi_file(obj, indent=""):
+    string = ""
+    if inspect.ismodule(obj):
+        string += GENERATED_COMMENT
+        members = get_module_members(obj)
+        for member in members:
+            string += pyi_file(member, indent)
+
+    elif inspect.isclass(obj):
+        indent += INDENT
+        mro = inspect.getmro(obj)
+        if len(mro) > 2:
+            inherit = f"({mro[1].__name__})"
+        else:
+            inherit = ""
+        string += f"class {obj.__name__}{inherit}:\n"
+
+        body = ""
+        if obj.__doc__:
+            body += f'{indent}"""\n{indent}{do_indent(obj.__doc__, indent)}\n{indent}"""\n'
+
+        fns = inspect.getmembers(obj, fn_predicate)
+
+        # Init
+        if obj.__text_signature__:
+            body += f"{indent}def __init__{obj.__text_signature__}:\n"
+            body += f"{indent+INDENT}pass\n"
+            body += "\n"
+
+        for (name, fn) in fns:
+            body += pyi_file(fn, indent=indent)
+
+        if not body:
+            body += f"{indent}pass\n"
+
+        string += body
+        string += "\n\n"
+
+    elif inspect.isbuiltin(obj):
+        string += f"{indent}@staticmethod\n"
+        string += function(obj, indent)
+
+    elif inspect.ismethoddescriptor(obj):
+        string += function(obj, indent)
+
+    elif inspect.isgetsetdescriptor(obj):
+        # TODO it would be interesing to add the setter maybe ?
+        string += f"{indent}@property\n"
+        string += function(obj, indent, text_signature="(self)")
+    else:
+        raise Exception(f"Object {obj} is not supported")
+    return string
+
+
+def py_file(module, origin):
+    members = get_module_members(module)
+
+    string = GENERATED_COMMENT
+    string += f"from .. import {origin}\n"
+    string += "\n"
+    for member in members:
+        name = member.__name__
+        string += f"{name} = {origin}.{name}\n"
+    return string
+
+
+def do_black(content, is_pyi):
+    mode = black.Mode(
+        target_versions={black.TargetVersion.PY35},
+        line_length=119,
+        is_pyi=is_pyi,
+        string_normalization=True,
+        experimental_string_processing=False,
+    )
+    try:
+        return black.format_file_contents(content, fast=True, mode=mode)
+    except black.NothingChanged:
+        return content
+
+
+def write(module, directory, origin, check=False):
+    submodules = [(name, member) for name, member in inspect.getmembers(module) if inspect.ismodule(member)]
+
+    filename = os.path.join(directory, "__init__.pyi")
+    pyi_content = pyi_file(module)
+    pyi_content = do_black(pyi_content, is_pyi=True)
+    os.makedirs(directory, exist_ok=True)
+    if check:
+        with open(filename, "r") as f:
+            data = f.read()
+            assert data == pyi_content, f"The content of {filename} seems outdated, please run `python stub.py`"
+    else:
+        with open(filename, "w") as f:
+            f.write(pyi_content)
+
+    filename = os.path.join(directory, "__init__.py")
+    py_content = py_file(module, origin)
+    py_content = do_black(py_content, is_pyi=False)
+    os.makedirs(directory, exist_ok=True)
+
+    is_auto = False
+    if not os.path.exists(filename):
+        is_auto = True
+    else:
+        with open(filename, "r") as f:
+            line = f.readline()
+            if line == GENERATED_COMMENT:
+                is_auto = True
+
+    if is_auto:
+        if check:
+            with open(filename, "r") as f:
+                data = f.read()
+                assert data == py_content, f"The content of {filename} seems outdated, please run `python stub.py`"
+        else:
+            with open(filename, "w") as f:
+                f.write(py_content)
+
+    for name, submodule in submodules:
+        write(submodule, os.path.join(directory, name), f"{name}", check=check)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true")
+
+    args = parser.parse_args()
+    import safetensors
+
+    write(safetensors.safetensors_rust, "py_src/safetensors/", "safetensors", check=args.check)

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -1,0 +1,8 @@
+- sections: 
+  - local: index
+    title: 🤗 Safetensors
+  title: Getting started
+- sections: 
+  - local: api/torch
+    title: Torch API
+  title: API

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -5,4 +5,10 @@
 - sections: 
   - local: api/torch
     title: Torch API
+  - local: api/tensorflow
+    title: Tensorflow API
+  - local: api/flax
+    title: Flax API
+  - local: api/numpy
+    title: Numpy API
   title: API

--- a/docs/source/api/flax.mdx
+++ b/docs/source/api/flax.mdx
@@ -1,0 +1,6 @@
+# Flax API
+
+[[autodoc]] safetensors.flax.load_file
+[[autodoc]] safetensors.flax.load
+[[autodoc]] safetensors.flax.save_file
+[[autodoc]] safetensors.flax.save

--- a/docs/source/api/numpy.mdx
+++ b/docs/source/api/numpy.mdx
@@ -1,0 +1,6 @@
+# Numpy API
+
+[[autodoc]] safetensors.numpy.load_file
+[[autodoc]] safetensors.numpy.load
+[[autodoc]] safetensors.numpy.save_file
+[[autodoc]] safetensors.numpy.save

--- a/docs/source/api/tensorflow.mdx
+++ b/docs/source/api/tensorflow.mdx
@@ -1,0 +1,6 @@
+# Tensorflow API
+
+[[autodoc]] safetensors.tensorflow.load_file
+[[autodoc]] safetensors.tensorflow.load
+[[autodoc]] safetensors.tensorflow.save_file
+[[autodoc]] safetensors.tensorflow.save

--- a/docs/source/api/torch.mdx
+++ b/docs/source/api/torch.mdx
@@ -1,3 +1,6 @@
 # Torch API
 
 [[autodoc]] safetensors.torch.load_file
+[[autodoc]] safetensors.torch.load
+[[autodoc]] safetensors.torch.save_file
+[[autodoc]] safetensors.torch.save

--- a/docs/source/api/torch.mdx
+++ b/docs/source/api/torch.mdx
@@ -1,0 +1,3 @@
+# Torch API
+
+[[autodoc]] safetensors.torch.load_file

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -1,0 +1,5 @@
+<!-- DISABLE-FRONTMATTER-SECTIONS -->
+
+# Safetensors
+
+Safetensors is a new simple format for storing tensors safely (as opposed to pickle) and that is still fast (zero-copy).

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -3,3 +3,40 @@
 # Safetensors
 
 Safetensors is a new simple format for storing tensors safely (as opposed to pickle) and that is still fast (zero-copy).
+
+
+## Load tensors
+
+```python
+from safetensors import safe_open
+
+tensors = {}
+with safe_open("model.safetensors", framework="pt", device=0) as f:
+    for k in f.keys():
+        tensors[k] = f.get_tensor(k)
+```
+
+Loading only part of the tensors (interesting when running on multiple GPU)
+
+```python
+from safetensors import safe_open
+
+tensors = {}
+with safe_open("model.safetensors", framework="pt", device=0) as f:
+    tensor_slice = f.get_slice("embedding")
+    vocab_size, hidden_dim = tensor_slice.get_shape()
+    tensor = tensor_slice[:, :hidden_dim]
+```
+
+## Save tensors
+
+```python
+import torch
+from safetensors.torch import save_file
+
+tensors = {
+    "embedding": torch.zeros((2, 2)),
+    "attention": torch.zeros((2, 3))
+}
+save_file(tensors, "model.safetensors")
+```


### PR DESCRIPTION
### TLDR: add safetensors docs

I've added:
1. [Basic structure](https://github.com/huggingface/safetensors/tree/docs/docs/source)
2. Example [docstring](https://github.com/huggingface/safetensors/blob/02fa688554aceb5529de6f2ba35769c6bceef907/bindings/python/py_src/safetensors/torch.py#L49-L71)

@Narsil please feel free to continue from here (directly push to this PR etc.)
When writing docs, please refer [to this guide](https://github.com/huggingface/doc-builder#writing-documentation-for-hugging-face-libraries) & transformers docs for reference

You can test the docs locally by:
```
pip install hf-doc-builder
pip install black watchdog
# replace the path with yours
doc-builder preview safetensors ~/Desktop/safetensors/docs/source/
```

Todos:
- [ ] we should probably setup.py install extras as in `extras["flax"] = (jax flax); extras["testing"] = extras["flax"]+extras["torch"]+...; ` so that doc-builder can just call `pip install .[dev]`. At the moment, I hacked them in https://github.com/huggingface/doc-builder/pull/323
- [ ] in the [moon-ci-docs.huggingface.co preview](https://moon-ci-docs.huggingface.co/docs/safetensors/pr_55/en/api/torch#safetensors.torch.load_file), `python setup.py develop` is intalling `main` branch, not `docs` this branch. Hence, 
the docstring looks empty:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/11827707/199468309-d68099f6-e907-470d-acca-5b5ac25956dc.png">
however, if you run locally with `doc-builder preview safetensors ...`, it renders as expected
<img width="400" alt="image" src="https://user-images.githubusercontent.com/11827707/199468410-711d7db6-0d8c-4785-9d0e-e643d9a61404.png">
I'm looking into this issue in the meantime

@Narsil please let me know of any questions 😊
