### PR TITLE
Add conversion validation support for the float8 tensor dtype 

### DIFF
--- a/bindings/python/convert.py
+++ b/bindings/python/convert.py
@@ -205,7 +205,7 @@ def convert_file(
     for k in loaded:
         pt_tensor = loaded[k]
         sf_tensor = reloaded[k]
-        if pt_tensor.dtype != sf_tensor.dtype or not torch.equal(pt_tensor.to(torch.float16), sf_tensor.to(torch.float16)):
+        if pt_tensor.dtype != sf_tensor.dtype or not torch.equal(pt_tensor.to(torch.float32), sf_tensor.to(torch.float32)):
             raise RuntimeError(f"The output tensors do not match for key {k}")
 
 

--- a/bindings/python/convert.py
+++ b/bindings/python/convert.py
@@ -205,7 +205,7 @@ def convert_file(
     for k in loaded:
         pt_tensor = loaded[k]
         sf_tensor = reloaded[k]
-        if not torch.equal(pt_tensor, sf_tensor):
+        if pt_tensor.dtype != sf_tensor.dtype or not torch.equal(pt_tensor.to(torch.float16), sf_tensor.to(torch.float16)):
             raise RuntimeError(f"The output tensors do not match for key {k}")
 
 


### PR DESCRIPTION
# What does this PR do?

Torch does not support `equal_cpu` for the torch.float8_e4m3fn or torch.float8_e5m2 dtypes so the convert script fails with errors like:

```bash
RuntimeError: "equal_cpu" not implemented for 'Float8_e4m3fn'
```

This PR changes the output tensor validation to check that the dtypes are the same and the float32 value of each tensor is equal instead. This should always succeed if the values are, even for new dtypes in the future.
