### PR TITLE
Forcing byte order in numpy at load time (Fixes loading a safetensor from a big endian machine).

### DIFF
--- a/bindings/python/py_src/safetensors/numpy.py
+++ b/bindings/python/py_src/safetensors/numpy.py
@@ -158,6 +158,7 @@ def _view2np(safeview) -> Dict[str, np.ndarray]:
     result = {}
     for k, v in safeview:
         dtype = _getdtype(v["dtype"])
+        dtype = dtype.newbyteorder("<")
         arr = np.frombuffer(v["data"], dtype=dtype).reshape(v["shape"])
         result[k] = arr
     return result

--- a/bindings/python/py_src/safetensors/numpy.py
+++ b/bindings/python/py_src/safetensors/numpy.py
@@ -158,7 +158,7 @@ def _view2np(safeview) -> Dict[str, np.ndarray]:
     result = {}
     for k, v in safeview:
         dtype = _getdtype(v["dtype"])
-        dtype = dtype.newbyteorder("<")
+        dtype = np.dtype(dtype).newbyteorder("<")
         arr = np.frombuffer(v["data"], dtype=dtype).reshape(v["shape"])
         result[k] = arr
     return result

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -809,7 +809,15 @@ fn create_tensor(
         .ok_or_else(|| SafetensorError::new_err(format!("Could not find module {framework:?}",)))?
         .as_ref(py);
         let frombuffer = module.getattr(intern!(py, "frombuffer"))?;
-        let dtype: PyObject = get_pydtype(module, dtype)?;
+        let mut dtype: PyObject = get_pydtype(module, dtype)?;
+        if framework != &Framework::Pytorch {
+            dtype = module
+                .getattr(intern!(py, "dtype"))?
+                .call1((dtype,))?
+                .getattr(intern!(py, "newbyteorder"))?
+                .call1(("<",))?
+                .into();
+        }
         let kwargs = [
             (intern!(py, "buffer"), array),
             (intern!(py, "dtype"), dtype),


### PR DESCRIPTION
Fixes #190 I guess.

Would be nice to know what happens with Pytorch and endianess too to find a similar fix.

Seems the buffer is not modified so speed shouldn't suffer.
https://numpy.org/doc/stable/reference/generated/numpy.ndarray.newbyteorder.html

Also:
https://lkml.org/lkml/2015/4/24/606

Not sure how many machines are really running big endian, or how to get access or emulate to test all this.