### PR TITLE
Update to actions/checkout@v3

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -12,7 +12,7 @@ jobs:
         working-directory: ./safetensors
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Install Rust Stable
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/python-bench.yml
+++ b/.github/workflows/python-bench.yml
@@ -15,7 +15,7 @@ jobs:
     name: Performance regression check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/python-release-conda.yml
+++ b/.github/workflows/python-release-conda.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install miniconda
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/python-release-extra.yml
+++ b/.github/workflows/python-release-extra.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Create wheels for manylinux2014 - PowerPC
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Upgrade libssl
         run: sudo apt-get install -y libssl-dev

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -19,7 +19,7 @@ jobs:
     name: Create wheels for manylinux2014
     container: quay.io/pypa/manylinux2014_x86_64
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Install dependencies
         run: yum install -y openssl-devel

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -18,7 +18,7 @@ jobs:
         working-directory: ./bindings/python
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
         
 
       - name: Install Rust

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
         working-directory: ./safetensors
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Install Rust Stable
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
This PR upgrades actions/checkout from v[1,2]… to v3 to notably improve performance (retrieve only the commit being checked-out)

See:

v2.0 : https://github.com/actions/checkout/releases/tag/v2.0.0
v3.0 : https://github.com/actions/checkout/releases/tag/v3.0.0