### PR TITLE
Adding support for wrapper tensor subclass for safetensor

### DIFF
--- a/bindings/python/tests/test_pt_model.py
+++ b/bindings/python/tests/test_pt_model.py
@@ -276,3 +276,15 @@ class TorchModelTestCase(unittest.TestCase):
             load_model(model2, "tmp3.safetensors")
         # Safetensors properly warns the user that some ke
         self.assertIn("""Unexpected key(s) in state_dict: "b.bias", "b.weight""", str(ctx.exception))
+
+    def test_wrapper_tensor_subclass(self):
+        from torch.testing._internal.two_tensor import TwoTensor
+
+        for model_cls in (NoSharedModel, OnesModel):
+            model = model_cls()
+            # Convert every parameter/buffer to a wrapper tensor subclass (TwoTensor)
+            model._apply(lambda t: TwoTensor(t, t))
+            save_model(model, "tmp_wrapper_tensor_subclass.safetensors")
+
+            model2 = cls()
+            load_model(model2)

--- a/bindings/python/tests/test_pt_model.py
+++ b/bindings/python/tests/test_pt_model.py
@@ -15,6 +15,17 @@ from safetensors.torch import (
 )
 
 
+# util functions for checking the version for pytorch
+def is_wrapper_tensor_subclass_available():
+    try:
+        from torch.testing._internal.two_tensor import TwoTensor  # noqa: F401
+        from torch.utils._python_dispatch import is_traceable_wrapper_subclass  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
 class OnesModel(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -277,6 +288,7 @@ class TorchModelTestCase(unittest.TestCase):
         # Safetensors properly warns the user that some ke
         self.assertIn("""Unexpected key(s) in state_dict: "b.bias", "b.weight""", str(ctx.exception))
 
+    @unittest.skipIf(not is_two_tensor_available(), "Need TwoTensor tensor subclass to be available")
     def test_wrapper_tensor_subclass(self):
         from torch.testing._internal.two_tensor import TwoTensor
 


### PR DESCRIPTION
Summary:
Similar to https://github.com/huggingface/huggingface_hub/pull/2440 we want to allow safetensor to handle wrapper tensor subclasses, we mainly added:

1. tensor storage size: this is done through flattening the wrapper tensor subclass and add up the storage size of all sub tensors recursively
2. storage_ptr: this is done by constructing a tuple given the "storage_ptr" for flattened tensors, this could be a nested tuple of tuple of int, e.g. ((1, 2), 3, (4, (5, 6),),)

Test Plan:
Added a test in test_pt_model.py, will also test manually

Reviewers:

Subscribers:

Tasks:

Tags:
