### PR TITLE
Fix/errors for some models including Mistral-7b and Flan-ul2

### DIFF
--- a/bindings/python/convert.py
+++ b/bindings/python/convert.py
@@ -162,7 +162,7 @@ def convert_multi(
     local_filenames.append(index)
 
     operations = [
-        CommitOperationAdd(path_in_repo=local.split("/")[-1], path_or_fileobj=local) for local in local_filenames
+        CommitOperationAdd(path_in_repo=os.path.basename(local), path_or_fileobj=local) for local in local_filenames
     ]
     errors: List[Tuple[str, "Exception"]] = []
 

--- a/bindings/python/convert.py
+++ b/bindings/python/convert.py
@@ -145,7 +145,6 @@ def convert_multi(
         sf_filename = rename(pt_filename)
         sf_filename = os.path.join(folder, sf_filename)
         convert_file(pt_filename, sf_filename, discard_names=discard_names)
-
         local_filenames.append(sf_filename)
 
     index = os.path.join(folder, "model.safetensors.index.json")

--- a/bindings/python/convert.py
+++ b/bindings/python/convert.py
@@ -146,12 +146,7 @@ def convert_multi(
         sf_filename = os.path.join(folder, sf_filename)
         convert_file(pt_filename, sf_filename, discard_names=discard_names)
 
-        if 'snapshots' in sf_filename.split(os.sep):
-            new_sf_path = os.path.join(folder, os.path.basename(sf_filename))
-            shutil.move(sf_filename, new_sf_path)
-            local_filenames.append(new_sf_path)
-        else:
-            local_filenames.append(sf_filename)
+        local_filenames.append(sf_filename)
 
     index = os.path.join(folder, "model.safetensors.index.json")
     with open(index, "w") as f:

--- a/bindings/python/convert.py
+++ b/bindings/python/convert.py
@@ -145,7 +145,13 @@ def convert_multi(
         sf_filename = rename(pt_filename)
         sf_filename = os.path.join(folder, sf_filename)
         convert_file(pt_filename, sf_filename, discard_names=discard_names)
-        local_filenames.append(sf_filename)
+
+        if 'snapshots' in sf_filename.split(os.sep):
+            new_sf_path = os.path.join(folder, os.path.basename(sf_filename))
+            shutil.move(sf_filename, new_sf_path)
+            local_filenames.append(new_sf_path)
+        else:
+            local_filenames.append(sf_filename)
 
     index = os.path.join(folder, "model.safetensors.index.json")
     with open(index, "w") as f:


### PR DESCRIPTION
 * Use os.path.basename for all OS compatibility including Windows. 
 * Identify if the hub has downloaded to a snapshots subfolder and move to root directory before committing so that commits work.