### PR TITLE
docs: fix all typos

### DIFF
--- a/attacks/README.md
+++ b/attacks/README.md
@@ -57,7 +57,7 @@ A few things can be abused:
                 file a few megs tops, but defining many tensors on the same overlapping part of the file, it was essentially a DOS attack. The mitigation is rather simple, we sanitize the fact
                 that the offsets must be contiguous and non overlapping.
 - Proposal 5: The offsets could mismatch the declared shapes + dtype. This validated against.
-- Proposal 6: The file being mmaped could be modified while it's opened (attacker has access to your filesystem, seems like you're already pwned).
+- Proposal 6: The file being mapped could be modified while it's opened (attacker has access to your filesystem, seems like you're already pwned).
 - Proposal 7: serde JSON deserialization abuse (nothing so far: https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=serde). It doesn't mean there isn't a flaw. Same goes for the actual rust compiled binary.
 
 ```

--- a/bindings/python/convert.py
+++ b/bindings/python/convert.py
@@ -63,7 +63,7 @@ def _remove_duplicate_names(
 
         keep_name = sorted(list(complete_names))[0]
 
-        # Mecanism to preferentially select keys to keep
+        # Mechanism to preferentially select keys to keep
         # coming from the on-disk file to allow
         # loading models saved with a different choice
         # of keep_name
@@ -96,7 +96,7 @@ def get_discard_names(model_id: str, revision: Optional[str], folder: str, token
 
         class_ = getattr(transformers, architecture)
 
-        # Name for this varible depends on transformers version.
+        # Name for this variable depends on transformers version.
         discard_names = getattr(class_, "_tied_weights_keys", [])
 
     except Exception:

--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -185,7 +185,7 @@ def load_model(model: torch.nn.Module, filename: Union[str, os.PathLike], strict
         filename (`str`, or `os.PathLike`):
             The filename location to load the file from.
         strict (`bool`, *optional*, defaults to True):
-            Wether to fail if you're missing keys or having unexpected ones
+            Whether to fail if you're missing keys or having unexpected ones
             When false, the function simply returns missing and unexpected names.
 
     Returns:

--- a/bindings/python/stub.py
+++ b/bindings/python/stub.py
@@ -101,7 +101,7 @@ def pyi_file(obj, indent=""):
         string += function(obj, indent)
 
     elif inspect.isgetsetdescriptor(obj):
-        # TODO it would be interesing to add the setter maybe ?
+        # TODO it would be interesting to add the setter maybe ?
         string += f"{indent}@property\n"
         string += function(obj, indent, text_signature="(self)")
     else:

--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -210,7 +210,7 @@ fn prepare<S: AsRef<str> + Ord + std::fmt::Display, V: View, I: IntoIterator<Ite
     ))
 }
 
-/// Serialize to an owned byte buffer the dictionnary of tensors.
+/// Serialize to an owned byte buffer the dictionary of tensors.
 pub fn serialize<
     S: AsRef<str> + Ord + std::fmt::Display,
     V: View,
@@ -237,7 +237,7 @@ pub fn serialize<
     Ok(buffer)
 }
 
-/// Serialize to a regular file the dictionnary of tensors.
+/// Serialize to a regular file the dictionary of tensors.
 /// Writing directly to file reduces the need to allocate the whole amount to
 /// memory.
 pub fn serialize_to_file<
@@ -401,7 +401,7 @@ impl<'data> SafeTensors<'data> {
     }
 }
 
-/// The stuct representing the header of safetensor files which allow
+/// The struct representing the header of safetensor files which allow
 /// indexing into the raw byte-buffer array and how to interpret it.
 #[derive(Debug, Clone)]
 pub struct Metadata {
@@ -635,7 +635,7 @@ pub struct TensorInfo {
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
 #[non_exhaustive]
 pub enum Dtype {
-    /// Boolan type
+    /// Boolean type
     BOOL,
     /// Unsigned byte
     U8,
@@ -834,7 +834,7 @@ mod tests {
     }
 
     #[test]
-    fn test_serialization_forced_alignement() {
+    fn test_serialization_forced_alignment() {
         let data: Vec<u8> = vec![0.0f32, 1.0, 2.0, 3.0, 4.0, 5.0]
             .into_iter()
             .flat_map(|f| f.to_le_bytes())
@@ -852,7 +852,7 @@ mod tests {
                 72, 0, 0, 0, 0, 0, 0, 0, 123, 34, 97, 116, 116, 110, 48, 34, 58, 123, 34, 100, 116,
                 121, 112, 101, 34, 58, 34, 70, 51, 50, 34, 44, 34, 115, 104, 97, 112, 101, 34, 58,
                 91, 49, 44, 49, 44, 50, 44, 51, 93, 44, 34, 100, 97, 116, 97, 95, 111, 102, 102,
-                // All the 32 are forcing alignement of the tensor data for casting to f32, f64
+                // All the 32 are forcing alignment of the tensor data for casting to f32, f64
                 // etc..
                 115, 101, 116, 115, 34, 58, 91, 48, 44, 50, 52, 93, 125, 125, 32, 32, 32, 32, 32,
                 32, 32, 0, 0, 0, 0, 0, 0, 128, 63, 0, 0, 0, 64, 0, 0, 64, 64, 0, 0, 128, 64, 0, 0,


### PR DESCRIPTION
Fixes all typos with [crate-ci/typos](https://github.com/crate-ci/typos)