### PR TITLE
[Major Change] Enforcing tensor alignment

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -111,9 +111,7 @@ fn serialize<'b>(
     tensor_dict: HashMap<String, &PyDict>,
     metadata: Option<HashMap<String, String>>,
 ) -> PyResult<&'b PyBytes> {
-    println!("Tensor dict {:?}", tensor_dict);
     let tensors = prepare(tensor_dict)?;
-    println!("Tensors {:?}", tensors);
     let metadata_map = metadata.map(|data| HashMap::from_iter(data.into_iter()));
     let out = safetensors::tensor::serialize(&tensors, &metadata_map)
         .map_err(|e| SafetensorError::new_err(format!("Error while serializing: {e:?}")))?;

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -85,7 +85,7 @@ fn prepare(tensor_dict: HashMap<String, &PyDict>) -> PyResult<HashMap<String, Te
             SafetensorError::new_err(format!("Missing `data` in {tensor_desc:?}"))
         })?;
         let tensor = TensorView::new(dtype, shape, data).map_err(|e| {
-            SafetensorError::new_err(format!("Error preparing tensor view: {:?}", e))
+            SafetensorError::new_err(format!("Error preparing tensor view: {e:?}"))
         })?;
         tensors.insert(tensor_name, tensor);
     }
@@ -913,7 +913,7 @@ impl PySafeSlice {
 
                 let tensor = TensorView::new(self.info.dtype, self.info.shape.clone(), data)
                     .map_err(|e| {
-                        SafetensorError::new_err(format!("Error preparing tensor view: {:?}", e))
+                        SafetensorError::new_err(format!("Error preparing tensor view: {e:?}"))
                     })?;
                 let slices: Vec<TensorIndexer> = slices
                     .into_iter()

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -84,9 +84,8 @@ fn prepare(tensor_dict: HashMap<String, &PyDict>) -> PyResult<HashMap<String, Te
         let data = data.ok_or_else(|| {
             SafetensorError::new_err(format!("Missing `data` in {tensor_desc:?}"))
         })?;
-        let tensor = TensorView::new(dtype, shape, data).map_err(|e| {
-            SafetensorError::new_err(format!("Error preparing tensor view: {e:?}"))
-        })?;
+        let tensor = TensorView::new(dtype, shape, data)
+            .map_err(|e| SafetensorError::new_err(format!("Error preparing tensor view: {e:?}")))?;
         tensors.insert(tensor_name, tensor);
     }
     Ok(tensors)

--- a/bindings/python/tests/test_pt_comparison.py
+++ b/bindings/python/tests/test_pt_comparison.py
@@ -27,7 +27,8 @@ class TorchTestCase(unittest.TestCase):
         binary = save(data)
         self.assertEqual(
             binary,
-            b'<\x00\x00\x00\x00\x00\x00\x00{"test":{"dtype":"F32","shape":[2,2],"data_offsets":[0,16]}}\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+            # Spaces are for forcing the alignment.
+            b'@\x00\x00\x00\x00\x00\x00\x00{"test":{"dtype":"F32","shape":[2,2],"data_offsets":[0,16]}}    \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
         )
         reloaded = load(binary)
         self.assertTrue(torch.equal(data["test"], reloaded["test"]))

--- a/safetensors/benches/benchmark.rs
+++ b/safetensors/benches/benchmark.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use safetensors::tensor::*;
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 
 // Returns a sample data of size 2_MB
 fn get_sample_data() -> (Vec<u8>, Vec<usize>, Dtype) {
@@ -16,7 +16,7 @@ pub fn bench_serialize(c: &mut Criterion) {
     let (data, shape, dtype) = get_sample_data();
     let n_layers = 5;
 
-    let mut metadata: BTreeMap<String, TensorView> = BTreeMap::new();
+    let mut metadata: HashMap<String, TensorView> = HashMap::new();
     // 2_MB x 5 = 10_MB
     for i in 0..n_layers {
         let tensor = TensorView::new(dtype, shape.clone(), &data[..]);
@@ -34,7 +34,7 @@ pub fn bench_deserialize(c: &mut Criterion) {
     let (data, shape, dtype) = get_sample_data();
     let n_layers = 5;
 
-    let mut metadata: BTreeMap<String, TensorView> = BTreeMap::new();
+    let mut metadata: HashMap<String, TensorView> = HashMap::new();
     // 2_MB x 5 = 10_MB
     for i in 0..n_layers {
         let tensor = TensorView::new(dtype, shape.clone(), &data[..]);

--- a/safetensors/benches/benchmark.rs
+++ b/safetensors/benches/benchmark.rs
@@ -19,7 +19,7 @@ pub fn bench_serialize(c: &mut Criterion) {
     let mut metadata: HashMap<String, TensorView> = HashMap::new();
     // 2_MB x 5 = 10_MB
     for i in 0..n_layers {
-        let tensor = TensorView::new(dtype, shape.clone(), &data[..]);
+        let tensor = TensorView::new(dtype, shape.clone(), &data[..]).unwrap();
         metadata.insert(format!("weight{i}"), tensor);
     }
 
@@ -37,7 +37,7 @@ pub fn bench_deserialize(c: &mut Criterion) {
     let mut metadata: HashMap<String, TensorView> = HashMap::new();
     // 2_MB x 5 = 10_MB
     for i in 0..n_layers {
-        let tensor = TensorView::new(dtype, shape.clone(), &data[..]);
+        let tensor = TensorView::new(dtype, shape.clone(), &data[..]).unwrap();
         metadata.insert(format!("weight{i}"), tensor);
     }
 

--- a/safetensors/src/slice.rs
+++ b/safetensors/src/slice.rs
@@ -215,17 +215,17 @@ impl<'data> SliceIterator<'data> {
     ) -> Result<Self, InvalidSlice> {
         // Make sure n. axis does not exceed n. of dimensions
         let n_slice = slices.len();
-        let n_shape = view.shape.len();
+        let n_shape = view.shape().len();
         if n_slice > n_shape {
             return Err(InvalidSlice::TooManySlices);
         }
-        let mut newshape = Vec::with_capacity(view.shape.len());
+        let mut newshape = Vec::with_capacity(view.shape().len());
 
         // Minimum span is the span of 1 item;
-        let mut span = view.dtype.size();
+        let mut span = view.dtype().size();
         let mut indices = vec![];
         // Everything is row major.
-        for (i, &shape) in view.shape.iter().enumerate().rev() {
+        for (i, &shape) in view.shape().iter().enumerate().rev() {
             if i >= slices.len() {
                 // We are  not slicing yet, just increase the local span
                 newshape.push(shape);
@@ -273,7 +273,7 @@ impl<'data> SliceIterator<'data> {
             span *= shape;
         }
         if indices.is_empty() {
-            indices.push((0, view.data.len()));
+            indices.push((0, view.data().len()));
         }
         // Reversing so we can pop faster while iterating on the slice
         let indices = indices.into_iter().rev().collect();
@@ -307,7 +307,7 @@ impl<'data> Iterator for SliceIterator<'data> {
         // here actually to remove the need to get all the indices
         // upfront.
         let (start, stop) = self.indices.pop()?;
-        Some(&self.view.data[start..stop])
+        Some(&self.view.data()[start..stop])
     }
 }
 
@@ -323,11 +323,7 @@ mod tests {
             .flat_map(|f| f.to_le_bytes())
             .collect();
 
-        let attn_0 = TensorView {
-            dtype: Dtype::F32,
-            shape: vec![1, 2, 3],
-            data: &data,
-        };
+        let attn_0 = TensorView::new(Dtype::F32, vec![1, 2, 3], &data).unwrap();
 
         let iterator = SliceIterator::new(
             &attn_0,
@@ -356,11 +352,7 @@ mod tests {
             .flat_map(|f| f.to_le_bytes())
             .collect();
 
-        let attn_0 = TensorView {
-            dtype: Dtype::F32,
-            shape: vec![1, 2, 3],
-            data: &data,
-        };
+        let attn_0 = TensorView::new(Dtype::F32, vec![1, 2, 3], &data).unwrap();
 
         let mut iterator = SliceIterator::new(
             &attn_0,
@@ -423,11 +415,7 @@ mod tests {
             .flat_map(|f| f.to_le_bytes())
             .collect();
 
-        let attn_0 = TensorView {
-            dtype: Dtype::F32,
-            shape: vec![1, 2, 3],
-            data: &data,
-        };
+        let attn_0 = TensorView::new(Dtype::F32, vec![1, 2, 3], &data).unwrap();
 
         let mut iterator = SliceIterator::new(
             &attn_0,
@@ -484,11 +472,7 @@ mod tests {
             .flat_map(|f| f.to_le_bytes())
             .collect();
 
-        let attn_0 = TensorView {
-            dtype: Dtype::F32,
-            shape: vec![2, 3],
-            data: &data,
-        };
+        let attn_0 = TensorView::new(Dtype::F32, vec![2, 3], &data).unwrap();
 
         let mut iterator = SliceIterator::new(
             &attn_0,

--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -294,7 +294,6 @@ impl Serialize for Metadata {
             map.serialize_entry("__metadata__", metadata)?;
         }
         for (name, info) in tensors {
-            println!("Info {:?}", info);
             map.serialize_entry(&name, &info)?;
         }
         map.end()
@@ -331,8 +330,6 @@ impl Metadata {
         for (i, info) in self.tensors.iter().enumerate() {
             let (s, e) = info.data_offsets;
             if s != start || e < s {
-                println!("S {s:?} start {start:?} e {e:?}");
-                println!("Error {:?} - {:?}", s != start, e < s);
                 let tensor_name = self
                     .index_map
                     .iter()


### PR DESCRIPTION
- Now the header will automatically align itself to 8 bytes (f64) with
  appending extra spaces as necessary.
- This will allow extra fast memory mapping by reinterpreting bytes as
  f32/f64 etc.. Unaligned bytes do not allow for this. https://www.reddit.com/r/rust/comments/tanaxm/mutating_a_buffer_of_u8s_as_f32s_in_place/
- This does not change contiguousness of tensors
- This does not change the actual spec (we're just putting extra valid bytes
  in the header and using a different serialization ordering)
- Readers should still be able to read old files, they would just need
  to be copied before being cast as their final destination when using
  mmap
- This has no effect for GPU since copy is already necessary (*I think*,
  depends on the cuda API actually if it allows filling f32 addresses
  from raw unaligned bytes).

This change will only be interesting if things like https://github.com/Narsil/fast_gpt2
actually pick up. And even with the copy, load times are still vastly
faster than `pytorch`/`transformers`.