### PR TITLE
Fixing alignment

### DIFF
--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -192,11 +192,9 @@ fn prepare<S: AsRef<str> + Ord + std::fmt::Display, V: View, I: IntoIterator<Ite
 
     let metadata: Metadata = Metadata::new(data_info.clone(), hmetadata)?;
     let mut metadata_buf = serde_json::to_string(&metadata)?.into_bytes();
-    // Force alignment
-    let extra = metadata_buf.len() % 8;
-    if extra != 0 {
-        metadata_buf.extend(vec![b' '; 8 - extra]);
-    }
+    // Force alignment to 8 bytes.
+    let extra = (8 - metadata_buf.len() % 8) % 8;
+    metadata_buf.extend(vec![b' '; extra]);
 
     let n: u64 = metadata_buf.len() as u64;
 

--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -194,7 +194,9 @@ fn prepare<S: AsRef<str> + Ord + std::fmt::Display, V: View, I: IntoIterator<Ite
     let mut metadata_buf = serde_json::to_string(&metadata)?.into_bytes();
     // Force alignment
     let extra = metadata_buf.len() % 8;
-    metadata_buf.extend(vec![b' '; extra]);
+    if extra != 0 {
+        metadata_buf.extend(vec![b' '; 8 - extra]);
+    }
 
     let n: u64 = metadata_buf.len() as u64;
 


### PR DESCRIPTION
Alignment was broken.

Simple logic failure (with pretty bad consequences):

- We're calculating how "unaligned" the header is. But we were adding the wrong padding to fix the alignment.
- Adding some test in the proptest to make sure it's aligned after reload
- Update the other tests


Fix #231
