### PR TITLE
Added method `len` on `SafeTensors` 

### DIFF
--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -390,7 +390,7 @@ impl<'data> SafeTensors<'data> {
     /// Indicate if the SafeTensors contains or not any tensor.
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+    self.metadata.tensors.is_empty()
     }
 }
 

--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -390,7 +390,7 @@ impl<'data> SafeTensors<'data> {
     /// Indicate if the SafeTensors contains or not any tensor.
     #[inline]
     pub fn is_empty(&self) -> bool {
-    self.metadata.tensors.is_empty()
+        self.metadata.tensors.is_empty()
     }
 }
 

--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -380,6 +380,12 @@ impl<'data> SafeTensors<'data> {
     pub fn names(&self) -> Vec<&'_ String> {
         self.metadata.index_map.keys().collect()
     }
+
+    /// Return how many tensors are currently stored within the SafeTensors.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.metadata.tensors.len()
+    }
 }
 
 /// The stuct representing the header of safetensor files which allow
@@ -945,6 +951,7 @@ mod tests {
 
         let loaded = SafeTensors::deserialize(serialized).unwrap();
 
+        assert_eq!(loaded.len(), 1);
         assert_eq!(loaded.names(), vec!["test"]);
         let tensor = loaded.tensor("test").unwrap();
         assert_eq!(tensor.shape(), vec![2, 2]);

--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -386,6 +386,12 @@ impl<'data> SafeTensors<'data> {
     pub fn len(&self) -> usize {
         self.metadata.tensors.len()
     }
+
+    /// Indicate if the SafeTensors contains or not any tensor.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 /// The stuct representing the header of safetensor files which allow


### PR DESCRIPTION
This avoid allocating a new tensor through `names()` or `tensors()`