### PR TITLE
Fix id_tensor_storage for XLA tensors.

### DIFF
--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -12,6 +12,11 @@ def storage_ptr(tensor: torch.Tensor) -> int:
     try:
         return tensor.untyped_storage().data_ptr()
     except Exception:
+        if tensor.device.type == 'xla':
+            # this is a XLA tensor, it must be created using torch_xla's
+            # device. So the following import is safe:
+            import torch_xla
+            return torch_xla._XLAC._xla_get_tensor_id(tensor)
         # Fallback for torch==1.10
         try:
             return tensor.storage().data_ptr()


### PR DESCRIPTION
XLA tensors don't have storage and attempting to get it's storage will get

  RuntimeError: Attempted to access the data pointer on an
                invalid python storage.

Repro:
```python
from transformers import pytorch_utils
import torch_xla.core.xla_model as xm
device = xm.xla_device()
a = torch.ones((10,10)).to(device)
pytorch_utils.id_tensor_storage(a)  # raises RuntimeError
```
With this patch it would print out
(device(type='xla', index=0), 1, 400).


