### PR TITLE
Add `safejax` in "Featured Projects"

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -88,3 +88,4 @@ Safetensors is being used widely at leading AI enterprises, such as [Hugging Fac
 * [brycedrennan/imaginAIry](https://github.com/brycedrennan/imaginAIry)
 * [comfyanonymous/ComfyUI](https://github.com/comfyanonymous/ComfyUI)
 * [LianjiaTech/BELLE](https://github.com/LianjiaTech/BELLE)
+* [alvarobartt/safejax](https://github.com/alvarobartt/safejax)


### PR DESCRIPTION
## What's in this PR?

As of @julien-c's recent tweet at https://twitter.com/julien_c/status/1663239984772526085, I've decided to include https://github.com/alvarobartt/safejax in the "Featured Projects" section of the `safetensors` documentation.

Thanks, and, again, great work @Narsil!