### PR TITLE
Deprecating loading files without specifying device (removing the default).

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -9,7 +9,7 @@ name = "safetensors_rust"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.17.2", features = ["extension-module"] }
+pyo3 = { version = "0.18.1", features = ["extension-module"] }
 memmap2 = "0.5"
 serde_json = "1.0"
 libloading = "0.7"

--- a/bindings/python/benches/test_flax.py
+++ b/bindings/python/benches/test_flax.py
@@ -53,7 +53,7 @@ def test_flax_sf_load(benchmark):
     weights = create_gpt2(12)
     with tempfile.NamedTemporaryFile() as f:
         save_file(weights, f.name)
-        result = benchmark(load_file, f.name)
+        result = benchmark(load_file, f.name, device="cpu")
 
     for k, v in weights.items():
         tv = result[k]

--- a/bindings/python/benches/test_paddle.py
+++ b/bindings/python/benches/test_paddle.py
@@ -46,7 +46,7 @@ def test_paddle_sf_load(benchmark):
     weights = create_gpt2(12)
     with tempfile.NamedTemporaryFile() as f:
         save_file(weights, f.name)
-        result = benchmark(load_file, f.name)
+        result = benchmark(load_file, f.name, device="cpu")
 
     for k, v in weights.items():
         tv = result[k]

--- a/bindings/python/benches/test_pt.py
+++ b/bindings/python/benches/test_pt.py
@@ -46,7 +46,7 @@ def test_pt_sf_load_cpu(benchmark):
     weights = create_gpt2(12)
     with tempfile.NamedTemporaryFile() as f:
         save_file(weights, f.name)
-        result = benchmark(load_file, f.name)
+        result = benchmark(load_file, f.name, device="cpu")
 
     for k, v in weights.items():
         tv = result[k]

--- a/bindings/python/benches/test_tf.py
+++ b/bindings/python/benches/test_tf.py
@@ -68,7 +68,7 @@ def test_tf_sf_load(benchmark):
     weights = create_gpt2(12)
     with tempfile.NamedTemporaryFile() as f:
         save_file(weights, f.name)
-        result = benchmark(load_file, f.name)
+        result = benchmark(load_file, f.name, device="cpu")
 
     for k, v in weights.items():
         tv = result[k]

--- a/bindings/python/py_src/safetensors/flax.py
+++ b/bindings/python/py_src/safetensors/flax.py
@@ -98,7 +98,7 @@ def load(data: bytes) -> Dict[str, jnp.DeviceArray]:
     return _np2jnp(flat)
 
 
-def load_file(filename: Union[str, os.PathLike]) -> Dict[str, jnp.DeviceArray]:
+def load_file(filename: Union[str, os.PathLike], device: str = None) -> Dict[str, jnp.DeviceArray]:
     """
     Loads a safetensors file into flax format.
 
@@ -108,6 +108,10 @@ def load_file(filename: Union[str, os.PathLike]) -> Dict[str, jnp.DeviceArray]:
         device (`Dict[str, any]`, *optional*, defaults to `cpu`):
             The device where the tensors need to be located after load.
             available options are all regular flax device locations
+
+            Note: In future versions, the default will be removed. The device
+            is required to be set to the real final device to get the best
+            load performance. Default will be removed in version >= 0.5.
 
     Returns:
         `Dict[str, jnp.DeviceArray]`: dictionary that contains name as key, value as `jnp.DeviceArray`
@@ -121,7 +125,7 @@ def load_file(filename: Union[str, os.PathLike]) -> Dict[str, jnp.DeviceArray]:
     loaded = load_file(file_path)
     ```
     """
-    flat = numpy.load_file(filename)
+    flat = numpy.load_file(filename, device=device)
     return _np2jnp(flat)
 
 

--- a/bindings/python/py_src/safetensors/numpy.py
+++ b/bindings/python/py_src/safetensors/numpy.py
@@ -104,7 +104,7 @@ def load(data: bytes) -> Dict[str, np.ndarray]:
     return _view2np(flat)
 
 
-def load_file(filename: Union[str, os.PathLike]) -> Dict[str, np.ndarray]:
+def load_file(filename: Union[str, os.PathLike], device: str = None) -> Dict[str, np.ndarray]:
     """
     Loads a safetensors file into numpy format.
 
@@ -114,6 +114,10 @@ def load_file(filename: Union[str, os.PathLike]) -> Dict[str, np.ndarray]:
         device (`Dict[str, any]`, *optional*, defaults to `cpu`):
             The device where the tensors need to be located after load.
             available options are all regular numpy device locations
+
+            Note: In future versions, the default will be removed. The device
+            is required to be set to the real final device to get the best
+            load performance. Default will be removed in version >= 0.5.
 
     Returns:
         `Dict[str, np.ndarray]`: dictionary that contains name as key, value as `np.ndarray`
@@ -128,7 +132,7 @@ def load_file(filename: Union[str, os.PathLike]) -> Dict[str, np.ndarray]:
     ```
     """
     result = {}
-    with safe_open(filename, framework="np") as f:
+    with safe_open(filename, framework="np", device=device) as f:
         for k in f.keys():
             result[k] = f.get_tensor(k)
     return result

--- a/bindings/python/py_src/safetensors/paddle.py
+++ b/bindings/python/py_src/safetensors/paddle.py
@@ -71,13 +71,21 @@ def save_file(
     return numpy.save_file(np_tensors, filename, metadata=metadata)
 
 
-def load(data: bytes, device: str = "cpu") -> Dict[str, paddle.Tensor]:
+def load(data: bytes, device: str = None) -> Dict[str, paddle.Tensor]:
     """
     Loads a safetensors file into paddle format from pure bytes.
 
     Args:
         data (`bytes`):
             The content of a safetensors file
+        device (`Dict[str, any]`, *optional*, defaults to `cpu`):
+            The device where the tensors need to be located after load.
+            available options are all regular paddle device locations
+
+            Note: In future versions, the default will be removed. The device
+            is required to be set to the real final device to get the best
+            load performance. Default will be removed in version >= 0.5.
+
 
     Returns:
         `Dict[str, paddle.Tensor]`: dictionary that contains name as key, value as `paddle.Tensor` on cpu
@@ -98,7 +106,7 @@ def load(data: bytes, device: str = "cpu") -> Dict[str, paddle.Tensor]:
     return _np2paddle(flat, device)
 
 
-def load_file(filename: Union[str, os.PathLike], device="cpu") -> Dict[str, paddle.Tensor]:
+def load_file(filename: Union[str, os.PathLike], device: str = None) -> Dict[str, paddle.Tensor]:
     """
     Loads a safetensors file into paddle format.
 
@@ -108,6 +116,10 @@ def load_file(filename: Union[str, os.PathLike], device="cpu") -> Dict[str, padd
         device (`Dict[str, any]`, *optional*, defaults to `cpu`):
             The device where the tensors need to be located after load.
             available options are all regular paddle device locations
+
+            Note: In future versions, the default will be removed. The device
+            is required to be set to the real final device to get the best
+            load performance. Default will be removed in version >= 0.5.
 
     Returns:
         `Dict[str, paddle.Tensor]`: dictionary that contains name as key, value as `paddle.Tensor`
@@ -121,7 +133,7 @@ def load_file(filename: Union[str, os.PathLike], device="cpu") -> Dict[str, padd
     loaded = load_file(file_path)
     ```
     """
-    flat = numpy.load_file(filename)
+    flat = numpy.load_file(filename, device=device)
     output = _np2paddle(flat, device)
     return output
 

--- a/bindings/python/py_src/safetensors/tensorflow.py
+++ b/bindings/python/py_src/safetensors/tensorflow.py
@@ -98,7 +98,7 @@ def load(data: bytes) -> Dict[str, tf.Tensor]:
     return _np2tf(flat)
 
 
-def load_file(filename: Union[str, os.PathLike]) -> Dict[str, tf.Tensor]:
+def load_file(filename: Union[str, os.PathLike], device: str = None) -> Dict[str, tf.Tensor]:
     """
     Loads a safetensors file into tensorflow format.
 
@@ -108,6 +108,10 @@ def load_file(filename: Union[str, os.PathLike]) -> Dict[str, tf.Tensor]:
         device (`Dict[str, any]`, *optional*, defaults to `cpu`):
             The device where the tensors need to be located after load.
             available options are all regular tensorflow device locations
+
+            Note: In future versions, the default will be removed. The device
+            is required to be set to the real final device to get the best
+            load performance. Default will be removed in version >= 0.5.
 
     Returns:
         `Dict[str, tf.Tensor]`: dictionary that contains name as key, value as `tf.Tensor`
@@ -121,7 +125,7 @@ def load_file(filename: Union[str, os.PathLike]) -> Dict[str, tf.Tensor]:
     loaded = load_file(file_path)
     ```
     """
-    flat = numpy.load_file(filename)
+    flat = numpy.load_file(filename, device=device)
     return _np2tf(flat)
 
 

--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -72,7 +72,7 @@ def save_file(
     serialize_file(_flatten(tensors), filename, metadata=metadata)
 
 
-def load_file(filename: Union[str, os.PathLike], device="cpu") -> Dict[str, torch.Tensor]:
+def load_file(filename: Union[str, os.PathLike], device: str = None) -> Dict[str, torch.Tensor]:
     """
     Loads a safetensors file into torch format.
 
@@ -82,6 +82,10 @@ def load_file(filename: Union[str, os.PathLike], device="cpu") -> Dict[str, torc
         device (`Dict[str, any]`, *optional*, defaults to `cpu`):
             The device where the tensors need to be located after load.
             available options are all regular torch device locations
+
+            Note: In future versions, the default will be removed. The device
+            is required to be set to the real final device to get the best
+            load performance. Default will be removed in version >= 0.5.
 
     Returns:
         `Dict[str, torch.Tensor]`: dictionary that contains name as key, value as `torch.Tensor`

--- a/bindings/python/tests/test_flax_comparison.py
+++ b/bindings/python/tests/test_flax_comparison.py
@@ -32,7 +32,7 @@ class LoadTestCase(unittest.TestCase):
         save_file(data, self.sf_filename)
 
     def test_deserialization_safe(self):
-        weights = load_file(self.sf_filename)
+        weights = load_file(self.sf_filename, device="cpu")
 
         with open(self.flax_filename, "rb") as f:
             data = f.read()
@@ -44,7 +44,7 @@ class LoadTestCase(unittest.TestCase):
 
     def test_deserialization_safe_open(self):
         weights = {}
-        with safe_open(self.sf_filename, framework="flax") as f:
+        with safe_open(self.sf_filename, framework="flax", device="cpu") as f:
             for k in f.keys():
                 weights[k] = f.get_tensor(k)
 

--- a/bindings/python/tests/test_paddle_comparison.py
+++ b/bindings/python/tests/test_paddle_comparison.py
@@ -20,7 +20,7 @@ class SafeTestCase(unittest.TestCase):
         save_file(data, self.sf_filename)
 
     def test_deserialization_safe(self):
-        weights = load_file(self.sf_filename)
+        weights = load_file(self.sf_filename, device="cpu")
 
         paddle_weights = paddle.load(self.paddle_filename)
         for k, v in weights.items():

--- a/bindings/python/tests/test_pt_comparison.py
+++ b/bindings/python/tests/test_pt_comparison.py
@@ -15,7 +15,7 @@ class TorchTestCase(unittest.TestCase):
         }
         local = "./tests/data/out_safe_pt_mmap_small.safetensors"
         save_file(data, local)
-        reloaded = load_file(local)
+        reloaded = load_file(local, device="cpu")
         self.assertTrue(torch.equal(data["test"], reloaded["test"]))
         self.assertTrue(torch.equal(data["test2"], reloaded["test2"]))
         self.assertTrue(torch.equal(data["test3"], reloaded["test3"]))
@@ -40,7 +40,7 @@ class TorchTestCase(unittest.TestCase):
         }
         local = "./tests/data/out_safe_pt_mmap_small.safetensors"
         save_file(data, local)
-        reloaded = load_file(local)
+        reloaded = load_file(local, device="cpu")
         self.assertTrue(torch.equal(torch.arange(4).view((2, 2)), reloaded["test"]))
 
     def test_sparse(self):
@@ -90,7 +90,7 @@ class LoadTestCase(unittest.TestCase):
 
     def test_deserialization_safe(self):
         tweights = torch.load(self.pt_filename)
-        weights = load_file(self.sf_filename)
+        weights = load_file(self.sf_filename, device="cpu")
 
         for k, v in weights.items():
             tv = tweights[k]
@@ -153,7 +153,7 @@ class SliceTestCase(unittest.TestCase):
             save_file(data, "./tests/data/out.safetensors")
 
     def test_deserialization_slice(self):
-        with safe_open(self.local, framework="pt") as f:
+        with safe_open(self.local, framework="pt", device="cpu") as f:
             tensor = f.get_slice("test")[:, :, 1:2]
 
         self.assertEqual(
@@ -165,7 +165,7 @@ class SliceTestCase(unittest.TestCase):
         self.assertTrue(torch.equal(tensor, self.tensor[:, :, 1:2]))
 
     def test_deserialization_metadata(self):
-        with safe_open(self.local, framework="pt") as f:
+        with safe_open(self.local, framework="pt", device="cpu") as f:
             metadata = f.metadata()
         self.assertEqual(metadata, None)
 
@@ -175,6 +175,6 @@ class SliceTestCase(unittest.TestCase):
         local = "./tests/data/out_safe_pt_mmap2.safetensors"
         # Need to copy since that call mutates the tensors to numpy
         save_file(data, local, metadata={"Something": "more"})
-        with safe_open(local, framework="pt") as f:
+        with safe_open(local, framework="pt", device="cpu") as f:
             metadata = f.metadata()
         self.assertEqual(metadata, {"Something": "more"})

--- a/bindings/python/tests/test_tf_comparison.py
+++ b/bindings/python/tests/test_tf_comparison.py
@@ -42,7 +42,7 @@ class SafeTestCase(unittest.TestCase):
         save_file(data, self.sf_filename)
 
     def test_deserialization_safe(self):
-        weights = load_file(self.sf_filename)
+        weights = load_file(self.sf_filename, device="cpu")
 
         with h5py.File(self.tf_filename, "r") as f:
             tf_weights = _load(f)
@@ -53,7 +53,7 @@ class SafeTestCase(unittest.TestCase):
 
     def test_deserialization_safe_open(self):
         weights = {}
-        with safe_open(self.sf_filename, framework="tf") as f:
+        with safe_open(self.sf_filename, framework="tf", device="cpu") as f:
             for k in f.keys():
                 weights[k] = f.get_tensor(k)
 


### PR DESCRIPTION
This is now only a deprecation notice.

The reason for this:
- Moving to `0.3` for the alignment modification allowing for more
  change.
- Not specifying the default has been a real performance hurt:
  https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/5893
  https://github.com/huggingface/diffusers/blob/e5810e686ea4ac499e325c2961808c8972dee039/src/diffusers/models/modeling_utils.py#L103

  This should only affect from disk -> CPU/GPU since this is where the
  location is modified. When loading from bytes, the location is already
  CPU so it's natural to use CPU (no alloc).

- Giving 2 "minor" versions before dropping support, this should allow
  users to have time to move.