### PR TITLE
Python 2.0 added a warning on ByteStorage, so using UntypedStorage

### DIFF
--- a/bindings/python/py_src/safetensors/__init__.py
+++ b/bindings/python/py_src/safetensors/__init__.py
@@ -1,36 +1,4 @@
 __version__ = "0.3.0"
-import json
-from typing import Dict
 
 # Re-export this
 from ._safetensors_rust import SafetensorError, deserialize, safe_open, serialize, serialize_file  # noqa: F401
-
-
-def metadata(data: bytes) -> Dict[str, str]:
-    """
-    Loads the metadata of a safetensors byte representation
-
-    Args:
-        data (`bytes`):
-            The content of a safetensors file
-
-    Returns:
-        `Dict[str, str]`: dictionary of the metadata in the file
-
-    Example:
-
-    ```python
-    import safetensors
-
-    file_path = "./my_folder/bert.safetensors"
-    with open(file_path, "rb") as f:
-        data = f.read()
-
-    metadata = safetensors.metadata(data)
-    ```
-    """
-    n_header = data[:8]
-    n = int.from_bytes(n_header, "little")
-    metadata_bytes = data[8 : 8 + n]
-    header = json.loads(metadata_bytes)
-    return header.get("__metadata__", {})

--- a/bindings/python/py_src/safetensors/__init__.py
+++ b/bindings/python/py_src/safetensors/__init__.py
@@ -1,4 +1,36 @@
 __version__ = "0.3.0"
+import json
+from typing import Dict
 
 # Re-export this
 from ._safetensors_rust import SafetensorError, deserialize, safe_open, serialize, serialize_file  # noqa: F401
+
+
+def metadata(data: bytes) -> Dict[str, str]:
+    """
+    Loads the metadata of a safetensors byte representation
+
+    Args:
+        data (`bytes`):
+            The content of a safetensors file
+
+    Returns:
+        `Dict[str, str]`: dictionary of the metadata in the file
+
+    Example:
+
+    ```python
+    import safetensors
+
+    file_path = "./my_folder/bert.safetensors"
+    with open(file_path, "rb") as f:
+        data = f.read()
+
+    metadata = safetensors.metadata(data)
+    ```
+    """
+    n_header = data[:8]
+    n = int.from_bytes(n_header, "little")
+    metadata_bytes = data[8 : 8 + n]
+    header = json.loads(metadata_bytes)
+    return header.get("__metadata__", {})

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -371,10 +371,15 @@ impl Open {
                     let py_filename: PyObject = filename.into_py(py);
                     let size: PyObject = buffer.len().into_py(py);
                     let shared: PyObject = false.into_py(py);
-                    let kwargs = [(intern!(py, "shared"), shared), (intern!(py, "size"), size)]
-                        .into_py_dict(py);
+                    let (size_name, storage_name) = if version >= Version::new(2, 0, 0) {
+                        (intern!(py, "nbytes"), intern!(py, "UntypedStorage"))
+                    } else {
+                        (intern!(py, "size"), intern!(py, "ByteStorage"))
+                    };
+                    let kwargs =
+                        [(intern!(py, "shared"), shared), (size_name, size)].into_py_dict(py);
                     let storage = module
-                        .getattr(intern!(py, "ByteStorage"))?
+                        .getattr(storage_name)?
                         .getattr(intern!(py, "from_file"))?
                         .call((py_filename,), Some(kwargs))?;
 


### PR DESCRIPTION
directly for that version.

Small error in their docs, `size` got renamed `nbytes`.