### PR TITLE
Restore compatibility with Rust 1.74

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,11 +4,15 @@ on:
   pull_request:
 
 jobs:
-  build-stable:
+  build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        toolchain: [stable]
+        include:
+          - os: ubuntu-latest
+            toolchain: "1.74"
     defaults:
       run:
         working-directory: ./safetensors
@@ -59,28 +63,3 @@ jobs:
         #     token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
         #     working-directory: ./safetensors
         #     fail_ci_if_error: true
-
-  build-msrv:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./safetensors
-    env:
-      MSRV: "1.74"
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Install Rust ${{ env.MSRV }}
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ env.MSRV }}
-          override: true
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Build
-        run: cargo build --all-targets --verbose
-
-      - name: Run Tests
-        run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  build-stable:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -59,3 +59,28 @@ jobs:
         #     token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
         #     working-directory: ./safetensors
         #     fail_ci_if_error: true
+
+  build-msrv:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./safetensors
+    env:
+      MSRV: "1.74"
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust ${{ env.MSRV }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.MSRV }}
+          override: true
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build --all-targets --verbose
+
+      - name: Run Tests
+        run: cargo test --verbose

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -2,6 +2,7 @@
 name = "safetensors-python"
 version = "0.5.3-dev.0"
 edition = "2021"
+rust-version = "1.74"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/safetensors/Cargo.toml
+++ b/safetensors/Cargo.toml
@@ -2,6 +2,7 @@
 name = "safetensors"
 version = "0.5.3-dev.0"
 edition = "2021"
+rust-version = "1.74"
 homepage = "https://github.com/huggingface/safetensors"
 repository = "https://github.com/huggingface/safetensors"
 documentation = "https://docs.rs/safetensors/"

--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -64,7 +64,11 @@ impl core::fmt::Display for SafeTensorError {
     }
 }
 
+#[cfg(not(feature = "std"))]
 impl core::error::Error for SafeTensorError {}
+
+#[cfg(feature = "std")]
+impl std::error::Error for SafeTensorError {}
 
 struct PreparedData {
     n: u64,


### PR DESCRIPTION
# What does this PR do?

PR #544 added support for `no_std` feature. The PR changed `std::error::Error` to `core::error::Error`. The `core::error` trait was stabilized in Rust 1.81, so the change bumped MSRV to 1.81. Before the Python package built with Rust 1.66 and the `safetensors` create with all features built with 1.74.

This commit restores compatibility with Rust 1.74 for `std` builds:

- `mixed_integer_ops` feature requires 1.66
- `half v2.4.1` requires 1.70
- `clap_lex v0.7.4` requires 1.74

I'm also adding `rust-version` to `Cargo.toml`, so cargo creates a backwards compatible `Cargo.lock`. By default, Cargo >= 1.83 creates a `v4` lock file, which is not compatible with Cargo < 1.78.