### PR TITLE
Make tensor identifier a bit more robust, and transformers compatible

### DIFF
--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -38,7 +38,7 @@ def _find_shared_tensors(state_dict: Dict[str, torch.Tensor]) -> List[Set[str]]:
     for k, v in state_dict.items():
         if v.device != torch.device("meta"):
             # Need to add device as key because of multiple GPU.
-            tensors[(storage_ptr(v), v.device)].add(k)
+            tensors[(v.device, storage_ptr(v), storage_size(v))].add(k)
     tensors = list(sorted(tensors.values()))
     return tensors
 


### PR DESCRIPTION
`transformers`: https://github.com/huggingface/transformers/pull/23871

I think `nbytes` is required otherwise you might be having multiple storage starting from the same offset but not the same length considered as duplicate, which I'm guessing is not something you support. Granted it's a weird case.