### PR TITLE
feat: Add filter for shared storage non overlapping tensors

### DIFF
--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -19,6 +19,7 @@ def storage_ptr(tensor: torch.Tensor) -> int:
             # Fallback for meta storage
             return 0
 
+
 def _end_ptr(tensor: torch.Tensor) -> int:
     stop = tensor.view(-1)[-1].data_ptr() + _SIZE[tensor.dtype]
     return stop
@@ -36,6 +37,7 @@ def storage_size(tensor: torch.Tensor) -> int:
             # On torch >=2.0 this is the tensor size
             return tensor.nelement() * _SIZE[tensor.dtype]
 
+
 def _filter_shared_not_shared(tensors: List[Set[str]], state_dict: Dict[str, torch.Tensor]) -> List[Set[str]]:
     filtered_tensors = []
     for shared in tensors:
@@ -50,7 +52,6 @@ def _filter_shared_not_shared(tensors: List[Set[str]], state_dict: Dict[str, tor
             areas.append((tensor.data_ptr(), _end_ptr(tensor), name))
         areas.sort()
 
-        
         _, last_stop, last_name = areas[0]
         filtered_tensors.append({last_name})
         for start, stop, name in areas[1:]:
@@ -61,6 +62,7 @@ def _filter_shared_not_shared(tensors: List[Set[str]], state_dict: Dict[str, tor
             last_stop = stop
 
     return filtered_tensors
+
 
 def _find_shared_tensors(state_dict: Dict[str, torch.Tensor]) -> List[Set[str]]:
     tensors = defaultdict(set)
@@ -96,7 +98,11 @@ def _remove_duplicate_names(
         complete_names = set([name for name in shared if _is_complete(state_dict[name])])
         if not complete_names:
             raise RuntimeError(
-                f"Error while trying to find names to remove to save state dict, but found no suitable name to keep for saving amongst: {shared}. None is covering the entire storage.Refusing to save/load the model since you could be storing much more memory than needed. Please refer to https://huggingface.co/docs/safetensors/torch_shared_tensors for more information. Or open an issue."
+                "Error while trying to find names to remove to save state dict, but found no suitable name to keep"
+                f" for saving amongst: {shared}. None is covering the entire storage.Refusing to save/load the model"
+                " since you could be storing much more memory than needed. Please refer to"
+                " https://huggingface.co/docs/safetensors/torch_shared_tensors for more information. Or open an"
+                " issue."
             )
 
         keep_name = sorted(list(complete_names))[0]

--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -21,7 +21,10 @@ def storage_ptr(tensor: torch.Tensor) -> int:
 
 
 def _end_ptr(tensor: torch.Tensor) -> int:
-    stop = tensor.view(-1)[-1].data_ptr() + _SIZE[tensor.dtype]
+    if tensor.nelement():
+        stop = tensor.view(-1)[-1].data_ptr() + _SIZE[tensor.dtype]
+    else:
+        stop = tensor.data_ptr()
     return stop
 
 

--- a/bindings/python/tests/test_pt_comparison.py
+++ b/bindings/python/tests/test_pt_comparison.py
@@ -43,13 +43,11 @@ class TorchTestCase(unittest.TestCase):
     def test_disjoint_tensors_shared_storage(self):
         A = torch.zeros((10, 10))
         data = {
-            "test": A[:, :0],
-            "test2": A[:0],
+            "test": A[1:],
+            "test2": A[:1],
         }
         local = "./tests/data/out_safe_pt_mmap_small4.safetensors"
-        with self.assertRaises(RuntimeError) as ex:
-            save_file(data, local)
-        self.assertIn("tensors share memory", str(ex.exception))
+        save_file(data, local)
 
     def test_meta_tensor(self):
         A = torch.zeros((10, 10), device=torch.device("meta"))

--- a/bindings/python/tests/test_pt_comparison.py
+++ b/bindings/python/tests/test_pt_comparison.py
@@ -69,7 +69,8 @@ class TorchTestCase(unittest.TestCase):
         self.assertEqual(
             binary,
             # Spaces are for forcing the alignment.
-            b'@\x00\x00\x00\x00\x00\x00\x00{"test":{"dtype":"F32","shape":[2,2],"data_offsets":[0,16]}}    \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+            b'@\x00\x00\x00\x00\x00\x00\x00{"test":{"dtype":"F32","shape":[2,2],"data_offsets":[0,16]}}   '
+            b" \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
         )
         reloaded = load(binary)
         self.assertTrue(torch.equal(data["test"], reloaded["test"]))
@@ -91,8 +92,8 @@ class TorchTestCase(unittest.TestCase):
             save_file(data, local)
         self.assertEqual(
             str(ctx.exception),
-            "You are trying to save a sparse tensors: `['test']` which this library does not support. You can make it a"
-            " dense tensor before saving with `.to_dense()` but be aware this might make a much larger file than"
+            "You are trying to save a sparse tensors: `['test']` which this library does not support. You can make it"
+            " a dense tensor before saving with `.to_dense()` but be aware this might make a much larger file than"
             " needed.",
         )
 

--- a/bindings/python/tests/test_pt_model.py
+++ b/bindings/python/tests/test_pt_model.py
@@ -5,10 +5,10 @@ import torch
 
 from safetensors import safe_open
 from safetensors.torch import (
+    _end_ptr,
     _find_shared_tensors,
     _is_complete,
     _remove_duplicate_names,
-    _end_ptr,
     load_model,
     save_file,
     save_model,

--- a/bindings/python/tests/test_pt_model.py
+++ b/bindings/python/tests/test_pt_model.py
@@ -8,6 +8,7 @@ from safetensors.torch import (
     _find_shared_tensors,
     _is_complete,
     _remove_duplicate_names,
+    _end_ptr,
     load_model,
     save_file,
     save_model,
@@ -73,6 +74,50 @@ class TorchModelTestCase(unittest.TestCase):
         self.assertEqual(_find_shared_tensors({"C": C, "D": D}), [])
         self.assertEqual(_find_shared_tensors({"C": C}), [])
         self.assertEqual(_find_shared_tensors({"D": D}), [])
+
+    def test_find_shared_non_shared_tensors(self):
+        A = torch.zeros((4,))
+        B = A[:2]
+        C = A[2:]
+        # Shared storage but do not overlap
+        self.assertEqual(_find_shared_tensors({"B": B, "C": C}), [{"B"}, {"C"}])
+
+        B = A[:2]
+        C = A[1:]
+        # Shared storage but *do* overlap
+        self.assertEqual(_find_shared_tensors({"B": B, "C": C}), [{"B", "C"}])
+
+        B = A[:2]
+        C = A[2:]
+        D = A[:1]
+        # Shared storage but *do* overlap
+        self.assertEqual(_find_shared_tensors({"B": B, "C": C, "D": D}), [{"B", "D"}, {"C"}])
+
+    def test_end_ptr(self):
+        A = torch.zeros((4,))
+        start = A.data_ptr()
+        end = _end_ptr(A)
+        self.assertEqual(end - start, 16)
+        B = torch.zeros((16,))
+        A = B[::4]
+        start = A.data_ptr()
+        end = _end_ptr(A)
+        # Jump 3 times 16 byes (the stride of B)
+        # Then add the size of the datapoint 4 bytes
+        self.assertEqual(end - start, 16 * 3 + 4)
+
+        ## FLOAT16
+        A = torch.zeros((4,), dtype=torch.float16)
+        start = A.data_ptr()
+        end = _end_ptr(A)
+        self.assertEqual(end - start, 8)
+        B = torch.zeros((16,), dtype=torch.float16)
+        A = B[::4]
+        start = A.data_ptr()
+        end = _end_ptr(A)
+        # Jump 3 times 8 bytes (the stride of B)
+        # Then add the size of the datapoint 4 bytes
+        self.assertEqual(end - start, 8 * 3 + 2)
 
     def test_remove_duplicate_names(self):
         A = torch.zeros((3, 3))

--- a/bindings/python/tests/test_simple.py
+++ b/bindings/python/tests/test_simple.py
@@ -21,7 +21,8 @@ class TestCase(unittest.TestCase):
 
         self.assertEqual(
             out,
-            b'@\x00\x00\x00\x00\x00\x00\x00{"test":{"dtype":"I32","shape":[2,2],"data_offsets":[0,16]}}    \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+            b'@\x00\x00\x00\x00\x00\x00\x00{"test":{"dtype":"I32","shape":[2,2],"data_offsets":[0,16]}}   '
+            b" \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
         )
 
         data[1, 1] = 1
@@ -29,7 +30,8 @@ class TestCase(unittest.TestCase):
 
         self.assertEqual(
             out,
-            b'@\x00\x00\x00\x00\x00\x00\x00{"test":{"dtype":"I32","shape":[2,2],"data_offsets":[0,16]}}    \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00',
+            b'@\x00\x00\x00\x00\x00\x00\x00{"test":{"dtype":"I32","shape":[2,2],"data_offsets":[0,16]}}   '
+            b" \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00",
         )
 
     def test_deserialization(self):
@@ -40,7 +42,10 @@ class TestCase(unittest.TestCase):
         np.testing.assert_array_equal(out["test"], np.zeros((2, 2), dtype=np.int32))
 
     def test_deserialization_metadata(self):
-        serialized = b'f\x00\x00\x00\x00\x00\x00\x00{"__metadata__":{"framework":"pt"},"test1":{"dtype":"I32","shape":[2,2],"data_offsets":[0,16]}}       \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+        serialized = (
+            b'f\x00\x00\x00\x00\x00\x00\x00{"__metadata__":{"framework":"pt"},"test1":{"dtype":"I32","shape":[2,2],"data_offsets":[0,16]}}'
+            b"       \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+        )
 
         with tempfile.NamedTemporaryFile() as f:
             f.write(serialized)
@@ -63,7 +68,8 @@ class TestCase(unittest.TestCase):
         self.assertEqual(out1, out2)
         self.assertEqual(
             out1,
-            b'\x80\x00\x00\x00\x00\x00\x00\x00{"test1":{"dtype":"I32","shape":[2,2],"data_offsets":[0,16]},"test2":{"dtype":"F16","shape":[2,2],"data_offsets":[16,24]}}      \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+            b'\x80\x00\x00\x00\x00\x00\x00\x00{"test1":{"dtype":"I32","shape":[2,2],"data_offsets":[0,16]},"test2":{"dtype":"F16","shape":[2,2],"data_offsets":[16,24]}}'
+            b"      \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
         )
         self.assertEqual(out1[8:].index(b"\x00") + 8, 136)
         self.assertEqual((out1[8:].index(b"\x00") + 8) % 8, 0)
@@ -73,7 +79,8 @@ class TestCase(unittest.TestCase):
         out1 = save({"test1": data}, metadata={"framework": "pt"})
         self.assertEqual(
             out1,
-            b'`\x00\x00\x00\x00\x00\x00\x00{"__metadata__":{"framework":"pt"},"test1":{"dtype":"I32","shape":[2,2],"data_offsets":[0,16]}} \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+            b'`\x00\x00\x00\x00\x00\x00\x00{"__metadata__":{"framework":"pt"},"test1":{"dtype":"I32","shape":[2,2],"data_offsets":[0,16]}}'
+            b" \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
         )
         self.assertEqual(out1[8:].index(b"\x00") + 8, 104)
         self.assertEqual((out1[8:].index(b"\x00") + 8) % 8, 0)


### PR DESCRIPTION
# What does this PR do?

Deepspeed does some tensor sharing but not actually overlapping
tensors. (It's not exactly clear why).

This PR fixes it by adding a global check for all shared tensors if the
actual offsets are overlapping or not.
It looks at all (start, stop) pointers of the tensors, sorts them by start pointer, and decides 2 tensors are disjoint if stop(previous) <= start(next)


Linked issues:

- https://github.com/huggingface/text-generation-inference/issues/742
- https://github.com/huggingface/text-generation-inference/issues/701
- https://github.com/huggingface/text-generation-inference/issues/622
- https://github.com/huggingface/diffusers/issues/4361

This will require a new release after merge to fix user's issues.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue) or description of the problem this PR solves.