### PR TITLE
Fix wrong signature of `safe_open.__init__`  in stub file

### DIFF
--- a/bindings/python/py_src/safetensors/__init__.pyi
+++ b/bindings/python/py_src/safetensors/__init__.pyi
@@ -69,7 +69,7 @@ class safe_open:
             The device on which you want the tensors.
     """
 
-    def __init__(filename, framework, device=...):
+    def __init__(self, filename, framework, device=...):
         pass
     def __enter__(self):
         """

--- a/bindings/python/stub.py
+++ b/bindings/python/stub.py
@@ -42,10 +42,7 @@ def fn_predicate(obj):
         return (
             obj.__doc__
             and obj.__text_signature__
-            and (
-                not obj.__name__.startswith("_")
-                or obj.__name__ in {"__enter__", "__exit__"}
-            )
+            and (not obj.__name__.startswith("_") or obj.__name__ in {"__enter__", "__exit__"})
         )
     if inspect.isgetsetdescriptor(obj):
         return obj.__doc__ and not obj.__name__.startswith("_")
@@ -81,15 +78,14 @@ def pyi_file(obj, indent=""):
 
         body = ""
         if obj.__doc__:
-            body += (
-                f'{indent}"""\n{indent}{do_indent(obj.__doc__, indent)}\n{indent}"""\n'
-            )
+            body += f'{indent}"""\n{indent}{do_indent(obj.__doc__, indent)}\n{indent}"""\n'
 
         fns = inspect.getmembers(obj, fn_predicate)
 
         # Init
         if obj.__text_signature__:
-            body += f"{indent}def __init__{obj.__text_signature__}:\n"
+            signature = obj.__text_signature__.replace("(", "(self, ")
+            body += f"{indent}def __init__{signature}:\n"
             body += f"{indent+INDENT}pass\n"
             body += "\n"
 
@@ -146,11 +142,7 @@ def do_black(content, is_pyi):
 
 
 def write(module, directory, origin, check=False):
-    submodules = [
-        (name, member)
-        for name, member in inspect.getmembers(module)
-        if inspect.ismodule(member)
-    ]
+    submodules = [(name, member) for name, member in inspect.getmembers(module) if inspect.ismodule(member)]
 
     filename = os.path.join(directory, "__init__.pyi")
     pyi_content = pyi_file(module)
@@ -159,9 +151,7 @@ def write(module, directory, origin, check=False):
     if check:
         with open(filename, "r") as f:
             data = f.read()
-            assert (
-                data == pyi_content
-            ), f"The content of {filename} seems outdated, please run `python stub.py`"
+            assert data == pyi_content, f"The content of {filename} seems outdated, please run `python stub.py`"
     else:
         with open(filename, "w") as f:
             f.write(pyi_content)
@@ -184,9 +174,7 @@ def write(module, directory, origin, check=False):
         if check:
             with open(filename, "r") as f:
                 data = f.read()
-                assert (
-                    data == py_content
-                ), f"The content of {filename} seems outdated, please run `python stub.py`"
+                assert data == py_content, f"The content of {filename} seems outdated, please run `python stub.py`"
         else:
             with open(filename, "w") as f:
                 f.write(py_content)


### PR DESCRIPTION
# What does this PR do?

First argument of `safe_open.__init__` (`self`) is omitted. So add it.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->
