### PR TITLE
Fix byte order detection for `np.uint8` and other types for which byte order is not defined.

### DIFF
--- a/bindings/python/py_src/safetensors/numpy.py
+++ b/bindings/python/py_src/safetensors/numpy.py
@@ -165,4 +165,6 @@ def _byte_order(tensor: np.ndarray) -> str:
             return "<"
         else:
             return ">"
+    elif byteorder == "|":
+        return "<"
     return byteorder

--- a/bindings/python/tests/test_simple.py
+++ b/bindings/python/tests/test_simple.py
@@ -71,9 +71,13 @@ class ReadmeTestCase(unittest.TestCase):
         tensors = {"a": np.zeros((2, 2)), "b": np.zeros((2, 3), dtype=np.uint8)}
 
         save_file(tensors, "./out.safetensors")
+        out = save(tensors)
 
         # Now loading
         loaded = load_file("./out.safetensors")
+        self.assertTensorEqual(tensors, loaded, np.allclose)
+
+        loaded = load(out)
         self.assertTensorEqual(tensors, loaded, np.allclose)
 
     def test_torch_example(self):


### PR DESCRIPTION
Fixes #154.

Superseed  #155 