### PR TITLE
Fix byte order detection for `np.uint8` and other types for which byte order is not defined.

### DIFF
--- a/bindings/python/py_src/safetensors/numpy.py
+++ b/bindings/python/py_src/safetensors/numpy.py
@@ -165,4 +165,6 @@ def _byte_order(tensor: np.ndarray) -> str:
             return "<"
         else:
             return ">"
+    elif byteorder == "|":
+        return "<"
     return byteorder


### PR DESCRIPTION
Fixes: #154