### PR TITLE
use BTreeMap to preserve metadata dict order

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -16,6 +16,7 @@ use std::iter::FromIterator;
 use std::ops::Bound;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::collections::BTreeMap;
 
 static TORCH_MODULE: GILOnceCell<Py<PyModule>> = GILOnceCell::new();
 static NUMPY_MODULE: GILOnceCell<Py<PyModule>> = GILOnceCell::new();
@@ -92,10 +93,10 @@ fn prepare(tensor_dict: HashMap<String, &PyDict>) -> PyResult<HashMap<String, Te
 fn serialize<'b>(
     py: Python<'b>,
     tensor_dict: HashMap<String, &PyDict>,
-    metadata: Option<HashMap<String, String>>,
+    metadata: Option<BTreeMap<String, String>>,
 ) -> PyResult<&'b PyBytes> {
     let tensors = prepare(tensor_dict)?;
-    let metadata_map = metadata.map(HashMap::from_iter);
+    let metadata_map = metadata.map(BTreeMap::from_iter);
     let out = safetensors::tensor::serialize(&tensors, &metadata_map)
         .map_err(|e| SafetensorError::new_err(format!("Error while serializing: {e:?}")))?;
     let pybytes = PyBytes::new(py, &out);
@@ -121,7 +122,7 @@ fn serialize<'b>(
 fn serialize_file(
     tensor_dict: HashMap<String, &PyDict>,
     filename: PathBuf,
-    metadata: Option<HashMap<String, String>>,
+    metadata: Option<BTreeMap<String, String>>,
 ) -> PyResult<()> {
     let tensors = prepare(tensor_dict)?;
     safetensors::tensor::serialize_to_file(&tensors, &metadata, filename.as_path())
@@ -432,7 +433,7 @@ impl Open {
     /// Returns:
     ///     (`Dict[str, str]`):
     ///         The freeform metadata.
-    pub fn metadata(&self) -> Option<HashMap<String, String>> {
+    pub fn metadata(&self) -> Option<BTreeMap<String, String>> {
         self.metadata.metadata().clone()
     }
 
@@ -636,7 +637,7 @@ impl safe_open {
     /// Returns:
     ///     (`Dict[str, str]`):
     ///         The freeform metadata.
-    pub fn metadata(&self) -> PyResult<Option<HashMap<String, String>>> {
+    pub fn metadata(&self) -> PyResult<Option<BTreeMap<String, String>>> {
         Ok(self.inner()?.metadata())
     }
 

--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
+use std::collections::BTreeMap;
 
 const MAX_HEADER_SIZE: usize = 100_000_000;
 
@@ -166,7 +167,7 @@ pub trait View {
 
 fn prepare<S: AsRef<str> + Ord + std::fmt::Display, V: View, I: IntoIterator<Item = (S, V)>>(
     data: I,
-    data_info: &Option<HashMap<String, String>>,
+    data_info: &Option<BTreeMap<String, String>>,
     // ) -> Result<(Metadata, Vec<&'hash TensorView<'data>>, usize), SafeTensorError> {
 ) -> Result<(PreparedData, Vec<V>), SafeTensorError> {
     // Make sure we're sorting by descending dtype alignment
@@ -217,7 +218,7 @@ pub fn serialize<
     I: IntoIterator<Item = (S, V)>,
 >(
     data: I,
-    data_info: &Option<HashMap<String, String>>,
+    data_info: &Option<BTreeMap<String, String>>,
 ) -> Result<Vec<u8>, SafeTensorError> {
     let (
         PreparedData {
@@ -246,7 +247,7 @@ pub fn serialize_to_file<
     I: IntoIterator<Item = (S, V)>,
 >(
     data: I,
-    data_info: &Option<HashMap<String, String>>,
+    data_info: &Option<BTreeMap<String, String>>,
     filename: &Path,
 ) -> Result<(), SafeTensorError> {
     let (
@@ -405,7 +406,7 @@ impl<'data> SafeTensors<'data> {
 /// indexing into the raw byte-buffer array and how to interpret it.
 #[derive(Debug, Clone)]
 pub struct Metadata {
-    metadata: Option<HashMap<String, String>>,
+    metadata: Option<BTreeMap<String, String>>,
     tensors: Vec<TensorInfo>,
     index_map: HashMap<String, usize>,
 }
@@ -415,7 +416,7 @@ pub struct Metadata {
 struct HashMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "__metadata__")]
-    metadata: Option<HashMap<String, String>>,
+    metadata: Option<BTreeMap<String, String>>,
     #[serde(flatten)]
     tensors: HashMap<String, TensorInfo>,
 }
@@ -461,7 +462,7 @@ impl Serialize for Metadata {
 
 impl Metadata {
     fn new(
-        metadata: Option<HashMap<String, String>>,
+        metadata: Option<BTreeMap<String, String>>,
         tensors: Vec<(String, TensorInfo)>,
     ) -> Result<Self, SafeTensorError> {
         let mut index_map = HashMap::with_capacity(tensors.len());
@@ -528,7 +529,7 @@ impl Metadata {
     }
 
     /// Gives back the tensor metadata
-    pub fn metadata(&self) -> &Option<HashMap<String, String>> {
+    pub fn metadata(&self) -> &Option<BTreeMap<String, String>> {
         &self.metadata
     }
 }


### PR DESCRIPTION
# What does this PR do?

use `BTreeMap` to preserve metadata dict order to get a reproducible hash (or after in-memory hashing) of a given safetensors after saving.

(without metadata, the hash of the stored safetensors is always the same. but with metadata, the hash is not always reproducible.)

(rebased. reopened manually. PR #386