### PR TITLE
load_file: load tensors ordered by their offsets

### DIFF
--- a/bindings/python/py_src/safetensors/flax.py
+++ b/bindings/python/py_src/safetensors/flax.py
@@ -121,7 +121,7 @@ def load_file(filename: Union[str, os.PathLike]) -> Dict[str, Array]:
     """
     result = {}
     with safe_open(filename, framework="flax") as f:
-        for k in f.keys():
+        for k in f.offset_keys():
             result[k] = f.get_tensor(k)
     return result
 

--- a/bindings/python/py_src/safetensors/mlx.py
+++ b/bindings/python/py_src/safetensors/mlx.py
@@ -120,7 +120,7 @@ def load_file(filename: Union[str, os.PathLike]) -> Dict[str, mx.array]:
     """
     result = {}
     with safe_open(filename, framework="mlx") as f:
-        for k in f.keys():
+        for k in f.offset_keys():
             result[k] = f.get_tensor(k)
     return result
 

--- a/bindings/python/py_src/safetensors/numpy.py
+++ b/bindings/python/py_src/safetensors/numpy.py
@@ -126,7 +126,7 @@ def load_file(filename: Union[str, os.PathLike]) -> Dict[str, np.ndarray]:
     """
     result = {}
     with safe_open(filename, framework="np") as f:
-        for k in f.keys():
+        for k in f.offset_keys():
             result[k] = f.get_tensor(k)
     return result
 

--- a/bindings/python/py_src/safetensors/tensorflow.py
+++ b/bindings/python/py_src/safetensors/tensorflow.py
@@ -120,7 +120,7 @@ def load_file(filename: Union[str, os.PathLike]) -> Dict[str, tf.Tensor]:
     """
     result = {}
     with safe_open(filename, framework="tf") as f:
-        for k in f.keys():
+        for k in f.offset_keys():
             result[k] = f.get_tensor(k)
     return result
 

--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -317,7 +317,7 @@ def load_file(filename: Union[str, os.PathLike], device: Union[str, int] = "cpu"
     """
     result = {}
     with safe_open(filename, framework="pt", device=device) as f:
-        for k in f.keys():
+        for k in f.offset_keys():
             result[k] = f.get_tensor(k)
     return result
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -443,6 +443,16 @@ impl Open {
         Ok(keys)
     }
 
+    /// Returns the names of the tensors in the file, ordered by offset.
+    ///
+    /// Returns:
+    ///     (`List[str]`):
+    ///         The name of the tensors contained in that file
+    pub fn offset_keys(&self) -> PyResult<Vec<String>> {
+        let keys: Vec<String> = self.metadata.offset_keys();
+        Ok(keys)
+    }
+
     /// Returns a full tensor
     ///
     /// Args:
@@ -649,6 +659,15 @@ impl safe_open {
     ///         The name of the tensors contained in that file
     pub fn keys(&self) -> PyResult<Vec<String>> {
         self.inner()?.keys()
+    }
+
+    /// Returns the names of the tensors in the file, ordered by offset.
+    ///
+    /// Returns:
+    ///     (`List[str]`):
+    ///         The name of the tensors contained in that file
+    pub fn offset_keys(&self) -> PyResult<Vec<String>> {
+        self.inner()?.offset_keys()
     }
 
     /// Returns a full tensor

--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -554,6 +554,13 @@ impl Metadata {
             .collect()
     }
 
+    /// Gives back the tensor names ordered by offset
+    pub fn offset_keys(&self) -> Vec<String> {
+        let mut index_vec: Vec<_> = self.index_map.iter().collect();
+        index_vec.sort_by_key(|a| a.1);
+        index_vec.into_iter().map(|a| a.0.clone()).collect()
+    }
+
     /// Gives back the tensor metadata
     pub fn metadata(&self) -> &Option<HashMap<String, String>> {
         &self.metadata


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This change introduces a new method `offset_keys()` returning names of tensors ordered by their offsets in the file.  We then change `load_file()` func to use the new method so that they will try to load data in a sequential way, independent of naming of tensor names.

We put model files on S3-like object storages and use prefetch strategy to maximize throughput.  The change can greatly shorten load time for files like `revAnimated_v122.safetensors`, and has negligible effects for others (e.g. `sd_xl_base_1.0.safetensors`)

Load time in seconds.  

```
## sd_xl_base_1.0.safetensors np
old 15.66
new 17.65
## sd_xl_base_1.0.safetensors pt
old 32.34
new 31.55
## revAnimated_v122.safetensors np
old 67.13
new 14.15
## revAnimated_v122.safetensors pt
old 43.42
new 28.31
```

```
-rwxrwxrwx 1 root root 5.2G Sep 19 02:55 revAnimated_v122.safetensors
-rwxrwxrwx 1 root root 6.5G Dec 31 09:27 sd_xl_base_1.0.safetensors
```