### PR TITLE
Better error messages on outdated context manager.

### DIFF
--- a/bindings/python/py_src/safetensors/__init__.py
+++ b/bindings/python/py_src/safetensors/__init__.py
@@ -1,20 +1,4 @@
 __version__ = "0.2.9"
 
 # Re-export this
-from ._safetensors_rust import safe_open as rust_open, serialize, serialize_file, deserialize, SafetensorError
-
-
-class safe_open:
-    def __init__(self, *args, **kwargs):
-        self.args = args
-        self.kwargs = kwargs
-
-    def __getattr__(self, __name: str):
-        return getattr(self.f, __name)
-
-    def __enter__(self):
-        self.f = rust_open(*self.args, **self.kwargs)
-        return self
-
-    def __exit__(self, type, value, traceback):
-        del self.f
+from ._safetensors_rust import safe_open, serialize, serialize_file, deserialize, SafetensorError  # noqa: F401

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -644,7 +644,9 @@ impl Open {
                     let start = (info.data_offsets.0 + self.offset) as isize;
                     let stop = (info.data_offsets.1 + self.offset) as isize;
                     let slice = pyslice_new(py, start, stop, 1);
-                    let storage: &PyObject = storage.get(py)?;
+                    let storage: &PyObject = storage
+                        .get(py)
+                        .ok_or_else(|| SafetensorError::new_err("Could not find storage"))?;
                     let storage: &PyAny = storage.as_ref(py);
 
                     let storage_slice = storage
@@ -825,7 +827,7 @@ impl safe_open {
     }
 
     pub fn __exit__(&mut self, _exc_type: PyObject, _exc_value: PyObject, _traceback: PyObject) {
-        if let Some(inner) = self.inner {
+        if let Some(inner) = &self.inner {
             if let (Device::Cuda(_), Framework::Pytorch) = (&inner.device, &inner.framework) {
                 Python::with_gil(|py| -> PyResult<()> {
                     let module = get_module(py, &TORCH_MODULE)?;
@@ -960,7 +962,9 @@ impl PySafeSlice {
                 let start = (self.info.data_offsets.0 + self.offset) as isize;
                 let stop = (self.info.data_offsets.1 + self.offset) as isize;
                 let slice = pyslice_new(py, start, stop, 1);
-                let storage: &PyObject = storage.get(py)?;
+                let storage: &PyObject = storage
+                    .get(py)
+                    .ok_or_else(|| SafetensorError::new_err("Could not find storage"))?;
                 let storage: &PyAny = storage.as_ref(py);
 
                 let storage_slice = storage

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -723,7 +723,7 @@ impl safe_open {
         let inner = self
             .inner
             .as_ref()
-            .ok_or_else(|| SafetensorError::new_err(format!("File is closed",)))?;
+            .ok_or_else(|| SafetensorError::new_err("File is closed".to_string()))?;
         Ok(inner)
     }
 }

--- a/bindings/python/tests/test_simple.py
+++ b/bindings/python/tests/test_simple.py
@@ -69,6 +69,9 @@ class WindowsTestCase(unittest.TestCase):
         with safe_open("./out.safetensors", framework="pt") as f:
             pass
 
+        with self.assertRaises(SafetensorError):
+            print(f.keys())
+
         with open("./out.safetensors", "w") as g:
             g.write("something")
 


### PR DESCRIPTION
I think this PR might improve what was done in PR : https://github.com/huggingface/safetensors/pull/166

Link to idea: https://github.com/PyO3/pyo3/issues/1205#issuecomment-1397029973

The problem is showcased in the test, were usage of `f` after the context manager would create a recursion error instead of a simple error.
By encapsulating everything within an `inner` class, we case rely on the type system to provide a correct error which is that the context manager is outdated.