### PR TITLE
fix syntax error in import statement of safetensors pytorch api docs code example

### DIFF
--- a/docs/source/torch_shared_tensors.mdx
+++ b/docs/source/torch_shared_tensors.mdx
@@ -7,7 +7,7 @@ Using specific functions, which should work in most cases for you.
 This is not without side effects.
 
 ```python
-from safetensors.torch load_model, save_model
+from safetensors.torch import load_model, save_model
 
 save_model(model, "model.safetensors")
 # Instead of save_file(model.state_dict(), "model.safetensors")


### PR DESCRIPTION
# What does this PR do?

This PR proposes a fix to an import statement in a safetensors pytorch api docs code example.