### PR TITLE
support no_std

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,7 @@ jobs:
         run: cargo build --all-targets --verbose
 
       - name: Lint with Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
 
       - name: Run Tests
         run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Run Tests
         run: cargo test --verbose
 
+      - name: Run No-STD Tests
+        run: cargo test --no-default-features --features alloc --verbose
+
       - name: Run Audit
         # RUSTSEC-2021-0145 is criterion so only within benchmarks
         run: cargo audit -D warnings --ignore RUSTSEC-2021-0145

--- a/safetensors/Cargo.toml
+++ b/safetensors/Cargo.toml
@@ -21,13 +21,19 @@ exclude = [ "rust-toolchain", "target/*", "Cargo.lock"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = {version = "1.0", features = ["derive"]}
-serde_json = "1.0"
+hashbrown = { version = "0.15.2", features = ["serde"], optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde_json = { version = "1.0", default-features = false }
 
 [dev-dependencies]
 criterion = "0.5"
 memmap2 = "0.9"
 proptest = "1.4"
+
+[features]
+default = ["std"]
+std = ["serde/default", "serde_json/default"]
+alloc = ["serde/alloc", "serde_json/alloc", "hashbrown"]
 
 [[bench]]
 name = "benchmark"

--- a/safetensors/src/lib.rs
+++ b/safetensors/src/lib.rs
@@ -1,5 +1,43 @@
 #![deny(missing_docs)]
 #![doc = include_str!("../README.md")]
+#![cfg_attr(not(feature = "std"), no_std)]
 pub mod slice;
 pub mod tensor;
-pub use tensor::{serialize, serialize_to_file, Dtype, SafeTensorError, SafeTensors, View};
+/// serialize_to_file only valid in std
+#[cfg(feature = "std")]
+pub use tensor::serialize_to_file;
+pub use tensor::{serialize, Dtype, SafeTensorError, SafeTensors, View};
+
+#[cfg(feature = "alloc")]
+#[macro_use]
+extern crate alloc;
+
+#[cfg(all(feature = "std", feature = "alloc"))]
+compile_error!("must choose either the `std` or `alloc` feature, but not both.");
+#[cfg(all(not(feature = "std"), not(feature = "alloc")))]
+compile_error!("must choose either the `std` or `alloc` feature");
+
+/// A facade around all the types we need from the `std`, `core`, and `alloc`
+/// crates. This avoids elaborate import wrangling having to happen in every
+/// module.
+mod lib {
+    #[cfg(not(feature = "std"))]
+    mod no_stds {
+        pub use alloc::borrow::Cow;
+        pub use alloc::string::{String, ToString};
+        pub use alloc::vec::Vec;
+        pub use hashbrown::HashMap;
+    }
+    #[cfg(feature = "std")]
+    mod stds {
+        pub use std::borrow::Cow;
+        pub use std::collections::HashMap;
+        pub use std::string::{String, ToString};
+        pub use std::vec::Vec;
+    }
+    /// choose std or no_std to export by feature flag
+    #[cfg(not(feature = "std"))]
+    pub use no_stds::*;
+    #[cfg(feature = "std")]
+    pub use stds::*;
+}

--- a/safetensors/src/slice.rs
+++ b/safetensors/src/slice.rs
@@ -1,7 +1,7 @@
 //! Module handling lazy loading via iterating on slices on the original buffer.
+use crate::lib::{String, ToString, Vec};
 use crate::tensor::TensorView;
-use std::fmt;
-use std::ops::{
+use core::ops::{
     Bound, Range, RangeBounds, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
 };
 
@@ -40,8 +40,8 @@ fn display_bound(bound: &Bound<usize>) -> String {
 }
 
 /// Intended for Python users mostly or at least for its conventions
-impl fmt::Display for TensorIndexer {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl core::fmt::Display for TensorIndexer {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             TensorIndexer::Select(n) => {
                 write!(f, "{n}")
@@ -77,7 +77,7 @@ macro_rules! impl_from_range {
     ($range_type:ty) => {
         impl From<$range_type> for TensorIndexer {
             fn from(range: $range_type) -> Self {
-                use std::ops::Bound::*;
+                use core::ops::Bound::*;
 
                 let start = match range.start_bound() {
                     Included(idx) => Included(*idx),


### PR DESCRIPTION
# What does this PR do?

Fixes #544 
Core changes are:

1. add features: [`default`, `std`, `alloc`]: developers must choose either `std` or `alloc`, `default` to `std`
2. if no `std`: use `hashbrown::HashMap` as alternative to `std::collections::HashMap`
3. if no `std`: remove `IoError` from `Error` enum, and remove  `serialize_to_file`