### PR TITLE
README.md proposed clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ with safe_open("model.safetensors", framework="pt", device="cpu") as f:
 
 - 8 bytes: `N`, a u64 int, containing the size of the header
 - N bytes: a JSON utf-8 string representing the header.
-  - The header is a dict like {"TENSOR_NAME": {"dtype": "float16", "shape": [1, 16, 256], "offsets": (X, Y)}}, where X and Y are the offsets in the byte buffer of the tensor data
+  - The header is a dict like {"TENSOR_NAME": {"dtype": "float16", "shape": [1, 16, 256], "offsets": [BEGIN, END]}, "NEXT_TENSOR_NAME": {...}, ...}, where offsets point to the tensor data relative to the beginning of the byte buffer, with BEGIN as the starting offset and END as the one-past offset (so total tensor byte size = END - BEGIN).
   - A special key `__metadata__` is allowed to contain free form text map.
 - Rest of the file: byte-buffer.
 

--- a/safetensors/README.md
+++ b/safetensors/README.md
@@ -54,7 +54,7 @@ with safe_open("model.safetensors", framework="pt", device="cpu") as f:
 
 - 8 bytes: `N`, a u64 int, containing the size of the header
 - N bytes: a JSON utf-8 string representing the header.
-  - The header is a dict like {"TENSOR_NAME": {"dtype": "float16", "shape": [1, 16, 256], "offsets": (X, Y)}}, where X and Y are the offsets in the byte buffer of the tensor data
+  - The header is a dict like {"TENSOR_NAME": {"dtype": "float16", "shape": [1, 16, 256], "offsets": [BEGIN, END]}, "NEXT_TENSOR_NAME": {...}, ...}, where offsets point to the tensor data relative to the beginning of the byte buffer, with BEGIN as the starting offset and END as the one-past offset (so total tensor byte size = END - BEGIN).
   - A special key `__metadata__` is allowed to contain free form text map.
 - Rest of the file: byte-buffer.
 

--- a/safetensors/src/lib.rs
+++ b/safetensors/src/lib.rs
@@ -53,7 +53,7 @@
 //!
 //! - 8 bytes: `N`, a u64 int, containing the size of the header
 //! - N bytes: a JSON utf-8 string representing the header.
-//!   - The header is a dict like {"TENSOR_NAME": {"dtype": "float16", "shape": [1, 16, 256], "offsets": (X, Y)}}, where X and Y are the offsets in the byte buffer of the tensor data
+//!   - The header is a dict like {"TENSOR_NAME": {"dtype": "float16", "shape": [1, 16, 256], "offsets": [BEGIN, END]}, "NEXT_TENSOR_NAME": {...}, ...}, where offsets point to the tensor data relative to the beginning of the byte buffer, with BEGIN as the starting offset and END as the one-past offset (so total tensor byte size = END - BEGIN).
 //!   - A special key `__metadata__` is allowed to contain free form text map.
 //! - Rest of the file: byte-buffer.
 //!


### PR DESCRIPTION
I had to look via a hex editor at an existing .safetensors file to figure it out (maybe this will accelerate others slightly to adopt it 😅), because parentheses "(...)" are not legal JSON, and it wasn't clear to me whether the offsets were file relative or byte buffer relative.