### PR TITLE
Add a reference to tch-rs

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -90,3 +90,4 @@ Safetensors is being used widely at leading AI enterprises, such as [Hugging Fac
 * [LianjiaTech/BELLE](https://github.com/LianjiaTech/BELLE)
 * [alvarobartt/safejax](https://github.com/alvarobartt/safejax)
 * [MaartenGr/BERTopic](https://github.com/MaartenGr/BERTopic)
+* [LaurentMazare/tch-rs](https://github.com/LaurentMazare/tch-rs)


### PR DESCRIPTION
# What does this PR do?

As per [julien_c's tweet](https://twitter.com/julien_c/status/1663239984772526085) suggesting to add mention to project using safetensors, this adds a reference to tch-rs that use it for saving/loading weights. I have a couple other projects using it but it would probably be too much for this list (just mentioning them here for exhaustivity: [ocaml-torch](https://github.com/LaurentMazare/ocaml-torch), [diffusers-rs](https://github.com/LaurentMazare/diffusers-rs), [ocaml-xla](https://github.com/LaurentMazare/ocaml-xla)). 
