### PR TITLE
Update convert.py to allow local (default) cache to be used

### DIFF
--- a/bindings/python/convert.py
+++ b/bindings/python/convert.py
@@ -88,7 +88,7 @@ def get_discard_names(model_id: str, revision: Optional[str], folder: str, token
         import transformers
 
         config_filename = hf_hub_download(
-            model_id, revision=revision, filename="config.json", token=token, cache_dir=folder
+            model_id, revision=revision, filename="config.json", token=token,
         )
         with open(config_filename, "r") as f:
             config = json.load(f)
@@ -132,7 +132,7 @@ def convert_multi(
     model_id: str, *, revision=Optional[str], folder: str, token: Optional[str], discard_names: List[str]
 ) -> ConversionResult:
     filename = hf_hub_download(
-        repo_id=model_id, revision=revision, filename="pytorch_model.bin.index.json", token=token, cache_dir=folder
+        repo_id=model_id, revision=revision, filename="pytorch_model.bin.index.json", token=token, 
     )
     with open(filename, "r") as f:
         data = json.load(f)
@@ -140,7 +140,7 @@ def convert_multi(
     filenames = set(data["weight_map"].values())
     local_filenames = []
     for filename in filenames:
-        pt_filename = hf_hub_download(repo_id=model_id, filename=filename, token=token, cache_dir=folder)
+        pt_filename = hf_hub_download(repo_id=model_id, filename=filename, token=token, )
 
         sf_filename = rename(pt_filename)
         sf_filename = os.path.join(folder, sf_filename)
@@ -167,7 +167,7 @@ def convert_single(
     model_id: str, *, revision: Optional[str], folder: str, token: Optional[str], discard_names: List[str]
 ) -> ConversionResult:
     pt_filename = hf_hub_download(
-        repo_id=model_id, revision=revision, filename="pytorch_model.bin", token=token, cache_dir=folder
+        repo_id=model_id, revision=revision, filename="pytorch_model.bin", token=token, 
     )
 
     sf_name = "model.safetensors"
@@ -251,7 +251,7 @@ def convert_generic(
         prefix, ext = os.path.splitext(filename)
         if ext in extensions:
             pt_filename = hf_hub_download(
-                model_id, revision=revision, filename=filename, token=token, cache_dir=folder
+                model_id, revision=revision, filename=filename, token=token, 
             )
             dirname, raw_filename = os.path.split(filename)
             if raw_filename == "pytorch_model.bin":


### PR DESCRIPTION
Remove cache_dir completely from hf_hub_download() calls in convert.py so that local cached files can be used still.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

In current state, the .bin files are re-downloaded from the hub even if they exist in local cache to a TemporaryDirectory() that is deleted when the process finishes. By removing the cache_dir argument in hf_hub_download, the default settings take over and the local cache is used.

Arguably, we should expect that the safetensors files persist locally if we are converting them intentionally. It ends up saving them to the local cache directory (in the same tree structure), just not as symlinked blobs. 
