### PR TITLE
Fix building Windows x64 wheels

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -48,31 +48,24 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install Rust 32bits
-        if: ${{ matrix.os == '32' }}
+      - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable-i686-pc-windows-msvc
-          override: true
-
-      - name: Install Rust 64bits
-        if: ${{ matrix.os == '32' }}
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable-i686-pc-windows-msvc
+          toolchain: ${{ matrix.bits == '32' && 'stable-i686-pc-windows-msvc' || 'stable-x86_64-pc-windows-msvc' }}
           override: true
 
       - name: Override toolchain
-        if: ${{ matrix.os == '32' }}
         shell: bash
         working-directory: ./bindings/python
-        run: echo "stable-i686-pc-windows-msvc" > rust-toolchain
+        env:
+          TOOLCHAIN: ${{ matrix.bits == '32' && 'stable-i686-pc-windows-msvc' || 'stable-x86_64-pc-windows-msvc' }}
+        run: echo "$TOOLCHAIN" > rust-toolchain
 
       - name: Install Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
-          architecture: x86
+          architecture: ${{ matrix.bits == '32' && 'x86' || 'x64' }}
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
This PR attempts to fix building Windows x64 wheels by changing the `python-release.yml` workflow.
Currently, x64 wheels are missing for Windows as the current workflow is only generating x86 wheels.

I am unfamiliar with your particular workflow needs, so I can only hope that this fixes the issue.
If it does not, I hope this can give you some ideas on how to fix it.

See this relevant issue: https://github.com/huggingface/safetensors/issues/340