### PR TITLE
pip install .[dev]

### DIFF
--- a/.github/workflows/python-bench.yml
+++ b/.github/workflows/python-bench.yml
@@ -32,10 +32,7 @@ jobs:
         working-directory: ./bindings/python
         run: |
           pip install -U pip
-          pip install pytest pytest-benchmark setuptools_rust
-          pip install torch tensorflow numpy
-          pip install jax jaxlib flax
-          python setup.py develop
+          pip install .[dev]
 
       - name: Run tests
         working-directory: ./bindings/python

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -60,8 +60,8 @@ jobs:
         working-directory: ./bindings/python
         run: |
           pip install -U pip
+          pip install .[numpy,tensorflow,jax]
           pip install ${{ matrix.torch_version }}
-          pip install .[tensorflow,jax,numpy]
 
       - name: Check style
         working-directory: ./bindings/python

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -60,8 +60,15 @@ jobs:
         working-directory: ./bindings/python
         run: |
           pip install -U pip
-          pip install .[numpy,tensorflow,jax]
+          pip install .[numpy,tensorflow]
           pip install ${{ matrix.torch_version }}
+
+      - name: Install (jax, flax)
+        if: matrix.os != 'windows-latest'
+        working-directory: ./bindings/python
+        run: |
+          pip install .[jax]
+        shell: bash
 
       - name: Check style
         working-directory: ./bindings/python

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Check style
         working-directory: ./bindings/python
         run: |
+          pip install .[quality]
           black --check --line-length 119 --target-version py35 py_src/safetensors tests
 
       - name: Run tests

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -60,8 +60,8 @@ jobs:
         working-directory: ./bindings/python
         run: |
           pip install -U pip
-          pip install .[dev]
-          pip install ${{ matrix.torch_version }} --force-reinstall
+          pip install ${{ matrix.torch_version }}
+          pip install .[tensorflow,jax,numpy]
 
       - name: Check style
         working-directory: ./bindings/python
@@ -73,4 +73,5 @@ jobs:
         working-directory: ./bindings/python
         run: |
           cargo test
+          pip install .[testing]
           pytest -sv tests/

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -54,15 +54,12 @@ jobs:
         working-directory: ./bindings/python
         run: |
           pip install -U pip
-          pip install pytest requests setuptools_rust numpy pyarrow datasets
-          pip install ${{ matrix.torch_version }} tensorflow numpy
-          pip install jax jaxlib flax
-          python setup.py develop
+          pip install .[dev]
+          pip install ${{ matrix.torch_version }} --force-reinstall
 
       - name: Check style
         working-directory: ./bindings/python
         run: |
-          pip install black==22.3 click==8.0.4
           black --check --line-length 119 --target-version py35 py_src/safetensors tests
 
       - name: Run tests

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -46,14 +46,15 @@ loaded = load_file("./model.safetensors")
 ### Developing
 
 ```
-pip install setuptools_rust
-python setup.py develop
+# inside ./safetensors/bindings/python
+pip install .[dev]
 ```
 Should be enough to install this library locally.
 
 ### Testing
 
 ```
-pip install pytest   # We don't require pytest, but it's a common library used across HF.
+# inside ./safetensors/bindings/python
+pip install .[dev]
 pytest -sv tests/
 ```

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools", "wheel", "setuptools-rust"]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 line-length = 119
 target-version = ['py35']

--- a/bindings/python/requirements-dev.txt
+++ b/bindings/python/requirements-dev.txt
@@ -1,7 +1,0 @@
-black==22.3  # after updating to black 2023, also update Python version in pyproject.toml to 3.7
-isort>=5.5.4
-flake8>=3.8.3
-pytest
-numpy
-setuptools_rust
-huggingface_hub

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -1,13 +1,52 @@
+import re
 from setuptools import setup
 from setuptools_rust import Binding, RustExtension
 
 
-with open("requirements-dev.txt", "r") as f:
-    testing = f.read().splitlines()
+# IMPORTANT:
+# 1. all dependencies should be listed here with their version requirements if any
+_deps = [
+    "black==22.3",  # after updating to black 2023, also update Python version in pyproject.toml to 3.7
+    "datasets",
+    "flake8>=3.8.3",
+    "flax",
+    "huggingface_hub",
+    "isort>=5.5.4",
+    "jax",
+    "jaxlib",
+    "numpy",
+    "setuptools_rust",
+    "pyarrow",
+    "pytest",
+    "tensorflow",
+    "torch",
+    "requests",
+]
+
+
+# this is a lookup table with items like:
+#
+# tokenizers: "tokenizers==0.9.4"
+# packaging: "packaging"
+#
+# some of the values are versioned whereas others aren't.
+deps = {b: a for a, b in (re.findall(r"^(([^!=<>~ ]+)(?:[!=<>~ ].*)?$)", x)[0] for x in _deps)}
+
+
+def deps_list(*pkgs):
+    return [deps[pkg] for pkg in pkgs]
+
+
 
 extras = {}
-extras["testing"] = testing
-extras["dev"] = testing
+extras["torch"] = deps_list("torch")
+extras["numpy"] = deps_list("numpy")
+extras["tensorflow"] = deps_list("tensorflow")
+extras["jax"] = deps_list("jax", "jaxlib", "flax")
+extras["quality"] = deps_list("black", "datasets", "pyarrow", "requests", "isort", "flake8")
+extras["testing"] = deps_list("setuptools_rust", "huggingface_hub", "pytest") + extras["numpy"]
+extras["all"] = extras["torch"] + extras["numpy"] + extras["tensorflow"] + extras["jax"] + extras["quality"] + extras["testing"]
+extras["dev"] = extras["all"]
 
 setup(
     name="safetensors",

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -11,10 +11,10 @@ _deps = [
     "datasets",
     "flake8>=3.8.3",
     "flax",
+    "h5py",
     "huggingface_hub",
     "isort>=5.5.4",
     "jax",
-    "jaxlib",
     "numpy",
     "setuptools_rust",
     "pyarrow",
@@ -44,9 +44,9 @@ extras = {}
 extras["torch"] = deps_list("torch")
 extras["numpy"] = deps_list("numpy")
 extras["tensorflow"] = deps_list("tensorflow")
-extras["jax"] = deps_list("jax", "jaxlib", "flax")
+extras["jax"] = deps_list("jax", "flax")
 extras["quality"] = deps_list("black", "datasets", "pyarrow", "requests", "isort", "flake8", "click")
-extras["testing"] = deps_list("setuptools_rust", "huggingface_hub", "pytest", "pytest-benchmark") + extras["numpy"]
+extras["testing"] = deps_list("setuptools_rust", "huggingface_hub", "pytest", "pytest-benchmark", "h5py") + extras["numpy"]
 extras["all"] = extras["torch"] + extras["numpy"] + extras["tensorflow"] + extras["jax"] + extras["quality"] + extras["testing"]
 extras["dev"] = extras["all"]
 

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -8,7 +8,6 @@ from setuptools_rust import Binding, RustExtension
 _deps = [
     "black==22.3",  # after updating to black 2023, also update Python version in pyproject.toml to 3.7
     "click==8.0.4",
-    "datasets",
     "flake8>=3.8.3",
     "flax",
     "h5py",
@@ -17,12 +16,10 @@ _deps = [
     "jax",
     "numpy",
     "setuptools_rust",
-    "pyarrow",
     "pytest",
     "pytest-benchmark",
     "tensorflow",
     "torch",
-    "requests",
 ]
 
 
@@ -45,7 +42,7 @@ extras["torch"] = deps_list("torch")
 extras["numpy"] = deps_list("numpy")
 extras["tensorflow"] = deps_list("tensorflow")
 extras["jax"] = deps_list("jax", "flax")
-extras["quality"] = deps_list("black", "datasets", "pyarrow", "requests", "isort", "flake8", "click")
+extras["quality"] = deps_list("black", "isort", "flake8", "click")
 extras["testing"] = deps_list("setuptools_rust", "huggingface_hub", "pytest", "pytest-benchmark", "h5py") + extras["numpy"]
 extras["all"] = extras["torch"] + extras["numpy"] + extras["tensorflow"] + extras["jax"] + extras["quality"] + extras["testing"]
 extras["dev"] = extras["all"]

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -7,6 +7,7 @@ from setuptools_rust import Binding, RustExtension
 # 1. all dependencies should be listed here with their version requirements if any
 _deps = [
     "black==22.3",  # after updating to black 2023, also update Python version in pyproject.toml to 3.7
+    "click==8.0.4",
     "datasets",
     "flake8>=3.8.3",
     "flax",
@@ -18,6 +19,7 @@ _deps = [
     "setuptools_rust",
     "pyarrow",
     "pytest",
+    "pytest-benchmark",
     "tensorflow",
     "torch",
     "requests",
@@ -43,8 +45,8 @@ extras["torch"] = deps_list("torch")
 extras["numpy"] = deps_list("numpy")
 extras["tensorflow"] = deps_list("tensorflow")
 extras["jax"] = deps_list("jax", "jaxlib", "flax")
-extras["quality"] = deps_list("black", "datasets", "pyarrow", "requests", "isort", "flake8")
-extras["testing"] = deps_list("setuptools_rust", "huggingface_hub", "pytest") + extras["numpy"]
+extras["quality"] = deps_list("black", "datasets", "pyarrow", "requests", "isort", "flake8", "click")
+extras["testing"] = deps_list("setuptools_rust", "huggingface_hub", "pytest", "pytest-benchmark") + extras["numpy"]
 extras["all"] = extras["torch"] + extras["numpy"] + extras["tensorflow"] + extras["jax"] + extras["quality"] + extras["testing"]
 extras["dev"] = extras["all"]
 


### PR DESCRIPTION
For [doc-builds](https://github.com/huggingface/safetensors/pull/55#issue-1432814611) & in general, `pip install .[dev]` is preferred over `python setup.py develop`

1. Previously, `pip install .[dev]` was erring due to lines below missing: https://github.com/huggingface/safetensors/blob/109f54c1f390e2906098f3e5144eff4272aac384/bindings/python/pyproject.toml#L1-L3
2. For the `extras` management, I've copied it from [transformers](https://github.com/huggingface/transformers/blob/af150e4a1c4c4efef634bc5ee3a1773a97772ffb/setup.py#L95-L98) 