### PR TITLE
Zero width shape are OK (0-rank tensors). They are simply a scalar.

### DIFF
--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -785,7 +785,7 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_shapes_not_allowed() {
+    fn test_empty_shapes_allowed() {
         let serialized = b"8\x00\x00\x00\x00\x00\x00\x00{\"test\":{\"dtype\":\"I32\",\"shape\":[],\"data_offsets\":[0,4]}}\x00\x00\x00\x00\x00\x00\x00\x00";
 
         let loaded = SafeTensors::deserialize(serialized).unwrap();

--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -785,6 +785,19 @@ mod tests {
     }
 
     #[test]
+    fn test_empty_shapes_not_allowed() {
+        let serialized = b"8\x00\x00\x00\x00\x00\x00\x00{\"test\":{\"dtype\":\"I32\",\"shape\":[],\"data_offsets\":[0,4]}}\x00\x00\x00\x00\x00\x00\x00\x00";
+
+        let loaded = SafeTensors::deserialize(serialized).unwrap();
+        assert_eq!(loaded.names(), vec!["test"]);
+        let tensor = loaded.tensor("test").unwrap();
+        assert!(tensor.shape().is_empty());
+        assert_eq!(tensor.dtype(), Dtype::I32);
+        // 4 bytes
+        assert_eq!(tensor.data(), b"\0\0\0\0");
+    }
+
+    #[test]
     fn test_deserialization() {
         let serialized = b"<\x00\x00\x00\x00\x00\x00\x00{\"test\":{\"dtype\":\"I32\",\"shape\":[2,2],\"data_offsets\":[0,16]}}\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
 


### PR DESCRIPTION
Reasosn for support is that both torch and numpy support them, and
they flow naturally from the definition that an empty product has
length 1.