### PR TITLE
Autodoc for save_model and load_model

### DIFF
--- a/docs/source/api/torch.mdx
+++ b/docs/source/api/torch.mdx
@@ -4,3 +4,5 @@
 [[autodoc]] safetensors.torch.load
 [[autodoc]] safetensors.torch.save_file
 [[autodoc]] safetensors.torch.save
+[[autodoc]] safetensors.torch.load_model
+[[autodoc]] safetensors.torch.save_model


### PR DESCRIPTION
# What does this PR do?

Adds load_model and save_model to the autodoc. These are useful functions that are currently only documented under the shared tensors page.
These functions are also useful outside of dealing with shared tensors and probably should be documented on the torch page.
