### PR TITLE
Fix link to shared tensor page

### DIFF
--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -95,7 +95,7 @@ def save_model(
     """
     Saves a given torch model to specified filename.
     This method exists specifically to avoid tensor sharing issues which are
-    not allowed in `safetensors`. [More information on tensor sharing](torch_shared_tensors)
+    not allowed in `safetensors`. [More information on tensor sharing](../torch_shared_tensors)
 
     Args:
         model (`torch.nn.Module`):
@@ -139,7 +139,7 @@ def load_model(model: torch.nn.Module, filename: str, strict=True) -> Tuple[List
     """
     Loads a given filename onto a torch model.
     This method exists specifically to avoid tensor sharing issues which are
-    not allowed in `safetensors`. [More information on tensor sharing](torch_shared_tensors)
+    not allowed in `safetensors`. [More information on tensor sharing](../torch_shared_tensors)
 
     Args:
         model (`torch.nn.Module`):


### PR DESCRIPTION
# What does this PR do?

Load_model and save_model are now documented, but they do not link correctly.
On the page https://huggingface.co/docs/safetensors/main/en/api/torch#safetensors.torch.load_model, the link "More information on tensor sharing links to https://huggingface.co/docs/safetensors/main/en/api/torch_shared_tensors
It should link to https://huggingface.co/docs/safetensors/main/en/torch_shared_tensors
