### PR TITLE
Disallowing zero-width tensor.

### DIFF
--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -911,7 +911,7 @@ mod tests {
 
     #[test]
     fn test_zero_sized_tensor() {
-        let serialized = b"<\x00\x00\x00\x00\x00\x00\x00{\"test\":{\"dtype\":\"I32\",\"shape\":[2,2],\"data_offsets\":[0, 0]}}\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+        let serialized = b"<\x00\x00\x00\x00\x00\x00\x00{\"test\":{\"dtype\":\"I32\",\"shape\":[2,0],\"data_offsets\":[0, 0]}}\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
 
         match SafeTensors::deserialize(serialized) {
             Err(SafeTensorError::InvalidOffset(_)) => {

--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -458,7 +458,7 @@ impl Metadata {
         let mut start = 0;
         for (i, info) in self.tensors.iter().enumerate() {
             let (s, e) = info.data_offsets;
-            if s != start || e < s {
+            if s != start || e <= s {
                 let tensor_name = self
                     .index_map
                     .iter()
@@ -903,6 +903,18 @@ mod tests {
         let serialized = b"\x01\x00\x00\x00\x00\x00\x00\x00{";
         match SafeTensors::deserialize(serialized) {
             Err(SafeTensorError::InvalidHeaderDeserialization) => {
+                // Yes we have the correct error
+            }
+            _ => panic!("This should not be able to be deserialized"),
+        }
+    }
+
+    #[test]
+    fn test_zero_sized_tensor() {
+        let serialized = b"<\x00\x00\x00\x00\x00\x00\x00{\"test\":{\"dtype\":\"I32\",\"shape\":[2,2],\"data_offsets\":[0, 0]}}\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+
+        match SafeTensors::deserialize(serialized) {
+            Err(SafeTensorError::InvalidOffset(_)) => {
                 // Yes we have the correct error
             }
             _ => panic!("This should not be able to be deserialized"),


### PR DESCRIPTION
This is disabling tensors of shape `[2, 0]` which **are** valid in Pytorch and Numpy but seem pretty useless on disk (since it doesn't store any data).

It seems that such tensors are only used at runtime, either to represent empty slices, or growing tensor, but are not ever useful in actual model weights (to the best of my knowledge)