### PR TITLE
Implement PyTorch support for float8 types (F8_E5M2 and F8_E4M3)

### DIFF
--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -349,6 +349,8 @@ _SIZE = {
     torch.int8: 1,
     torch.bool: 1,
     torch.float64: 8,
+    torch.float8_e4m3fn: 1,
+    torch.float8_e5m2: 1,
 }
 
 _TYPES = {
@@ -365,6 +367,8 @@ _TYPES = {
     "I8": torch.int8,
     "U8": torch.uint8,
     "BOOL": torch.bool,
+    "F8_E4M3": torch.float8_e4m3fn,
+    "F8_E5M2": torch.float8_e5m2,
 }
 
 
@@ -432,6 +436,9 @@ def _tobytes(tensor: torch.Tensor, name: str) -> bytes:
             torch.int8: np.int8,
             torch.bool: bool,
             torch.float64: np.float64,
+            # XXX: This is ok because both have the same width and byteswap is a no-op anyway
+            torch.float8_e4m3fn: np.uint8,
+            torch.float8_e5m2: np.uint8,
         }
         npdtype = NPDTYPES[tensor.dtype]
         # Not in place as that would potentially modify a live running model

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -48,6 +48,8 @@ fn prepare(tensor_dict: HashMap<String, &PyDict>) -> PyResult<HashMap<String, Te
                         "float32" => Some(Dtype::F32),
                         "float64" => Some(Dtype::F64),
                         "bfloat16" => Some(Dtype::BF16),
+                        "float8_e4m3fn" => Some(Dtype::F8_E4M3),
+                        "float8_e5m2" => Some(Dtype::F8_E5M2),
                         dtype_str => {
                             return Err(SafetensorError::new_err(format!(
                                 "dtype {dtype_str} is not covered",
@@ -1002,6 +1004,8 @@ fn get_pydtype(module: &PyModule, dtype: Dtype, is_numpy: bool) -> PyResult<PyOb
                     module.getattr(intern!(py, "bool"))?.into()
                 }
             }
+            Dtype::F8_E4M3 => module.getattr(intern!(py, "float8_e4m3fn"))?.into(),
+            Dtype::F8_E5M2 => module.getattr(intern!(py, "float8_e5m2"))?.into(),
             dtype => {
                 return Err(SafetensorError::new_err(format!(
                     "Dtype not understood: {dtype:?}"

--- a/bindings/python/tests/test_pt_comparison.py
+++ b/bindings/python/tests/test_pt_comparison.py
@@ -64,6 +64,21 @@ class TorchTestCase(unittest.TestCase):
         self.assertTrue(torch.equal(data["test2"], reloaded["test2"]))
         self.assertTrue(torch.equal(data["test3"], reloaded["test3"]))
 
+    def test_odd_dtype_fp8(self):
+        data = {
+            "test1": torch.tensor([-0.5], dtype=torch.float8_e4m3fn),
+            "test2": torch.tensor([-0.5], dtype=torch.float8_e5m2),
+        }
+        local = "./tests/data/out_safe_pt_mmap_small.safetensors"
+
+        save_file(data, local)
+        reloaded = load_file(local)
+        # note: PyTorch doesn't implement torch.equal for float8 so we just compare the single element
+        self.assertEqual(data["test1"].dtype, torch.float8_e4m3fn)
+        self.assertEqual(data["test1"].item(), -0.5)
+        self.assertEqual(data["test2"].dtype, torch.float8_e5m2)
+        self.assertEqual(data["test2"].item(), -0.5)
+
     def test_zero_sized(self):
         data = {
             "test": torch.zeros((2, 0), dtype=torch.float),


### PR DESCRIPTION
This PR completes support for float8 types by making them available when using safetensors from Python with PyTorch; float8 types are supported by PyTorch since July (https://github.com/pytorch/pytorch/pull/104242).

Note that PyTorch name for e4m3 type has an extra "fn" prefix to match MLIR, but the format should be the same ("fn" means "finite").

The added test checks that -0.5 roundtrips in both formats - both types are single-byte and have the same representation for zero, but different representations for -0.5.