### PR TITLE
Fixing the fact that the context manager wasn't properly cleaning up after itself.

### DIFF
--- a/bindings/python/py_src/safetensors/__init__.py
+++ b/bindings/python/py_src/safetensors/__init__.py
@@ -1,7 +1,7 @@
 __version__ = "0.2.9"
 
 # Re-export this
-from .safetensors_rust import safe_open as rust_open  # noqa: F401
+from ._safetensors_rust import safe_open as rust_open, serialize, serialize_file, deserialize, SafetensorError
 
 
 class safe_open:

--- a/bindings/python/py_src/safetensors/__init__.py
+++ b/bindings/python/py_src/safetensors/__init__.py
@@ -1,4 +1,20 @@
 __version__ = "0.2.9"
 
 # Re-export this
-from .safetensors_rust import safe_open  # noqa: F401
+from .safetensors_rust import safe_open as rust_open  # noqa: F401
+
+
+class safe_open:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def __getattr__(self, __name: str):
+        return getattr(self.f, __name)
+
+    def __enter__(self):
+        self.f = rust_open(*self.args, **self.kwargs)
+        return self
+
+    def __exit__(self, type, value, traceback):
+        del self.f

--- a/bindings/python/py_src/safetensors/numpy.py
+++ b/bindings/python/py_src/safetensors/numpy.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional, Union
 
 import numpy as np
 
-from .safetensors_rust import deserialize, safe_open, serialize, serialize_file
+from safetensors import deserialize, safe_open, serialize, serialize_file
 
 
 def save(tensor_dict: Dict[str, np.ndarray], metadata: Optional[Dict[str, str]] = None) -> bytes:

--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional, Union
 
 import torch
 
-from .safetensors_rust import deserialize, safe_open, serialize, serialize_file
+from safetensors import deserialize, safe_open, serialize, serialize_file
 
 
 def save(tensors: Dict[str, torch.Tensor], metadata: Optional[Dict[str, str]] = None) -> bytes:

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -59,7 +59,7 @@ setup(
     author_email="",
     url="https://github.com/huggingface/safetensors",
     license="Apache License 2.0",
-    rust_extensions=[RustExtension("safetensors.safetensors_rust", binding=Binding.PyO3, debug=False)],
+    rust_extensions=[RustExtension("safetensors._safetensors_rust", binding=Binding.PyO3, debug=False)],
     extras_require=extras,
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1021,7 +1021,7 @@ pyo3::create_exception!(
 
 /// A Python module implemented in Rust.
 #[pymodule]
-fn safetensors_rust(py: Python, m: &PyModule) -> PyResult<()> {
+fn _safetensors_rust(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(serialize, m)?)?;
     m.add_function(wrap_pyfunction!(serialize_file, m)?)?;
     m.add_function(wrap_pyfunction!(deserialize, m)?)?;

--- a/bindings/python/tests/test_pt_comparison.py
+++ b/bindings/python/tests/test_pt_comparison.py
@@ -2,7 +2,7 @@ import unittest
 
 import torch
 
-from safetensors.safetensors_rust import safe_open
+from safetensors import safe_open
 from safetensors.torch import load, load_file, save, save_file
 
 

--- a/bindings/python/tests/test_simple.py
+++ b/bindings/python/tests/test_simple.py
@@ -67,7 +67,7 @@ class WindowsTestCase(unittest.TestCase):
             "b": torch.zeros((2, 3), dtype=torch.uint8),
         }
         save_file_pt(tensors, "./out.safetensors")
-        with safe_open("./out.safetensors", framework="pt"):
+        with safe_open("./out.safetensors", framework="pt") as f:
             pass
 
         with open("./out.safetensors", "w") as g:

--- a/bindings/python/tests/test_simple.py
+++ b/bindings/python/tests/test_simple.py
@@ -5,9 +5,8 @@ from pathlib import Path
 import numpy as np
 import torch
 
-from safetensors import safe_open
 from safetensors.numpy import load, load_file, save, save_file
-from safetensors.safetensors_rust import SafetensorError, serialize
+from safetensors import safe_open, SafetensorError, serialize
 from safetensors.torch import load_file as load_file_pt
 from safetensors.torch import save_file as save_file_pt
 

--- a/bindings/python/tests/test_simple.py
+++ b/bindings/python/tests/test_simple.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import numpy as np
 import torch
 
+from safetensors import safe_open
 from safetensors.numpy import load, load_file, save, save_file
 from safetensors.safetensors_rust import SafetensorError, serialize
 from safetensors.torch import load_file as load_file_pt
@@ -57,6 +58,20 @@ class TestCase(unittest.TestCase):
         save_file_pt(tensors, Path("./out.safetensors"))
         load_file_pt(Path("./out.safetensors"))
         os.remove(Path("./out.safetensors"))
+
+
+class WindowsTestCase(unittest.TestCase):
+    def test_get_correctly_dropped(self):
+        tensors = {
+            "a": torch.zeros((2, 2)),
+            "b": torch.zeros((2, 3), dtype=torch.uint8),
+        }
+        save_file_pt(tensors, "./out.safetensors")
+        with safe_open("./out.safetensors", framework="pt"):
+            pass
+
+        with open("./out.safetensors", "w") as g:
+            g.write("something")
 
 
 class ReadmeTestCase(unittest.TestCase):


### PR DESCRIPTION
Fixes #164 

What happened:
- Windows doesn't like to open to write memory mapped files (that's OK and would also prevent potential weird bugs on other platforms)
- Context manager in PyO3 do not drop themselves on `__exit__`, so resources are still held for the rest of the program.

So `safe_open` a file, even not doing anything, would open the file in memory mapped mode (to read the header) and would prevent writing over it afterwards.

Solution:

- Make a real Python wrapper context manager still named `safe_open` (so hopefully transparent).
- Make the new wrapper actually `del f` the rust class, which **does** call `Drop` and cleanup the ressources.

There are other way to solve this, but this seems quite simple. The biggest drawback is if users would actually be using `safetensors.safetensors_rust.safe_open` and not `safetensors.safe_open`. I think this is limited.
To prevent further potential misuse, this PR also renames the rust class to something private. `_safe_open`.