### PR TITLE
Add support for Cambricon mlu devices

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -266,6 +266,7 @@ enum Device {
     Npu(usize),
     Xpu(usize),
     Xla(usize),
+    Mlu(usize),
     /// User didn't specify acceletor, torch
     /// is responsible for choosing.
     Anonymous(usize),
@@ -294,10 +295,12 @@ impl<'source> FromPyObject<'source> for Device {
                 "npu" => Ok(Device::Npu(0)),
                 "xpu" => Ok(Device::Xpu(0)),
                 "xla" => Ok(Device::Xla(0)),
+                "mlu" => Ok(Device::Mlu(0)),
                 name if name.starts_with("cuda:") => parse_device(name).map(Device::Cuda),
                 name if name.starts_with("npu:") => parse_device(name).map(Device::Npu),
                 name if name.starts_with("xpu:") => parse_device(name).map(Device::Xpu),
                 name if name.starts_with("xla:") => parse_device(name).map(Device::Xla),
+                name if name.starts_with("mlu:") => parse_device(name).map(Device::Mlu),
                 name => Err(SafetensorError::new_err(format!(
                     "device {name} is invalid"
                 ))),
@@ -319,6 +322,7 @@ impl IntoPy<PyObject> for Device {
             Device::Npu(n) => format!("npu:{n}").into_py(py),
             Device::Xpu(n) => format!("xpu:{n}").into_py(py),
             Device::Xla(n) => format!("xla:{n}").into_py(py),
+            Device::Mlu(n) => format!("mlu:{n}").into_py(py),
             Device::Anonymous(n) => n.into_py(py),
         }
     }


### PR DESCRIPTION
# What does this PR do?

Add support for Cambricon mlu devices.

Transformers and Accelerate have supported cambricon mlu (https://github.com/huggingface/transformers/pull/29627, https://github.com/huggingface/accelerate/pull/2552).

This PR enables users to leverage the cambricon mlu for training and inference with safetensors.

Test code:
```
import torch
import torch_mlu
from safetensors.torch import save_file
from safetensors import safe_open

test = {"a": torch.tensor([1, 2, 3])}

save_file(test, 'test.safetensors')

with safe_open("test.safetensors", framework="pt", device="mlu") as f:
   for key in f.keys():
      print(f.get_tensor(key).device)
```
