### PR TITLE
[doc] add missing metadata doc 

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ tensors = {
    "weight1": torch.zeros((1024, 1024)),
    "weight2": torch.zeros((1024, 1024))
 }
-save_file(tensors, "model.safetensors")
+save_file(tensors, "model.safetensors", framework="pt")
 
 tensors = {}
 with safe_open("model.safetensors", framework="pt", device="cpu") as f:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ tensors = {
    "weight1": torch.zeros((1024, 1024)),
    "weight2": torch.zeros((1024, 1024))
 }
-save_file(tensors, "model.safetensors", framework="pt")
+save_file(tensors, "model.safetensors", metadata={"format": "pt"})
 
 tensors = {}
 with safe_open("model.safetensors", framework="pt", device="cpu") as f:


### PR DESCRIPTION
`transformers` requires `metadata` - so update the example to show how it's added.