### PR TITLE
Adding `cargo fuzz` and found sanitation opportunities.

### DIFF
--- a/safetensors/fuzz/.gitignore
+++ b/safetensors/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/safetensors/fuzz/Cargo.toml
+++ b/safetensors/fuzz/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "safetensors-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.safetensors]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "fuzz_target_1"
+path = "fuzz_targets/fuzz_target_1.rs"
+test = false
+doc = false

--- a/safetensors/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/safetensors/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -1,0 +1,8 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use safetensors::tensor::SafeTensors;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = SafeTensors::deserialize(data);
+});


### PR DESCRIPTION
Enter `cargo fuzz` 

Which tries to send wrong payloads and see how your code performs.
It spotted a few ways which could cause the deserialization to panic.

I also ran `miri` on tests https://github.com/rust-lang/miri and everything went through. But I need to check how to run it on the Python part to gain more confidence in the correctness of the current code.