### PR TITLE
Pass device=cpu to torch.asarray() in get_tensor()

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -512,7 +512,7 @@ impl Open {
                     let torch = get_module(py, &TORCH_MODULE)?;
                     let dtype: PyObject = get_pydtype(torch, info.dtype, false)?;
                     let torch_uint8: PyObject = get_pydtype(torch, Dtype::U8, false)?;
-                    let kwargs = [(intern!(py, "dtype"), torch_uint8)].into_py_dict(py);
+                    let kwargs = [(intern!(py, "dtype"), torch_uint8),(intern!(py, "device"), "cpu".into_py(py))].into_py_dict(py);
                     let view_kwargs = [(intern!(py, "dtype"), dtype)].into_py_dict(py);
                     let shape = info.shape.to_vec();
                     let shape: PyObject = shape.into_py(py);


### PR DESCRIPTION
The code in get_tensor assumes that torch.asarray will always load the tensor in cpu, and then the tensor is copied to self.device in the "to" call at the end of the function. However, that assumption is not always correct. To make sure, device=cpu has to be passed to asarray.

Another option would be to set the final device since the beginning:
```
let device = match self.device {
    Device::Cpu     => format!("cpu"),
    Device::Cuda(n) => format!("cuda:{n}"),
    Device::Mps     => format!("mps"),
    Device::Npu(n)  => format!("npu:{n}"),
    Device::Xpu(n)  => format!("xpu:{n}"),
}.into_py(py);

let kwargs = [(intern!(py, "dtype"), torch_uint8),(intern!(py, "device"), device)].into_py_dict(py);
```
but I'm not sure what the implications of that would be.

Fixes issue #437 