### PR TITLE
Materialize TF state dicts on CPU not GPU

### DIFF
--- a/bindings/python/py_src/safetensors/tensorflow.py
+++ b/bindings/python/py_src/safetensors/tensorflow.py
@@ -126,8 +126,9 @@ def load_file(filename: Union[str, os.PathLike]) -> Dict[str, tf.Tensor]:
 
 
 def _np2tf(numpy_dict: Dict[str, np.ndarray]) -> Dict[str, tf.Tensor]:
-    for k, v in numpy_dict.items():
-        numpy_dict[k] = tf.convert_to_tensor(v)
+    with tf.device("CPU:0"):
+        for k, v in numpy_dict.items():
+            numpy_dict[k] = tf.convert_to_tensor(v)
     return numpy_dict
 
 


### PR DESCRIPTION
See discussion here: https://github.com/huggingface/transformers/issues/24393

Safetensors state dicts are materialized on GPU when loading in TF, which means the state dict and the original weights are both present at once, which increases peak memory usage by 2X - 2.5X.

This PR creates TF tensors on CPU to avoid this. It might cause some other issues, so I'm marking it as draft for now!