### PR TITLE
support hpu:0

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -267,7 +267,7 @@ enum Device {
     Xpu(usize),
     Xla(usize),
     Mlu(usize),
-    Hpu,
+    Hpu(usize),
     /// User didn't specify accelerator, torch
     /// is responsible for choosing.
     Anonymous(usize),
@@ -297,12 +297,13 @@ impl<'source> FromPyObject<'source> for Device {
                 "xpu" => Ok(Device::Xpu(0)),
                 "xla" => Ok(Device::Xla(0)),
                 "mlu" => Ok(Device::Mlu(0)),
-                "hpu" => Ok(Device::Hpu),
+                "hpu" => Ok(Device::Hpu(0)),
                 name if name.starts_with("cuda:") => parse_device(name).map(Device::Cuda),
                 name if name.starts_with("npu:") => parse_device(name).map(Device::Npu),
                 name if name.starts_with("xpu:") => parse_device(name).map(Device::Xpu),
                 name if name.starts_with("xla:") => parse_device(name).map(Device::Xla),
                 name if name.starts_with("mlu:") => parse_device(name).map(Device::Mlu),
+                name if name.starts_with("hpu:") => parse_device(name).map(Device::Hpu),
                 name => Err(SafetensorError::new_err(format!(
                     "device {name} is invalid"
                 ))),
@@ -329,7 +330,7 @@ impl<'py> IntoPyObject<'py> for Device {
             Device::Xpu(n) => format!("xpu:{n}").into_pyobject(py).map(|x| x.into_any()),
             Device::Xla(n) => format!("xla:{n}").into_pyobject(py).map(|x| x.into_any()),
             Device::Mlu(n) => format!("mlu:{n}").into_pyobject(py).map(|x| x.into_any()),
-            Device::Hpu => "hpu".into_pyobject(py).map(|x| x.into_any()),
+            Device::Hpu(n) => format!("hpu:{n}").into_pyobject(py).map(|x| x.into_any()),
             Device::Anonymous(n) => n.into_pyobject(py).map(|x| x.into_any()),
         }
     }


### PR DESCRIPTION
# What does this PR do?

Because some libs load tensors internally with `safe_load(name, device=str(torch_device))` and `str(torch_device)` will be `hpu:0` if `torch_device` is indexed