### PR TITLE
Replace `std::ffi::c_uint` w/ `std::os::raw::c_uint`

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -30,7 +30,7 @@ type MemcpyFn = unsafe extern "C" fn(
     src: *const std::ffi::c_void,
     count: usize,
     kind: cudaMemcpyKind,
-) -> std::ffi::c_uint;
+) -> std::os::raw::c_uint;
 static TORCH_MODULE: GILOnceCell<Py<PyModule>> = GILOnceCell::new();
 static NUMPY_MODULE: GILOnceCell<Py<PyModule>> = GILOnceCell::new();
 static CUDA_MEMCPY: GILOnceCell<Option<Symbol<MemcpyFn>>> = GILOnceCell::new();


### PR DESCRIPTION
### Getting error below on Intel CPU Macbook:
`cargo check` inside `safetensors/bindings/python`
```bash
(base) Mishigs-MacBook-Pro:python mishig$ cargo check
    Checking safetensors-python v0.2.3 (/Users/mishig/Desktop/safetensors/bindings/python)
error[E0412]: cannot find type `c_uint` in module `std::ffi`
  --> src/lib.rs:33:16
   |
33 | ) -> std::ffi::c_uint;
   |                ^^^^^^ not found in `std::ffi`
   |
help: consider importing this type alias
   |
3  | use std::os::raw::c_uint;
```

However, the error goes away when [std::ffi::c_uint](https://doc.rust-lang.org/stable/std/ffi/type.c_uint.html) is replaced with [std::os::raw::c_uint](https://doc.rust-lang.org/stable/std/os/raw/type.c_uint.html)

I don't know what's the difference between the two: their docs look identical