### PR TITLE
perf: make loading shallow weights up to 20X faster

### DIFF
--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -306,8 +306,9 @@ def load_file(filename: Union[str, os.PathLike], device="cpu") -> Dict[str, torc
     """
     result = {}
     with safe_open(filename, framework="pt", device=device) as f:
-        for k in f.keys():
-            result[k] = f.get_tensor(k)
+        keys = f.keys()
+        for key, tensor in zip(keys, f.get_tensors(keys)):
+            result[key] = tensor
     return result
 
 

--- a/safetensors/benches/benchmark.rs
+++ b/safetensors/benches/benchmark.rs
@@ -12,6 +12,17 @@ fn get_sample_data() -> (Vec<u8>, Vec<usize>, Dtype) {
     (data, shape, dtype)
 }
 
+// Return a shallow sample data of size 5 KiB
+fn get_shallow_sample_data() -> (Vec<u8>, Vec<usize>, Dtype) {
+    let shape = vec![32, 4];
+    let dtype = Dtype::F32;
+    let n: usize = shape.iter().product::<usize>() * dtype.size(); // 4
+    let data = vec![0; n];
+
+    (data, shape, dtype)
+}
+
+
 pub fn bench_serialize(c: &mut Criterion) {
     let (data, shape, dtype) = get_sample_data();
     let n_layers = 5;
@@ -50,6 +61,30 @@ pub fn bench_deserialize(c: &mut Criterion) {
     });
 }
 
+pub fn bench_deserialize_shallow(c: &mut Criterion) {
+    // Unlike classical models, LoRAs (and other derivatives) have a lot of "shallow" layers
+    // where the size of the weights themselves does not matter as much as the number of layers
+    // when it comes to the performance.
+
+    let (data, shape, dtype) = get_shallow_sample_data();
+    let n_layers = 4000;
+
+    let mut metadata: HashMap<String, TensorView> = HashMap::new();
+    // 5 KiB x 2000 = 10 MB
+    for i in 0..n_layers {
+        let tensor = TensorView::new(dtype, shape.clone(), &data[..]).unwrap();
+        metadata.insert(format!("weight{i}"), tensor);
+    }
+
+    let out = serialize(&metadata, &None).unwrap();
+
+    c.bench_function("Deserlialize 10_MB shallow", |b| {
+        b.iter(|| {
+            let _deserialized = SafeTensors::deserialize(black_box(&out)).unwrap();
+        })
+    });
+}
+
 criterion_group!(bench_ser, bench_serialize);
-criterion_group!(bench_de, bench_deserialize);
+criterion_group!(bench_de, bench_deserialize, bench_deserialize_shallow);
 criterion_main!(bench_ser, bench_de);


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #361. Local profiling shows majority of the time is spent on recurring accesses to the tensor metadata on every individual tensor fetching. This might be negligible when fetching a few tensors (and is actually better to have it lazily, so I understand the design intentions) but when reading whole weight files (such as a diffusion LoRA) it adds up quickly and causes exponential performance degradation.

With this PR, the example in #361 is now as fast as torch (and performs even better)! Median went from 0.33 seconds to 0.017 seconds. Torch is still at 0.023 seconds so safetensors beats it :) 

Testing a [real world LoRA](https://huggingface.co/nerijs/pixel-art-xl/blob/main/pixel-art-xl.safetensors) with results in similiar perf gains ([script.py](https://gist.github.com/isidentical/0739bfa3d0c5cb0d6946a7561d7c8171)) where median goes from ~0.4 seconds to under 0.018 seconds (more than 20X).
