### PR TITLE
support for Cambricon MLUs device

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -244,6 +244,7 @@ enum Device {
     Cuda(usize),
     Mps,
     Npu(usize),
+    Mlu(usize),
     Xpu(usize),
 }
 
@@ -255,6 +256,7 @@ impl<'source> FromPyObject<'source> for Device {
                 "cuda" => Ok(Device::Cuda(0)),
                 "mps" => Ok(Device::Mps),
                 "npu" => Ok(Device::Npu(0)),
+                "mlu" => Ok(Device::Mlu(0)),
                 "xpu" => Ok(Device::Xpu(0)),
                 name if name.starts_with("cuda:") => {
                     let tokens: Vec<_> = name.split(':').collect();
@@ -272,6 +274,17 @@ impl<'source> FromPyObject<'source> for Device {
                     if tokens.len() == 2 {
                         let device: usize = tokens[1].parse()?;
                         Ok(Device::Npu(device))
+                    } else {
+                        Err(SafetensorError::new_err(format!(
+                            "device {name} is invalid"
+                        )))
+                    }
+                }
+                name if name.starts_with("mlu:") => {
+                    let tokens: Vec<_> = name.split(':').collect();
+                    if tokens.len() == 2 {
+                        let device: usize = tokens[1].parse()?;
+                        Ok(Device::Mlu(device))
                     } else {
                         Err(SafetensorError::new_err(format!(
                             "device {name} is invalid"
@@ -308,6 +321,7 @@ impl IntoPy<PyObject> for Device {
             Device::Cuda(n) => format!("cuda:{n}").into_py(py),
             Device::Mps => "mps".into_py(py),
             Device::Npu(n) => format!("npu:{n}").into_py(py),
+            Device::Mlu(n) => format!("mlu:{n}").into_py(py),
             Device::Xpu(n) => format!("xpu:{n}").into_py(py),
         }
     }


### PR DESCRIPTION
Currently,Transformers and Accelerate have supported cambricon mlu (https://github.com/huggingface/transformers/pull/29627, https://github.com/huggingface/accelerate/pull/2552).

This PR enables users to leverage the cambricon mlu for training and inference with safetensors.