### PR TITLE
Fix byteswap for BF16 tensor on big-endian machine

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -573,7 +573,7 @@ impl Open {
                         .getattr(intern!(py, "asarray"))?
                         .call((storage_slice,), Some(&kwargs))?
                         .getattr(intern!(py, "view"))?
-                        .call((), Some(view_kwargs))?
+                        .call((), Some(&view_kwargs))?
                         .getattr(intern!(py, "reshape"))?
                         .call1((shape,))?;
                     if self.device != Device::Cpu {
@@ -916,7 +916,7 @@ impl PySafeSlice {
                     .getattr(intern!(py, "asarray"))?
                     .call((storage_slice,), Some(&kwargs))?
                     .getattr(intern!(py, "view"))?
-                    .call((), Some(view_kwargs))?
+                    .call((), Some(&view_kwargs))?
                     .getattr(intern!(py, "reshape"))?
                     .call1((shape,))?
                     .getattr(intern!(py, "__getitem__"))?

--- a/bindings/python/tests/test_pt_model.py
+++ b/bindings/python/tests/test_pt_model.py
@@ -171,6 +171,19 @@ class TorchModelTestCase(unittest.TestCase):
         for k, v in model2.state_dict().items():
             torch.testing.assert_close(v, state_dict[k])
 
+        # test tensors in bfloat16
+        model = OnesModel()
+        for k, v in model2.state_dict().items():
+            v = v.to(torch.bfloat16)
+        save_model(model, "tmp_ones_bf16.safetensors")
+
+        model2 = OnesModel()
+        load_model(model2, "tmp_ones_bf16.safetensors")
+
+        state_dict = model.state_dict()
+        for k, v in model2.state_dict().items():
+            torch.testing.assert_close(v, state_dict[k])
+
     def test_workaround(self):
         model = Model()
         save_model(model, "tmp.safetensors")


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

This PR fixes an incorrect Tensor's data swap in BF16 on a big-endian machine. It uses `Storage.byteswap(datatype)` in PyTorch instead of `numpy.byteswap()`. This is because numpy does not support BF16. Unnecessary data conversions between BF16 and F16 caused incorrect results.

<!-- Remove if not applicable -->

Fixes #448 
