### PR TITLE
Add "xpu" device tag to the device list to support Intel GPU

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -221,6 +221,7 @@ enum Device {
     Cuda(usize),
     Mps,
     Npu(usize),
+    Xpu(usize),
 }
 
 impl<'source> FromPyObject<'source> for Device {
@@ -231,6 +232,7 @@ impl<'source> FromPyObject<'source> for Device {
                 "cuda" => Ok(Device::Cuda(0)),
                 "mps" => Ok(Device::Mps),
                 "npu" => Ok(Device::Npu(0)),
+                "xpu" => Ok(Device::Xpu(0)),
                 name if name.starts_with("cuda:") => {
                     let tokens: Vec<_> = name.split(':').collect();
                     if tokens.len() == 2 {
@@ -253,6 +255,17 @@ impl<'source> FromPyObject<'source> for Device {
                         )))
                     }
                 }
+                name if name.starts_with("xpu:") => {
+                  let tokens: Vec<_> = name.split(':').collect();
+                  if tokens.len() == 2 {
+                      let device: usize = tokens[1].parse()?;
+                      Ok(Device::Xpu(device))
+                  } else {
+                      Err(SafetensorError::new_err(format!(
+                          "device {name} is invalid"
+                      )))
+                  }
+                }
                 name => Err(SafetensorError::new_err(format!(
                     "device {name} is invalid"
                 ))),
@@ -272,6 +285,7 @@ impl IntoPy<PyObject> for Device {
             Device::Cuda(n) => format!("cuda:{n}").into_py(py),
             Device::Mps => "mps".into_py(py),
             Device::Npu(n) => format!("npu:{n}").into_py(py),
+            Device::Xpu(n) => format!("xpu:{n}").into_py(py),
         }
     }
 }


### PR DESCRIPTION
# What does this PR do?

"xpu" is the PyTorch device for Intel GPU and is currently supported by Intel Extension for PyTorch (or IPEX for short, https://github.com/intel/intel-extension-for-pytorch). This PR adds the "xpu" device tag into the device support list of safetensors so that the XPU safetensors can be loaded without problem.