### PR TITLE
Stop recreating the hashmap all the time.

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -452,10 +452,12 @@ impl Open {
     ///
     /// ```
     pub fn get_tensor(&self, name: &str) -> PyResult<PyObject> {
-        let tensors = self.metadata.tensors();
-        let info = tensors.get(name).ok_or_else(|| {
+        let info = self.metadata.info(name).ok_or_else(|| {
             SafetensorError::new_err(format!("File does not contain tensor {name}",))
         })?;
+        // let info = tensors.get(name).ok_or_else(|| {
+        //     SafetensorError::new_err(format!("File does not contain tensor {name}",))
+        // })?;
 
         match &self.storage.as_ref() {
             Storage::Mmap(mmap) => {

--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -514,6 +514,12 @@ impl Metadata {
     }
 
     /// Gives back the tensor metadata
+    pub fn info(&self, name: &str) -> Option<&TensorInfo> {
+        let index = self.index_map.get(name)?;
+        self.tensors.get(*index)
+    }
+
+    /// Gives back the tensor metadata
     pub fn tensors(&self) -> HashMap<String, &TensorInfo> {
         self.index_map
             .iter()


### PR DESCRIPTION
# What does this PR do?

This is a different approach from #362 but should fix the same issue in the same way.

This doesn't change any external python API, and makes every existing code faster (by just using the structurs smarter).
This is better IMO as it fixes every potential use for the `safe_open` method, whereas #362 introduces a new layer that has to be used in order to benefit (so only users of `safetensors.torch.load_file` would actually see the difference).

The crux of the problem was `Metadata::tensors` which is a method that creates a full `HashMap<String, String>` to access the tensors. The structure used to be exactly that and just give directly the structure to callers, therefore relatively free. But since, the structure was refactored into a `HashMap<String, usize>` and `Vec<TensorInfo>`.
The main reason for it, is that the `Vec` is intrinsically ordered, and we maintain the `data_offsets` ordered in order to get efficient comparison when checking for malformed files (with overlapping data_offsets).
It also helps in during the serialization where we already have those information sorted so we write them sorted into the JSON header.

Fixes #361
Potentially superseeds #362


<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue) or description of the problem this PR solves.