### PR TITLE
[doc] Improve metadata parsing doc 

### DIFF
--- a/docs/source/metadata_parsing.mdx
+++ b/docs/source/metadata_parsing.mdx
@@ -18,7 +18,11 @@ There can be many potential use cases. For instance, we use it on the HuggingFac
     <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/safetensors/view-all-tensors-dark.png"/>
 </div>
 
-## Usage from JS
+## Usage
+
+### JavaScript/TypeScript[[js]]
+
+Using [`huggingface.js`](https://huggingface.co/docs/huggingface.js)
 
 ```ts
 import { parseSafetensorsMetadata } from "@huggingface/hub";
@@ -27,6 +31,22 @@ const info = await parseSafetensorsMetadata({
 	repo: { type: "model", name: "bigscience/bloom" },
 });
 
+console.log(info)
+// {
+//   sharded: true,
+//   index: {
+//     metadata: { total_size: 352494542848 },
+//     weight_map: {
+//       'h.0.input_layernorm.bias': 'model_00002-of-00072.safetensors',
+//       ...
+//     }
+//   },
+//   headers: {
+//     __metadata__: {'format': 'pt'},
+//     'h.2.attn.c_attn.weight': {'dtype': 'F32', 'shape': [768, 2304], 'data_offsets': [541012992, 548090880]},
+//     ...
+//   }
+// }
 ```
 
 Depending on whether the safetensors weights are sharded into multiple files or not, the output of the call above will be:
@@ -44,7 +64,7 @@ export type SafetensorsParseFromRepo =
 	};
 ```
 
-where the underlying types are the following:
+where the underlying `types` are the following:
 
 ```ts
 type FileName = string;
@@ -70,6 +90,41 @@ export type SafetensorsShardedHeaders = Record<FileName, SafetensorsFileHeader>;
 
 ```
 
+### Python
+
+In this example python script, we are parsing metadata of [gpt2](https://huggingface.co/gpt2/blob/main/model.safetensors).
+
+```python
+import requests # pip install requests
+import struct
+
+def parse_single_file(url):
+    # Fetch the first 8 bytes of the file
+    headers = {'Range': 'bytes=0-7'}
+    response = requests.get(url, headers=headers)
+    # Interpret the bytes as a little-endian unsigned 64-bit integer
+    length_of_header = struct.unpack('<Q', response.content)[0]
+    # Fetch length_of_header bytes starting from the 9th byte
+    headers = {'Range': f'bytes=8-{7 + length_of_header}'}
+    response = requests.get(url, headers=headers)
+    # Interpret the response as a JSON object
+    header = response.json()
+    return header
+
+url = "https://huggingface.co/gpt2/resolve/main/model.safetensors"
+header = parse_single_file(url)
+
+print(header)
+# {
+#   "__metadata__": { "format": "pt" },
+#   "h.10.ln_1.weight": {
+#     "dtype": "F32",
+#     "shape": [768],
+#     "data_offsets": [223154176, 223157248]
+#   },
+#   ...
+# }
+```
 
 ## Example output
 

--- a/docs/source/metadata_parsing.mdx
+++ b/docs/source/metadata_parsing.mdx
@@ -9,13 +9,13 @@ This parsing has been implemented in JS in [`huggingface.js`](https://huggingfac
 There can be many potential use cases. For instance, we use it on the HuggingFace Hub to display info about models which have safetensors weights:
 
 <div class="flex justify-center">
-    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/safetensors/model-page.png"/>
-    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/safetensors/model-page.png"/>
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/safetensors/model-page-light.png"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/safetensors/model-page-dark.png"/>
 </div>
 
 <div class="flex justify-center">
-    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/safetensors/view-all-tensors.png"/>
-    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/safetensors/view-all-tensors.png"/>
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/safetensors/view-all-tensors-light.png"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/safetensors/view-all-tensors-dark.png"/>
 </div>
 
 ## Usage from JS

--- a/docs/source/metadata_parsing.mdx
+++ b/docs/source/metadata_parsing.mdx
@@ -1,6 +1,6 @@
 # Metadata parsing
 
-Given the simplicity of the format, it's very simple and efficient to fetch and parse metadata about Safetensors weights – i.e. the list of tensors, their types, and their shapes or numbers of parameters – using small (Range) HTTP requests.
+Given the simplicity of the format, it's very simple and efficient to fetch and parse metadata about Safetensors weights – i.e. the list of tensors, their types, and their shapes or numbers of parameters – using small [(Range) HTTP requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests).
 
 This parsing has been implemented in JS in [`huggingface.js`](https://huggingface.co/docs/huggingface.js/main/en/hub/modules#parsesafetensorsmetadata) (sample code follows below), but it would be similar in any language.
 

--- a/docs/source/metadata_parsing.mdx
+++ b/docs/source/metadata_parsing.mdx
@@ -9,9 +9,15 @@ This parsing has been implemented in JS in [`huggingface.js`](https://huggingfac
 
 We use it on the HuggingFace Hub to display info about models which have safetensors weights:
 
-![model-page](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/safetensors/model-page.png)
+<div class="flex justify-center">
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/safetensors/model-page.png"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/safetensors/model-page.png"/>
+</div>
 
-![view-all-tensors](https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/safetensors/view-all-tensors.png)
+<div class="flex justify-center">
+    <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/safetensors/view-all-tensors.png"/>
+    <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/safetensors/view-all-tensors.png"/>
+</div>
 
 But many other use cases are possible.
 

--- a/docs/source/metadata_parsing.mdx
+++ b/docs/source/metadata_parsing.mdx
@@ -4,10 +4,9 @@ Given the simplicity of the format, it's very simple and efficient to fetch and 
 
 This parsing has been implemented in JS in [`huggingface.js`](https://huggingface.co/docs/huggingface.js/main/en/hub/modules#parsesafetensorsmetadata) (sample code follows below), but it would be similar in any language.
 
-
 ## Example use case
 
-We use it on the HuggingFace Hub to display info about models which have safetensors weights:
+There can be many potential use cases. For instance, we use it on the HuggingFace Hub to display info about models which have safetensors weights:
 
 <div class="flex justify-center">
     <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/safetensors/model-page.png"/>
@@ -18,8 +17,6 @@ We use it on the HuggingFace Hub to display info about models which have safeten
     <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/safetensors/view-all-tensors.png"/>
     <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/safetensors/view-all-tensors.png"/>
 </div>
-
-But many other use cases are possible.
 
 ## Usage from JS
 

--- a/docs/source/metadata_parsing.mdx
+++ b/docs/source/metadata_parsing.mdx
@@ -1,4 +1,4 @@
-# Metadata parsing
+# Metadata Parsing
 
 Given the simplicity of the format, it's very simple and efficient to fetch and parse metadata about Safetensors weights – i.e. the list of tensors, their types, and their shapes or numbers of parameters – using small [(Range) HTTP requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests).
 

--- a/docs/source/metadata_parsing.mdx
+++ b/docs/source/metadata_parsing.mdx
@@ -2,7 +2,7 @@
 
 Given the simplicity of the format, it's very simple and efficient to fetch and parse metadata about Safetensors weights – i.e. the list of tensors, their types, and their shapes or numbers of parameters – using small (Range) HTTP requests.
 
-This parsing has been implemented in JS in [`huggingface.js`](https://huggingface.co/docs/huggingface.js/index) (sample code follows below), but it would be similar in any language.
+This parsing has been implemented in JS in [`huggingface.js`](https://huggingface.co/docs/huggingface.js/main/en/hub/modules#parsesafetensorsmetadata) (sample code follows below), but it would be similar in any language.
 
 
 ## Example use case


### PR DESCRIPTION
Follow up to https://github.com/huggingface/safetensors/pull/243

Changes:
1. Changed some wording. Added references/links when necessary. For example, https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests because not many people know about range requests.
2. Added image for both lightmode and darkmode
3. Added small python example
4. Added example outputs to js and python scripts

Updated preview: https://moon-ci-docs.huggingface.co/docs/safetensors/pr_245/en/metadata_parsing