### PR TITLE
Update convert.py to fix ToB finding TOB-SFTN-8

### DIFF
--- a/bindings/python/convert.py
+++ b/bindings/python/convert.py
@@ -183,7 +183,7 @@ def convert_file(
     sf_filename: str,
     discard_names: List[str],
 ):
-    loaded = torch.load(pt_filename, map_location="cpu")
+    loaded = torch.load(pt_filename, map_location="cpu", weights_only=True)
     if "state_dict" in loaded:
         loaded = loaded["state_dict"]
     to_removes = _remove_duplicate_names(loaded, discard_names=discard_names)


### PR DESCRIPTION
" PyTorch conversion utility is vulnerable to arbitrary code execution"

# What does this PR do?

When the method’s weights_only parameter is not set to True, which means that
the pickle module is used to load the model in an unrestricted fashion.
The fix is in place here https://huggingface.co/spaces/safetensors/convert/commit/d63c3cd44470d3bd6f41a9c919c5453d12532f15#d2h-206692

but not here. 

Fixes # (issue) or description of the problem this PR solves.
fix ToB finding TOB-SFTN-8