### PR TITLE
Found out about `torch.asarray` + `torch.Storage` combo.

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ jobs:
         os: [ubuntu-18.04, macos-latest, windows-latest]
         # Lowest and highest, no version specified so that 
         # new releases get automatically tested against
-        torch_version: [torch==1.10, torch]
+        torch_version: [torch==1.11, torch]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ jobs:
         os: [ubuntu-18.04, macos-latest, windows-latest]
         # Lowest and highest, no version specified so that 
         # new releases get automatically tested against
-        torch_version: [torch==1.11, torch]
+        torch_version: [torch==1.10, torch]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1

--- a/bindings/python/benches/test_pt.py
+++ b/bindings/python/benches/test_pt.py
@@ -81,7 +81,7 @@ def test_pt_sf_load_gpu(benchmark):
         assert torch.allclose(v, tv)
 
 
-@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires mps")
+@pytest.mark.skipif(not hasattr(torch.backends, "mps") or not torch.backends.mps.is_available(), reason="requires mps")
 def test_pt_pt_load_mps(benchmark):
     # benchmark something
     weights = create_gpt2(12)
@@ -95,7 +95,7 @@ def test_pt_pt_load_mps(benchmark):
         assert torch.allclose(v, tv)
 
 
-@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="requires mps")
+@pytest.mark.skipif(not hasattr(torch.backends, "mps") or not torch.backends.mps.is_available(), reason="requires mps")
 def test_pt_sf_load_mps(benchmark):
     # benchmark something
     weights = create_gpt2(12)

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -462,10 +462,13 @@ impl safe_open {
                 let storage = module
                     .getattr(intern!(py, "ByteStorage"))?
                     .getattr(intern!(py, "from_file"))?
-                    .call((py_filename,), Some(kwargs))?
-                    .getattr(intern!(py, "untyped"))?
-                    .call0()?
-                    .into_py(py);
+                    .call((py_filename,), Some(kwargs))?;
+
+                let untyped: &PyAny = match storage.getattr(intern!(py, "untyped")) {
+                    Ok(untyped) => untyped,
+                    Err(_) => storage.getattr(intern!(py, "_untyped"))?,
+                };
+                let storage = untyped.call0()?.into_py(py);
                 let gil_storage = GILOnceCell::new();
                 gil_storage.get_or_init(py, || storage);
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -381,6 +381,10 @@ fn get_error_string(module: &PyModule, out: u32) -> PyResult<String> {
 
 enum Storage {
     Mmap(Mmap),
+    /// Torch specific mmap
+    /// This allows us to not manage it
+    /// so Pytorch can handle the whole lifecycle.
+    /// https://pytorch.org/docs/stable/storage.html#torch.TypedStorage.from_file.
     TorchStorage(GILOnceCell<PyObject>),
 }
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -259,29 +259,6 @@ impl IntoPy<PyObject> for Device {
     }
 }
 
-/// Opens a safetensors lazily and returns tensors as asked
-///
-/// Args:
-///     filename (:obj:`str`):
-///         The filename to open
-///
-///     framework (:obj:`str`):
-///         The framework you want you tensors in. Supported values:
-///         `pt`, `tf`, `flax`, `numpy`.
-///
-///     device (:obj:`str`, defaults to :obj:`"cpu"`):
-///         The device on which you want the tensors.
-#[pyclass]
-#[allow(non_camel_case_types)]
-#[pyo3(text_signature = "(self, filename, framework, device=\"cpu\")")]
-struct safe_open {
-    metadata: Metadata,
-    offset: usize,
-    framework: Framework,
-    device: Device,
-    mmap: Arc<Mmap>,
-}
-
 fn create_empty_tensor_pt<'a>(
     module: &'a PyModule,
     shape: &[usize],
@@ -402,6 +379,34 @@ fn get_error_string(module: &PyModule, out: u32) -> PyResult<String> {
         .extract()
 }
 
+enum Storage {
+    Mmap(Mmap),
+    TorchStorage(GILOnceCell<PyObject>),
+}
+
+/// Opens a safetensors lazily and returns tensors as asked
+///
+/// Args:
+///     filename (:obj:`str`):
+///         The filename to open
+///
+///     framework (:obj:`str`):
+///         The framework you want you tensors in. Supported values:
+///         `pt`, `tf`, `flax`, `numpy`.
+///
+///     device (:obj:`str`, defaults to :obj:`"cpu"`):
+///         The device on which you want the tensors.
+#[pyclass]
+#[allow(non_camel_case_types)]
+#[pyo3(text_signature = "(self, filename, framework, device=\"cpu\")")]
+struct safe_open {
+    metadata: Metadata,
+    offset: usize,
+    framework: Framework,
+    device: Device,
+    storage: Arc<Storage>,
+}
+
 #[pymethods]
 impl safe_open {
     #[new]
@@ -444,12 +449,39 @@ impl safe_open {
             Ok(())
         })?;
 
+        let storage = match (&framework, &device) {
+            (Framework::Pytorch, Device::Cpu) => Python::with_gil(|py| -> PyResult<Storage> {
+                let module = get_module(py, &TORCH_MODULE)?;
+
+                // storage = torch.ByteStorage.from_file(filename, shared=False, size=size).untyped()
+                let py_filename: PyObject = filename.into_py(py);
+                let size: PyObject = buffer.len().into_py(py);
+                let shared: PyObject = false.into_py(py);
+                let kwargs =
+                    [(intern!(py, "shared"), shared), (intern!(py, "size"), size)].into_py_dict(py);
+                let storage = module
+                    .getattr(intern!(py, "ByteStorage"))?
+                    .getattr(intern!(py, "from_file"))?
+                    .call((py_filename,), Some(kwargs))?
+                    .getattr(intern!(py, "untyped"))?
+                    .call0()?
+                    .into_py(py);
+                let gil_storage = GILOnceCell::new();
+                gil_storage.get_or_init(py, || storage);
+
+                Ok(Storage::TorchStorage(gil_storage))
+            })?,
+            _ => Storage::Mmap(buffer),
+        };
+
+        let storage = Arc::new(storage);
+
         Ok(Self {
             metadata,
             offset,
             framework,
             device,
-            mmap: Arc::new(buffer),
+            storage,
         })
     }
 
@@ -496,28 +528,64 @@ impl safe_open {
             exceptions::PyException::new_err(format!("File does not contain tensor {name}",))
         })?;
 
-        let data = &self.mmap[info.data_offsets.0 + self.offset..info.data_offsets.1 + self.offset];
+        match &self.storage.as_ref() {
+            Storage::Mmap(mmap) => {
+                let data =
+                    &mmap[info.data_offsets.0 + self.offset..info.data_offsets.1 + self.offset];
 
-        Python::with_gil(|py| -> PyResult<PyObject> {
-            match (&self.device, &self.framework, CUDA_MEMCPY.get(py)) {
-                (Device::Cuda(_), Framework::Pytorch, Some(Some(cuda_memcpy))) => {
-                    let module = get_module(py, &TORCH_MODULE)?;
-                    create_cuda_unsafe_tensor(module, cuda_memcpy, info, &self.device, data)
-                }
-                _ => {
-                    let array: PyObject =
-                        Python::with_gil(|py| PyByteArray::new(py, data).into_py(py));
+                Python::with_gil(|py| -> PyResult<PyObject> {
+                    match (&self.device, &self.framework, CUDA_MEMCPY.get(py)) {
+                        (Device::Cuda(_), Framework::Pytorch, Some(Some(cuda_memcpy))) => {
+                            let module = get_module(py, &TORCH_MODULE)?;
+                            create_cuda_unsafe_tensor(module, cuda_memcpy, info, &self.device, data)
+                        }
+                        _ => {
+                            let array: PyObject =
+                                Python::with_gil(|py| PyByteArray::new(py, data).into_py(py));
 
-                    create_tensor(
-                        &self.framework,
-                        info.dtype,
-                        &info.shape,
-                        array,
-                        &self.device,
-                    )
-                }
+                            create_tensor(
+                                &self.framework,
+                                info.dtype,
+                                &info.shape,
+                                array,
+                                &self.device,
+                            )
+                        }
+                    }
+                })
             }
-        })
+            Storage::TorchStorage(storage) => {
+                Python::with_gil(|py| -> PyResult<PyObject> {
+                    let torch = get_module(py, &TORCH_MODULE)?;
+                    let dtype: PyObject = get_pydtype(torch, info.dtype)?;
+                    let torch_uint8: PyObject = get_pydtype(torch, Dtype::U8)?;
+                    let kwargs = [(intern!(py, "dtype"), torch_uint8)].into_py_dict(py);
+                    let view_kwargs = [(intern!(py, "dtype"), dtype)].into_py_dict(py);
+                    let shape = info.shape.to_vec();
+                    let shape: PyObject = shape.into_py(py);
+
+                    let start = (info.data_offsets.0 + self.offset) as isize;
+                    let stop = (info.data_offsets.1 + self.offset) as isize;
+                    let slice = PySlice::new(py, start, stop, 1);
+                    let storage: &PyObject = storage.get(py).unwrap();
+                    let storage: &PyAny = storage.as_ref(py);
+
+                    let storage_slice = storage
+                        .getattr(intern!(py, "__getitem__"))?
+                        .call1((slice,))?;
+
+                    let tensor = torch
+                        .getattr(intern!(py, "asarray"))?
+                        .call((storage_slice,), Some(kwargs))?
+                        .getattr(intern!(py, "view"))?
+                        .call((), Some(view_kwargs))?
+                        .getattr(intern!(py, "reshape"))?
+                        .call1((shape,))?;
+                    Ok(tensor.into_py(py))
+                    // torch.asarray(storage[start + n : stop + n], dtype=torch.uint8).view(dtype=dtype).reshape(shape)
+                })
+            }
+        }
     }
 
     /// Returns a full slice view object
@@ -544,7 +612,7 @@ impl safe_open {
                 framework: self.framework.clone(),
                 offset: self.offset,
                 device: self.device.clone(),
-                mmap: self.mmap.clone(),
+                storage: self.storage.clone(),
             })
         } else {
             Err(exceptions::PyException::new_err(format!(
@@ -603,7 +671,7 @@ struct PySafeSlice {
     framework: Framework,
     offset: usize,
     device: Device,
-    mmap: Arc<Mmap>,
+    storage: Arc<Storage>,
 }
 
 #[derive(FromPyObject)]
@@ -642,60 +710,96 @@ impl PySafeSlice {
             Slice::Slice(slice) => vec![slice],
             Slice::Slices(slices) => slices,
         };
-        let data = &self.mmap
-            [self.info.data_offsets.0 + self.offset..self.info.data_offsets.1 + self.offset];
 
-        let tensor = TensorView::new(self.info.dtype, self.info.shape.clone(), data);
-        let slices: Vec<TensorIndexer> = slices
-            .into_iter()
-            .map(slice_to_indexer)
-            .collect::<Result<_, _>>()?;
+        match &self.storage.as_ref() {
+            Storage::Mmap(mmap) => {
+                let data = &mmap[self.info.data_offsets.0 + self.offset
+                    ..self.info.data_offsets.1 + self.offset];
 
-        let iterator = tensor.get_sliced_data(slices.clone()).map_err(|e| {
-            exceptions::PyException::new_err(format!(
-                "Error during slicing {slices:?} vs {:?}:  {:?}",
-                self.info.shape, e
-            ))
-        })?;
-        let newshape = iterator.newshape();
+                let tensor = TensorView::new(self.info.dtype, self.info.shape.clone(), data);
+                let slices: Vec<TensorIndexer> = slices
+                    .into_iter()
+                    .map(slice_to_indexer)
+                    .collect::<Result<_, _>>()?;
 
-        let mut offset = 0;
-        let length = iterator.remaining_byte_len();
+                let iterator = tensor.get_sliced_data(slices.clone()).map_err(|e| {
+                    exceptions::PyException::new_err(format!(
+                        "Error during slicing {slices:?} vs {:?}:  {:?}",
+                        self.info.shape, e
+                    ))
+                })?;
+                let newshape = iterator.newshape();
 
-        Python::with_gil(
-            |py| match (&self.device, &self.framework, CUDA_MEMCPY.get(py)) {
-                (Device::Cuda(_), Framework::Pytorch, Some(Some(cuda_memcpy))) => {
-                    let module = get_module(py, &TORCH_MODULE)?;
-                    create_cuda_unsafe_tensor_from_slice(
-                        module,
-                        cuda_memcpy,
-                        &newshape,
-                        self.info.dtype,
-                        &self.device,
-                        iterator,
-                    )
-                }
-                _ => {
-                    let array: PyObject =
-                        PyByteArray::new_with(py, length, |bytes: &mut [u8]| {
-                            for slice in iterator {
-                                let len = slice.len();
-                                bytes[offset..offset + slice.len()].copy_from_slice(slice);
-                                offset += len;
-                            }
-                            Ok(())
-                        })?
-                        .into_py(py);
-                    create_tensor(
-                        &self.framework,
-                        self.info.dtype,
-                        &newshape,
-                        array,
-                        &self.device,
-                    )
-                }
-            },
-        )
+                let mut offset = 0;
+                let length = iterator.remaining_byte_len();
+
+                Python::with_gil(
+                    |py| match (&self.device, &self.framework, CUDA_MEMCPY.get(py)) {
+                        (Device::Cuda(_), Framework::Pytorch, Some(Some(cuda_memcpy))) => {
+                            let module = get_module(py, &TORCH_MODULE)?;
+                            create_cuda_unsafe_tensor_from_slice(
+                                module,
+                                cuda_memcpy,
+                                &newshape,
+                                self.info.dtype,
+                                &self.device,
+                                iterator,
+                            )
+                        }
+                        _ => {
+                            let array: PyObject =
+                                PyByteArray::new_with(py, length, |bytes: &mut [u8]| {
+                                    for slice in iterator {
+                                        let len = slice.len();
+                                        bytes[offset..offset + slice.len()].copy_from_slice(slice);
+                                        offset += len;
+                                    }
+                                    Ok(())
+                                })?
+                                .into_py(py);
+                            create_tensor(
+                                &self.framework,
+                                self.info.dtype,
+                                &newshape,
+                                array,
+                                &self.device,
+                            )
+                        }
+                    },
+                )
+            }
+            Storage::TorchStorage(storage) => Python::with_gil(|py| -> PyResult<PyObject> {
+                let torch = get_module(py, &TORCH_MODULE)?;
+                let dtype: PyObject = get_pydtype(torch, self.info.dtype)?;
+                let torch_uint8: PyObject = get_pydtype(torch, Dtype::U8)?;
+                let kwargs = [(intern!(py, "dtype"), torch_uint8)].into_py_dict(py);
+                let view_kwargs = [(intern!(py, "dtype"), dtype)].into_py_dict(py);
+                let shape = self.info.shape.to_vec();
+                let shape: PyObject = shape.into_py(py);
+
+                let start = (self.info.data_offsets.0 + self.offset) as isize;
+                let stop = (self.info.data_offsets.1 + self.offset) as isize;
+                let slice = PySlice::new(py, start, stop, 1);
+                let storage: &PyObject = storage.get(py).unwrap();
+                let storage: &PyAny = storage.as_ref(py);
+
+                let storage_slice = storage
+                    .getattr(intern!(py, "__getitem__"))?
+                    .call1((slice,))?;
+
+                let slices = slices.into_py(py);
+                let tensor = torch
+                    .getattr(intern!(py, "asarray"))?
+                    .call((storage_slice,), Some(kwargs))?
+                    .getattr(intern!(py, "view"))?
+                    .call((), Some(view_kwargs))?
+                    .getattr(intern!(py, "reshape"))?
+                    .call1((shape,))?
+                    .getattr(intern!(py, "__getitem__"))?
+                    .call1((slices,))?;
+                Ok(tensor.into_py(py))
+            }),
+        }
     }
 }
 


### PR DESCRIPTION
Extremely fast (I'm guessing it's just pointer arithmetic and actual
load time would it when actually using the tensors.)

```
benches/test_pt.py::test_pt_pt_load_cpu PASSED
benches/test_pt.py::test_pt_sf_load_cpu PASSED


------------------------------------------------------------------------------------- benchmark: 2 tests ------------------------------------------------------------------------------------
Name (time in ms)            Min                 Max                Mean            StdDev              Median                IQR            Outliers       OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_pt_sf_load_cpu       4.4699 (1.0)        9.8395 (1.0)        5.5089 (1.0)      0.9217 (1.0)        5.2233 (1.0)       0.7899 (1.0)         24;13  181.5238 (1.0)         175           1
test_pt_pt_load_cpu     162.7417 (36.41)    183.1321 (18.61)    173.9028 (31.57)    8.4244 (9.14)     174.7930 (33.46)    13.4904 (17.08)         2;0    5.7503 (0.03)          6           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
=============================================================================================================== 2 passed, 4 deselected in 8.96s ================================================================================================================
```

I checked against transformers and I get:

```
============== DUMMY ====================
Loaded in 0:00:03.180369
Setting `pad_token_id` to `eos_token_id`:50256 for open-end generation.
[{'generated_text': 'test.\n\nThe first thing to note is that the "new" version of the app is not'}]
Ran in 0:00:04.339221
============== NO ALLOC ====================
Lookup in 0:00:00.000292
model from config in 0:00:00.581647
tokenizer in 0:00:00.641293
Loaded in 0:00:00.648781
Loaded weights in 0:00:00.654212
Loaded on model in 0:00:00.658909
Setting `pad_token_id` to `eos_token_id`:50256 for open-end generation.
Ran in 0:00:01.828281
[{'generated_text': 'test.\n\nThe first thing to note is that the "new" version of the app is not'}]
Setting `pad_token_id` to `eos_token_id`:50256 for open-end generation.
Ran in 0:00:02.982728
[{'generated_text': 'test.\n\nThe first thing to note is that the "new" version of the app is not'}]
```
And without `safetensors`

```
============== DUMMY (PT) ====================
Loaded in 0:00:04.272222
Setting `pad_token_id` to `eos_token_id`:50256 for open-end generation.
[{'generated_text': 'test.\n\nThe first thing to note is that the "new" version of the app is not'}]
Ran in 0:00:05.432200
```

https://gist.github.com/Narsil/57ddec904ee795cc6e78eb13562f0c36

I am not sure where the 500-600ms come from when loading the model with `no_init_weights` from accelerate, I'm guessing it's `torch` internals but I'm not sure.

the `NO_ALLOC` case is more of a showcase but maybe at some point we can manage to integrate into `transformers`. 
