### PR TITLE
[docs, untested] Attempt to fix links to source

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -16,6 +16,7 @@ jobs:
       package: safetensors
       notebook_folder: safetensors_doc
       package_path: safetensors/bindings/python/
+      version_tag_suffix: bindings/python/py_src
       install_rust: true
     secrets:
       token: ${{ secrets.HUGGINGFACE_PUSH }}

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -18,4 +18,5 @@ jobs:
       pr_number: ${{ github.event.number }}
       package: safetensors
       package_path: safetensors/bindings/python/
+      version_tag_suffix: bindings/python/py_src
       install_rust: true


### PR DESCRIPTION
# What does this PR do?

The functions in [this page](https://huggingface.co/docs/safetensors/api/torch) link to something like:
https://github.com/huggingface/safetensors/blob/main/src/safetensors/torch.py#L284 (which does not exist), however
https://github.com/huggingface/safetensors/blob/main/bindings/python/py_src/safetensors/torch.py#L284 does.

Looking at https://github.com/huggingface/doc-builder/blob/bc09a535b7ed1ccd1b57b59ccc0584a286fc3397/.github/workflows/build_main_documentation.yml#L159C38-L159C38 I see `version_tag_suffix` being used and accepted [here](https://github.com/huggingface/doc-builder/blob/bc09a535b7ed1ccd1b57b59ccc0584a286fc3397/.github/workflows/build_main_documentation.yml#L42).

I tried to test locally but `--version_tag_suffix` was not accepted, so I may still be missing something.

cc @mishig25