### PR TITLE
Adding `save_model` and `load_model` to help with shared tensors with PyTorch.

### DIFF
--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -58,10 +58,15 @@ def load_model(model: torch.nn.Module, filename: str, metadata: Optional[Dict[st
     for to_remove in to_removes:
         missing.remove(to_remove)
     if missing or unexpected:
+        missing_keys = ", ".join([f'"{k}"' for k in missing])
+        unexpected_keys = ", ".join([f'"{k}"' for k in unexpected])
         raise RuntimeError(
-            f"Error(s) in loading state_dict for {model.__class__}:",
-            f'    Missing key(s) in state_dict: {", ".join(missing)}' if missing else "",
-            f'    Unexpected key(s) in state_dict: {", ".join(unexpected)}' if unexpected else "",
+            f"Error(s) in loading state_dict for {model.__class__.__name__}:"
+            f"\n    Missing key(s) in state_dict: {missing_keys}"
+            if missing
+            else "" f"\n    Unexpected key(s) in state_dict: {unexpected_keys}"
+            if unexpected
+            else ""
         )
 
 

--- a/bindings/python/tests/test_pt_model.py
+++ b/bindings/python/tests/test_pt_model.py
@@ -1,0 +1,124 @@
+import copy
+import unittest
+
+import torch
+
+from safetensors.torch import (
+    _find_shared_tensors,
+    _is_complete,
+    _remove_duplicate_names,
+    load_model,
+    save_file,
+    save_model,
+)
+
+
+class Model(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.a = torch.nn.Linear(100, 100)
+        self.b = self.a
+
+
+class CopyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.a = torch.nn.Linear(100, 100)
+        self.b = copy.deepcopy(self.a)
+
+
+class NoSharedModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.a = torch.nn.Linear(100, 100)
+        self.b = torch.nn.Linear(100, 100)
+
+
+class TorchModelTestCase(unittest.TestCase):
+    def test_is_complete(self):
+        A = torch.zeros((3, 3))
+        self.assertTrue(_is_complete(A))
+
+        B = A[:1, :]
+        self.assertFalse(_is_complete(B))
+
+        # Covers the whole storage but with holes
+        C = A[::2, :]
+        self.assertFalse(_is_complete(C))
+
+        D = torch.zeros((2, 2), device=torch.device("meta"))
+        self.assertTrue(_is_complete(D))
+
+    def test_find_shared_tensors(self):
+        A = torch.zeros((3, 3))
+        B = A[:1, :]
+
+        self.assertEqual(_find_shared_tensors({"A": A, "B": B}), [{"A", "B"}])
+        self.assertEqual(_find_shared_tensors({"A": A}), [{"A"}])
+        self.assertEqual(_find_shared_tensors({"B": B}), [{"B"}])
+
+        C = torch.zeros((2, 2), device=torch.device("meta"))
+        D = C[:1]
+        # Meta device is not shared
+        self.assertEqual(_find_shared_tensors({"C": C, "D": D}), [])
+        self.assertEqual(_find_shared_tensors({"C": C}), [])
+        self.assertEqual(_find_shared_tensors({"D": D}), [])
+
+    def test_remove_duplicate_names(self):
+        A = torch.zeros((3, 3))
+        B = A[:1, :]
+
+        self.assertEqual(_remove_duplicate_names({"A": A, "B": B}), ["B"])
+        self.assertEqual(_remove_duplicate_names({"A": A, "B": B, "C": A}), ["B", "C"])
+        with self.assertRaises(RuntimeError):
+            self.assertEqual(_remove_duplicate_names({"B": B}), [])
+
+    def test_failure(self):
+        model = Model()
+        with self.assertRaises(RuntimeError):
+            save_file(model.state_dict(), "tmp.safetensors")
+
+    def test_workaround(self):
+        model = Model()
+        save_model(model, "tmp.safetensors")
+
+        model2 = Model()
+        load_model(model2, "tmp.safetensors")
+
+        state_dict = model.state_dict()
+        for k, v in model2.state_dict().items():
+            torch.testing.assert_close(v, state_dict[k])
+
+    def test_workaround_copy(self):
+        model = CopyModel()
+        save_model(model, "tmp.safetensors")
+
+        model2 = CopyModel()
+        load_model(model2, "tmp.safetensors")
+
+        state_dict = model.state_dict()
+        for k, v in model2.state_dict().items():
+            torch.testing.assert_close(v, state_dict[k])
+
+    def test_difference_with_torch(self):
+        model = Model()
+        torch.save(model.state_dict(), "tmp2.bin")
+
+        model2 = NoSharedModel()
+        # This passes on torch.
+        # The tensors are shared on disk, they are *not* shared within the model
+        # The model happily loads the tensors, and ends up *not* sharing the tensors by.
+        # doing copies
+        self.assertEqual(
+            _find_shared_tensors(model2.state_dict()), [{"a.weight"}, {"a.bias"}, {"b.weight"}, {"b.bias"}]
+        )
+        model2.load_state_dict(torch.load("tmp2.bin"))
+        self.assertEqual(
+            _find_shared_tensors(model2.state_dict()), [{"a.weight"}, {"a.bias"}, {"b.weight"}, {"b.bias"}]
+        )
+
+        # However safetensors cannot save those, so we cannot
+        # reload the saved file with the different model
+        save_model(model, "tmp2.safetensors")
+        with self.assertRaises(RuntimeError):
+            load_model(model2, "tmp2.safetensors")

--- a/bindings/python/tests/test_pt_model.py
+++ b/bindings/python/tests/test_pt_model.py
@@ -3,6 +3,7 @@ import unittest
 
 import torch
 
+from safetensors import safe_open
 from safetensors.torch import (
     _find_shared_tensors,
     _is_complete,
@@ -68,8 +69,8 @@ class TorchModelTestCase(unittest.TestCase):
         A = torch.zeros((3, 3))
         B = A[:1, :]
 
-        self.assertEqual(_remove_duplicate_names({"A": A, "B": B}), ["B"])
-        self.assertEqual(_remove_duplicate_names({"A": A, "B": B, "C": A}), ["B", "C"])
+        self.assertEqual(_remove_duplicate_names({"A": A, "B": B}), {"A": ["B"]})
+        self.assertEqual(_remove_duplicate_names({"A": A, "B": B, "C": A}), {"A": ["B", "C"]})
         with self.assertRaises(RuntimeError):
             self.assertEqual(_remove_duplicate_names({"B": B}), [])
 
@@ -81,9 +82,12 @@ class TorchModelTestCase(unittest.TestCase):
     def test_workaround(self):
         model = Model()
         save_model(model, "tmp.safetensors")
+        with safe_open("tmp.safetensors", framework="pt") as f:
+            self.assertEqual(f.metadata(), {"b.bias": "a.bias", "b.weight": "a.weight"})
 
         model2 = Model()
         load_model(model2, "tmp.safetensors")
+        (model2, "tmp.safetensors")
 
         state_dict = model.state_dict()
         for k, v in model2.state_dict().items():
@@ -91,6 +95,9 @@ class TorchModelTestCase(unittest.TestCase):
 
     def test_workaround_copy(self):
         model = CopyModel()
+        self.assertEqual(
+            _find_shared_tensors(model.state_dict()), [{"a.weight"}, {"a.bias"}, {"b.weight"}, {"b.bias"}]
+        )
         save_model(model, "tmp.safetensors")
 
         model2 = CopyModel()
@@ -120,5 +127,32 @@ class TorchModelTestCase(unittest.TestCase):
         # However safetensors cannot save those, so we cannot
         # reload the saved file with the different model
         save_model(model, "tmp2.safetensors")
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(RuntimeError) as ctx:
             load_model(model2, "tmp2.safetensors")
+        self.assertIn("""Missing key(s) in state_dict: "b.bias", "b.weight""", str(ctx.exception))
+
+    def test_difference_torch_odd(self):
+        model = NoSharedModel()
+        a = model.a.weight
+        b = model.b.weight
+        self.assertNotEqual(a.data_ptr(), b.data_ptr())
+        torch.save(model.state_dict(), "tmp3.bin")
+
+        model2 = Model()
+        self.assertEqual(_find_shared_tensors(model2.state_dict()), [{"a.weight", "b.weight"}, {"b.bias", "a.bias"}])
+        # Torch will affect either `b` or `a` to the shared tensor in the `model2`
+        model2.load_state_dict(torch.load("tmp3.bin"))
+
+        # XXX: model2 uses only the B weight not the A weight anymore.
+        self.assertFalse(torch.allclose(model2.a.weight, model.a.weight))
+        torch.testing.assert_close(model2.a.weight, model.b.weight)
+        self.assertEqual(_find_shared_tensors(model2.state_dict()), [{"a.weight", "b.weight"}, {"b.bias", "a.bias"}])
+
+        # Everything is saved as-is
+        save_model(model, "tmp3.safetensors")
+        # safetensors will yell that there were 2 tensors on disk, while
+        # the models expects only 1 tensor since both are shared.
+        with self.assertRaises(RuntimeError) as ctx:
+            load_model(model2, "tmp3.safetensors")
+        # Safetensors properly warns the user that some ke
+        self.assertIn("""Unexpected key(s) in state_dict: "b.bias", "b.weight""", str(ctx.exception))

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -3,6 +3,8 @@
     title: 🤗 Safetensors
   - local: speed
     title: Speed Comparison
+  - local: torch_shared_tensors
+    title: Tensor Sharing in Pytorch
   title: Getting started
 - sections: 
   - local: api/torch

--- a/docs/source/torch_shared_tensors.mdx
+++ b/docs/source/torch_shared_tensors.mdx
@@ -1,0 +1,107 @@
+# Torch shared tensors
+
+
+## TL;DR
+
+Using specific functions, which should work in most cases for you.
+This is not without side effects.
+
+```python
+from safetensors.torch load_model, save_model
+
+save_model(model, "model.safetensors")
+# Instead of save_file(model.state_dict(), "model.safetensors")
+
+load_model(model, "model.safetensors")
+# Instead of model.load_state_dict(load_file("model.safetensors"))
+```
+
+## What are shared tensors ?
+
+Pytorch uses shared tensors for some computation.
+This is extremely interesting to reduce memory usage in general.
+
+One very classic use case is in transformers the `embeddings` are shared with
+`lm_head`. By using the same matrix, the model uses less parameters, and gradients 
+flow much better to the `embeddings` (which is the start of the model, so they don't
+flow easily there, whereas `lm_head` is at the tail of the model, so gradients are
+extremely good over there, since they are the same tensors, they both benefit)
+
+
+```python
+from torch import nn
+
+class Model(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.a = nn.Linear(100, 100)
+        self.b = self.a
+
+    def forward(self, x):
+        return self.b(self.a(x))
+
+
+model = Model()
+print(model.state_dict())
+# odict_keys(['a.weight', 'a.bias', 'b.weight', 'b.bias'])
+torch.save(model.state_dict(), "model.bin")
+# This file is now 41k instead of ~80k, because A and B are the same weight hence only 1 is saved on disk with both `a` and `b` pointing to the same buffer
+```
+
+## Why are shared tensors not saved in `safetensors` ?
+
+Multiple reasons for that:
+
+- *Not all frameworks support them* for instance `tensorflow` does not.
+  So if someone saves shared tensors in torch, there is no way to 
+  load them in a similar fashion so we could not keep the same `Dict[str, Tensor]`
+  API.
+- *It makes lazy loading very quircky.*
+  Lazy loading is the ability to load only some tensors, or part of tensors for
+  a given file. This is trivial to do without sharing tensors but with tensor sharing
+
+  ```python
+  with safe_open("model.safetensors", framework="pt") as f:
+      a = f.get_tensor("a")
+      b = f.get_tensor("b")
+  ```
+
+  Now it's impossible with this given code to "reshare" buffers after the fact.
+  Once we give the `a` tensor we have no way to give back the same memory when
+  you ask for `b`. (In this particular example we could keep track of given buffers
+  but this is not the case in general, since you could do arbitrary work with `a`
+  like sending it to another device before asking for `b`)
+- *It can lead to much larger file than necessary*.
+  If you are saving a shared tensor which is only a fraction of a larger tensor,
+  then saving it with pytorch leads to saving the entire buffer instead of saving
+  just what is needed.
+
+  ```python
+  a = torch.zeros((100, 100))
+  b = a[:1, :]
+  torch.save({"b": b}, "model.bin")
+  # File is 41k instead of the epected 400 bytes
+  # In practice it could happen that you save several 10GB instead of 1GB.
+  ```
+
+Now with all those reasons being mentionned, nothing is set in stone in there.
+Shared tensors do not cause unsafety, or denial of service potential, so this
+decision could be revisited if current workarounds are not satisfactory.
+
+## How does it work ?
+
+The design is rather simple.
+We're going to look for all shared tensors, then looking for all tensors
+covering the entire buffer (there can be multiple such tensors).
+That gives us multiple names which can be saved, we simply choose the first one
+
+During `load_model`, we are loading a bit like `load_state_dict` does, except
+we're looking into the model itself, to check for shared buffers, and ignoring
+the "missed keys" which were actually covered by virtue of buffer sharing (they
+were properly loaded since there was a buffer that loaded under the hood).
+Every other error is raised as-is
+
+**Caveat**: This means we're dropping some keys within the file. meaning if you're
+checking for the keys saved on disk, you will see some "missing tensors" or if you're
+using `load_state_dict`. Unless we start supporting shared tensors directly in
+the format there's no real way around it.


### PR DESCRIPTION
This PR adds new surface which is PyTorch specific.
The idea is that allowing shared tensors on files opens a lot of issues, 
but at the same time, they are indeed quite used within torch ecosystem and
not trivial to workaround when not familiar with torch internals (or understand
the implications).

This PR adds 2 new functions:

`load_model` and `save_model` which should really be as convenient to use
as `torch.save(model.state_dict(), filename)` and `model.load_state_dict(torch.load(filename))`.

It also adds some documentation explaining the situation and various choices.

Some caveats:

- The functions will fail if user is attempting to save buffer which are unrecoverable,
  meaning trying to save a slice of a large shared tensor, where no reference points to 
  the entire tensor.
- If you load shared tensors on **not** shared model, torch will copy the weights
  to satisfy the non shared property. We will drop the shared weights on save
  meaning the missing weights will yell on load (you absolutely need to save
  tensor copies on disk if you want to do the same)
- If you load **not** shared tensors on shared model, PyTorch will arbitrarily
  choose one version to put on your model without alarming you that some weights
  were obfuscated. These function will explain that some keys were not expected
  on the file.