### PR TITLE
add tensorshare to featured projects

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -91,3 +91,4 @@ Safetensors is being used widely at leading AI enterprises, such as [Hugging Fac
 * [alvarobartt/safejax](https://github.com/alvarobartt/safejax)
 * [MaartenGr/BERTopic](https://github.com/MaartenGr/BERTopic)
 * [LaurentMazare/tch-rs](https://github.com/LaurentMazare/tch-rs)
+* [chainyo/tensorshare](https://github.com/chainyo/tensorshare)


### PR DESCRIPTION
Hi, this PR adds [tensorshare](https://github.com/chainyo/tensorshare) has a project using `safetensors`!
