### PR TITLE
Add NumPy for all backends dependencies

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -36,11 +36,11 @@ def deps_list(*pkgs):
 
 
 extras = {}
-extras["torch"] = deps_list("torch", "numpy")
 extras["numpy"] = deps_list("numpy")
-extras["tensorflow"] = deps_list("tensorflow", "numpy")
-extras["jax"] = deps_list("jax", "flax", "jaxlib", "numpy")
-extras["paddlepaddle"] = deps_list("paddlepaddle", "numpy")
+extras["torch"] = deps_list("torch") + extras["numpy"]
+extras["tensorflow"] = deps_list("tensorflow") + extras["numpy"]
+extras["jax"] = deps_list("jax", "flax", "jaxlib") + extras["numpy"]
+extras["paddlepaddle"] = deps_list("paddlepaddle") + extras["numpy"]
 extras["quality"] = deps_list("black", "isort", "flake8", "click")
 extras["testing"] = (
     deps_list("setuptools_rust", "huggingface_hub", "pytest", "pytest-benchmark", "h5py") + extras["numpy"]

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -36,11 +36,11 @@ def deps_list(*pkgs):
 
 
 extras = {}
-extras["torch"] = deps_list("torch")
+extras["torch"] = deps_list("torch", "numpy")
 extras["numpy"] = deps_list("numpy")
-extras["tensorflow"] = deps_list("tensorflow")
-extras["jax"] = deps_list("jax", "flax", "jaxlib")
-extras["paddlepaddle"] = deps_list("paddlepaddle")
+extras["tensorflow"] = deps_list("tensorflow", "numpy")
+extras["jax"] = deps_list("jax", "flax", "jaxlib", "numpy")
+extras["paddlepaddle"] = deps_list("paddlepaddle", "numpy")
 extras["quality"] = deps_list("black", "isort", "flake8", "click")
 extras["testing"] = (
     deps_list("setuptools_rust", "huggingface_hub", "pytest", "pytest-benchmark", "h5py") + extras["numpy"]


### PR DESCRIPTION
# What does this PR do?

I noticed that all backends require `numpy` as a dependency when you use the serialization and deserialization methods from `safetensors`.
I propose to add them as an extra dependency to `torch`, `tensorflow`, `paddlepaddle` and `flax`.

Wdyt? @Narsil 
