### PR TITLE
Making SAFETENSORS_FAST_GPU=1 work on Windows again.

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -322,9 +322,7 @@ fn find_cudart(module: &PyModule) -> Option<Library> {
         let mut path = path.ok()?;
         path.pop();
         path.push("lib");
-        println!("Using path {path:?}");
         let paths = std::fs::read_dir(path).ok()?;
-        println!("Using paths {paths:?}");
         let cudart_paths: Vec<_> = paths
             .into_iter()
             .filter_map(|p| {
@@ -337,10 +335,8 @@ fn find_cudart(module: &PyModule) -> Option<Library> {
                 }
             })
             .collect();
-        println!("Using cudart paths {cudart_paths:?}");
         let cudart_path = cudart_paths.get(0)?;
-        println!("Using cudart_path {cudart_path:?}");
-        unsafe { libloading::os::windows::Library::open_already_loaded(cudart_path).ok()? }
+        Library::from(libloading::os::windows::Library::open_already_loaded(cudart_path).ok()?)
     };
 
     Some(lib)

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -300,17 +300,49 @@ fn find_cudart(module: &PyModule) -> Option<Library> {
     if var != "1" {
         return None;
     }
-    let path: std::path::PathBuf = module
+
+    let path: PyResult<std::path::PathBuf> = module
         .getattr(intern!(module.py(), "_C"))
         .ok()?
         .getattr(intern!(module.py(), "__file__"))
         .ok()?
-        .extract()
-        .ok()?;
+        .extract();
+
     // SAFETY: This is unsafe because the library might run arbitrary code
     // So it's really important to make sure we are targeting the correct
     // library.
-    let lib = unsafe { Library::new(path).ok()? };
+    #[cfg(not(target_os = "windows"))]
+    let lib = {
+        let path = path.ok()?;
+        unsafe { Library::new(path).ok()? }
+    };
+
+    #[cfg(target_os = "windows")]
+    let lib = {
+        let mut path = path.ok()?;
+        path.pop();
+        path.push("lib");
+        println!("Using path {path:?}");
+        let paths = std::fs::read_dir(path).ok()?;
+        println!("Using paths {paths:?}");
+        let cudart_paths: Vec<_> = paths
+            .into_iter()
+            .filter_map(|p| {
+                let p = p.ok()?.path();
+                let filename = p.file_name()?.to_string_lossy();
+                if filename.starts_with("cudart") {
+                    Some(p)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        println!("Using cudart paths {cudart_paths:?}");
+        let cudart_path = cudart_paths.get(0)?;
+        println!("Using cudart_path {cudart_path:?}");
+        unsafe { libloading::os::windows::Library::open_already_loaded(cudart_path).ok()? }
+    };
+
     Some(lib)
 }
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -308,12 +308,12 @@ fn find_cudart(module: &PyModule) -> Option<Library> {
         .ok()?
         .extract();
 
-    // SAFETY: This is unsafe because the library might run arbitrary code
-    // So it's really important to make sure we are targeting the correct
-    // library.
     #[cfg(not(target_os = "windows"))]
     let lib = {
         let path = path.ok()?;
+        // SAFETY: This is unsafe because the library might run arbitrary code
+        // So it's really important to make sure we are targeting the correct
+        // library.
         unsafe { Library::new(path).ok()? }
     };
 


### PR DESCRIPTION
Turns out since we changed the loading of cudaMemcpy from looking
for cudart, to simply loading `_C.so` from Python, we broke Windows
fast path. That's because of this: https://github.com/nagisa/rust_libloading/issues/110
By default windows loads the DLL without being able to fetch nested DLLs.

There's a few choices to fix that:
- Use `load_with_flags` with a flag that would allow loading subdlls. 
  That's platform specific, and I got confused by all the options:
  https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexw#parameters 
- Use `open_already_loaded`. This seems particularly interesting  because despite
  being OS specific, it will only load DLLs already loaded by the program which happens to be safe.
  So by using it we don't need `unsafe`, but we still need to manually look for cudart in the subdirectory (which is brittle).


Decided to go for Option 2.

Hopefully fixes: https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/5893 (This is not the only part of the fix)