### PR TITLE
[docs] Use `hfoptions` for metadata

### DIFF
--- a/docs/source/metadata_parsing.mdx
+++ b/docs/source/metadata_parsing.mdx
@@ -23,7 +23,7 @@ There can be many potential use cases. For instance, we use it on the HuggingFac
 <hfoptions id="metadata">
 
 <hfoption id="http">
-From [🤗 Hub](hf.co/models), you can get metadata of a model with [HTTP range requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) instead of downloading the entire safetensors file with all the weights. In this example python script example (you can use any language that has HTTP requests support), we are parsing metadata of [gpt2](https://huggingface.co/gpt2/blob/main/model.safetensors). 
+From [🤗 Hub](hf.co/models), you can get metadata of a model with [HTTP range requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) instead of downloading the entire safetensors file with all the weights. In this example python script below (you can use any language that has HTTP requests support), we are parsing metadata of [gpt2](https://huggingface.co/gpt2/blob/main/model.safetensors). 
 
 ```python
 import requests # pip install requests

--- a/docs/source/metadata_parsing.mdx
+++ b/docs/source/metadata_parsing.mdx
@@ -20,8 +20,45 @@ There can be many potential use cases. For instance, we use it on the HuggingFac
 
 ## Usage
 
-### JavaScript/TypeScript[[js]]
+<hfoptions id="metadata">
 
+<hfoption id="http">
+From [🤗 Hub](hf.co/models), you can get metadata of a model with [HTTP range requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) instead of downloading the entire safetensors file with all the weights. In this example python script example (you can use any language that has HTTP requests support), we are parsing metadata of [gpt2](https://huggingface.co/gpt2/blob/main/model.safetensors). 
+
+```python
+import requests # pip install requests
+import struct
+
+def parse_single_file(url):
+    # Fetch the first 8 bytes of the file
+    headers = {'Range': 'bytes=0-7'}
+    response = requests.get(url, headers=headers)
+    # Interpret the bytes as a little-endian unsigned 64-bit integer
+    length_of_header = struct.unpack('<Q', response.content)[0]
+    # Fetch length_of_header bytes starting from the 9th byte
+    headers = {'Range': f'bytes=8-{7 + length_of_header}'}
+    response = requests.get(url, headers=headers)
+    # Interpret the response as a JSON object
+    header = response.json()
+    return header
+
+url = "https://huggingface.co/gpt2/resolve/main/model.safetensors"
+header = parse_single_file(url)
+
+print(header)
+# {
+#   "__metadata__": { "format": "pt" },
+#   "h.10.ln_1.weight": {
+#     "dtype": "F32",
+#     "shape": [768],
+#     "data_offsets": [223154176, 223157248]
+#   },
+#   ...
+# }
+```
+</hfoption>
+
+<hfoption id="javascript">
 Using [`huggingface.js`](https://huggingface.co/docs/huggingface.js)
 
 ```ts
@@ -87,11 +124,10 @@ interface SafetensorsIndexJson {
 }
 
 export type SafetensorsShardedHeaders = Record<FileName, SafetensorsFileHeader>;
-
 ```
+</hfoption>
 
-### Python
-
+<hfoption id="python">
 [`huggingface_hub`](https://huggingface.co/docs/huggingface_hub) provides a Python API to parse safetensors metadata.
 Use [`get_safetensors_metadata`](https://huggingface.co/docs/huggingface_hub/package_reference/hf_api#huggingface_hub.HfApi.get_safetensors_metadata) to get all safetensors metadata of a model.
 Depending on if the model is sharded or not, one or multiple safetensors files will be parsed.
@@ -125,7 +161,9 @@ NotASafetensorsRepoError: 'runwayml/stable-diffusion-v1-5' is not a safetensors 
 ```
 
 To parse the metadata of a single safetensors file, use [`parse_safetensors_file_metadata`](https://huggingface.co/docs/huggingface_hub/package_reference/hf_api#huggingface_hub.HfApi.parse_safetensors_file_metadata).
+</hfoption>
 
+</hfoptions>
 
 ## Example output
 


### PR DESCRIPTION
Based on [this comment](https://github.com/huggingface/safetensors/pull/417/files#r1442176507), bringing back the example on how to use http range requests to get metadata. Also, using [hfoptions](https://github.com/huggingface/doc-builder?tab=readme-ov-file#options) syntax for better UI/UX

you can test the page here: https://moon-ci-docs.huggingface.co/docs/safetensors/pr_424/en/metadata_parsing#usage

https://github.com/huggingface/safetensors/assets/11827707/53edac7e-5bfe-43b6-a158-a026d7540ac3

