### PR TITLE
Clarify specification around endianness and header padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ with safe_open("model.safetensors", framework="pt", device="cpu") as f:
 
 ### Format
 
-- 8 bytes: `N`, a u64 int, containing the size of the header
+- 8 bytes: `N`, an unsigned little-endian 64-bit integer, containing the size of the header
 - N bytes: a JSON utf-8 string representing the header.
   - The header is a dict like `{"TENSOR_NAME": {"dtype": "F16", "shape": [1, 16, 256], "data_offsets": [BEGIN, END]}, "NEXT_TENSOR_NAME": {...}, ...}`, where offsets point to the tensor data relative to the beginning of the byte buffer, with `BEGIN` as the starting offset and `END` as the one-past offset (so total tensor byte size = `END - BEGIN`).
   - A special key `__metadata__` is allowed to contain free form string-to-string map. Arbitrary JSON is not allowed, all values must be strings.

--- a/README.md
+++ b/README.md
@@ -76,8 +76,12 @@ with safe_open("model.safetensors", framework="pt", device="cpu") as f:
 ### Format
 
 - 8 bytes: `N`, an unsigned little-endian 64-bit integer, containing the size of the header
-- N bytes: a JSON utf-8 string representing the header.
-  - The header is a dict like `{"TENSOR_NAME": {"dtype": "F16", "shape": [1, 16, 256], "data_offsets": [BEGIN, END]}, "NEXT_TENSOR_NAME": {...}, ...}`, where offsets point to the tensor data relative to the beginning of the byte buffer, with `BEGIN` as the starting offset and `END` as the one-past offset (so total tensor byte size = `END - BEGIN`).
+- N bytes: a JSON UTF-8 string representing the header.
+  - The header data MUST begin with a `{` character (0x7B).
+  - The header data MAY be trailing padded with whitespace (any bytes 0x09, 0x0A, 0x0D, 0x20).
+  - The header is a dict like `{"TENSOR_NAME": {"dtype": "F16", "shape": [1, 16, 256], "data_offsets": [BEGIN, END]}, "NEXT_TENSOR_NAME": {...}, ...}`,
+    - `data_offsets` point to the tensor data relative to the beginning of the byte buffer (i.e. not an absolute position in the file),
+      with `BEGIN` as the starting offset and `END` as the one-past offset (so total tensor byte size = `END - BEGIN`).
   - A special key `__metadata__` is allowed to contain free form string-to-string map. Arbitrary JSON is not allowed, all values must be strings.
 - Rest of the file: byte-buffer.
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ with safe_open("model.safetensors", framework="pt", device="cpu") as f:
 - 8 bytes: `N`, an unsigned little-endian 64-bit integer, containing the size of the header
 - N bytes: a JSON UTF-8 string representing the header.
   - The header data MUST begin with a `{` character (0x7B).
-  - The header data MAY be trailing padded with whitespace (any bytes 0x09, 0x0A, 0x0D, 0x20).
+  - The header data MAY be trailing padded with whitespace (0x20).
   - The header is a dict like `{"TENSOR_NAME": {"dtype": "F16", "shape": [1, 16, 256], "data_offsets": [BEGIN, END]}, "NEXT_TENSOR_NAME": {...}, ...}`,
     - `data_offsets` point to the tensor data relative to the beginning of the byte buffer (i.e. not an absolute position in the file),
       with `BEGIN` as the starting offset and `END` as the one-past offset (so total tensor byte size = `END - BEGIN`).

--- a/safetensors/README.md
+++ b/safetensors/README.md
@@ -75,7 +75,7 @@ with safe_open("model.safetensors", framework="pt", device="cpu") as f:
 
 ### Format
 
-- 8 bytes: `N`, a u64 int, containing the size of the header
+- 8 bytes: `N`, an unsigned little-endian 64-bit integer, containing the size of the header
 - N bytes: a JSON utf-8 string representing the header.
   - The header is a dict like `{"TENSOR_NAME": {"dtype": "F16", "shape": [1, 16, 256], "data_offsets": [BEGIN, END]}, "NEXT_TENSOR_NAME": {...}, ...}`, where offsets point to the tensor data relative to the beginning of the byte buffer, with `BEGIN` as the starting offset and `END` as the one-past offset (so total tensor byte size = `END - BEGIN`).
   - A special key `__metadata__` is allowed to contain free form string-to-string map. Arbitrary JSON is not allowed, all values must be strings.

--- a/safetensors/README.md
+++ b/safetensors/README.md
@@ -76,8 +76,12 @@ with safe_open("model.safetensors", framework="pt", device="cpu") as f:
 ### Format
 
 - 8 bytes: `N`, an unsigned little-endian 64-bit integer, containing the size of the header
-- N bytes: a JSON utf-8 string representing the header.
-  - The header is a dict like `{"TENSOR_NAME": {"dtype": "F16", "shape": [1, 16, 256], "data_offsets": [BEGIN, END]}, "NEXT_TENSOR_NAME": {...}, ...}`, where offsets point to the tensor data relative to the beginning of the byte buffer, with `BEGIN` as the starting offset and `END` as the one-past offset (so total tensor byte size = `END - BEGIN`).
+- N bytes: a JSON UTF-8 string representing the header.
+  - The header data MUST begin with a `{` character (0x7B).
+  - The header data MAY be trailing padded with whitespace (any bytes 0x09, 0x0A, 0x0D, 0x20).
+  - The header is a dict like `{"TENSOR_NAME": {"dtype": "F16", "shape": [1, 16, 256], "data_offsets": [BEGIN, END]}, "NEXT_TENSOR_NAME": {...}, ...}`,
+    - `data_offsets` point to the tensor data relative to the beginning of the byte buffer (i.e. not an absolute position in the file),
+      with `BEGIN` as the starting offset and `END` as the one-past offset (so total tensor byte size = `END - BEGIN`).
   - A special key `__metadata__` is allowed to contain free form string-to-string map. Arbitrary JSON is not allowed, all values must be strings.
 - Rest of the file: byte-buffer.
 

--- a/safetensors/README.md
+++ b/safetensors/README.md
@@ -78,7 +78,7 @@ with safe_open("model.safetensors", framework="pt", device="cpu") as f:
 - 8 bytes: `N`, an unsigned little-endian 64-bit integer, containing the size of the header
 - N bytes: a JSON UTF-8 string representing the header.
   - The header data MUST begin with a `{` character (0x7B).
-  - The header data MAY be trailing padded with whitespace (any bytes 0x09, 0x0A, 0x0D, 0x20).
+  - The header data MAY be trailing padded with whitespace (0x20).
   - The header is a dict like `{"TENSOR_NAME": {"dtype": "F16", "shape": [1, 16, 256], "data_offsets": [BEGIN, END]}, "NEXT_TENSOR_NAME": {...}, ...}`,
     - `data_offsets` point to the tensor data relative to the beginning of the byte buffer (i.e. not an absolute position in the file),
       with `BEGIN` as the starting offset and `END` as the one-past offset (so total tensor byte size = `END - BEGIN`).

--- a/safetensors/src/lib.rs
+++ b/safetensors/src/lib.rs
@@ -53,8 +53,12 @@
 //!## Format
 //!
 //! - 8 bytes: `N`, an unsigned little-endian 64-bit integer, containing the size of the header
-//! - N bytes: a JSON utf-8 string representing the header.
-//!   - The header is a dict like `{"TENSOR_NAME": {"dtype": "F16", "shape": [1, 16, 256], "data_offsets": [BEGIN, END]}, "NEXT_TENSOR_NAME": {...}, ...}`, where offsets point to the tensor data relative to the beginning of the byte buffer, with `BEGIN` as the starting offset and `END` as the one-past offset (so total tensor byte size = `END - BEGIN`).
+//! - N bytes: a JSON UTF-8 string representing the header.
+//!   - The header data MUST begin with a `{` character (0x7B).
+//!   - The header data MAY be trailing padded with whitespace (any bytes 0x09, 0x0A, 0x0D, 0x20).
+//!   - The header is a dict like `{"TENSOR_NAME": {"dtype": "F16", "shape": [1, 16, 256], "data_offsets": [BEGIN, END]}, "NEXT_TENSOR_NAME": {...}, ...}`,
+//!     - `data_offsets` point to the tensor data relative to the beginning of the byte buffer (i.e. not an absolute position in the file),
+//!       with `BEGIN` as the starting offset and `END` as the one-past offset (so total tensor byte size = `END - BEGIN`).
 //!   - A special key `__metadata__` is allowed to contain free form string-to-string map. Arbitrary JSON is not allowed, all values must be strings.
 //! - Rest of the file: byte-buffer.
 //!

--- a/safetensors/src/lib.rs
+++ b/safetensors/src/lib.rs
@@ -55,7 +55,7 @@
 //! - 8 bytes: `N`, an unsigned little-endian 64-bit integer, containing the size of the header
 //! - N bytes: a JSON UTF-8 string representing the header.
 //!   - The header data MUST begin with a `{` character (0x7B).
-//!   - The header data MAY be trailing padded with whitespace (any bytes 0x09, 0x0A, 0x0D, 0x20).
+//!   - The header data MAY be trailing padded with whitespace (0x20).
 //!   - The header is a dict like `{"TENSOR_NAME": {"dtype": "F16", "shape": [1, 16, 256], "data_offsets": [BEGIN, END]}, "NEXT_TENSOR_NAME": {...}, ...}`,
 //!     - `data_offsets` point to the tensor data relative to the beginning of the byte buffer (i.e. not an absolute position in the file),
 //!       with `BEGIN` as the starting offset and `END` as the one-past offset (so total tensor byte size = `END - BEGIN`).

--- a/safetensors/src/lib.rs
+++ b/safetensors/src/lib.rs
@@ -52,7 +52,7 @@
 //!
 //!## Format
 //!
-//! - 8 bytes: `N`, a u64 int, containing the size of the header
+//! - 8 bytes: `N`, an unsigned little-endian 64-bit integer, containing the size of the header
 //! - N bytes: a JSON utf-8 string representing the header.
 //!   - The header is a dict like `{"TENSOR_NAME": {"dtype": "F16", "shape": [1, 16, 256], "data_offsets": [BEGIN, END]}, "NEXT_TENSOR_NAME": {...}, ...}`, where offsets point to the tensor data relative to the beginning of the byte buffer, with `BEGIN` as the starting offset and `END` as the one-past offset (so total tensor byte size = `END - BEGIN`).
 //!   - A special key `__metadata__` is allowed to contain free form string-to-string map. Arbitrary JSON is not allowed, all values must be strings.


### PR DESCRIPTION
# What does this PR do?

This PR clarifies the readme around the spec a little; the endianness of the header size was not specified.

Further, as discussed in https://github.com/huggingface/safetensors/issues/291#issuecomment-1660365431 `serde_json` (and in fact any spec-compliant JSON parser, I suppose) allows padding the JSON data with whitespace characters, so note that – and add a test for that, too.

**EDIT:** As discussed in the comments below, this also nails down the spec that the padding may only be trailing.

---

As an aside: it's not very clear for a contributor that you shouldn't modify `README.md` directly... 😁 