### PR TITLE
Add onnx-safetensors to the projects list in documentation

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -93,3 +93,4 @@ Safetensors is being used widely at leading AI enterprises, such as [Hugging Fac
 * [alvarobartt/safejax](https://github.com/alvarobartt/safejax)
 * [MaartenGr/BERTopic](https://github.com/MaartenGr/BERTopic)
 * [rachthree/safestructures](https://github.com/rachthree/safestructures)
+* [justinchuby/onnx-safetensors](https://github.com/justinchuby/onnx-safetensors)


### PR DESCRIPTION
# What does this PR do?

onnx-safetensors enables onnx files to use safetensors as external data for the ONNX model natively. This change adds onnx-safetensors to the projects list for users to discover support for using safetensors in onnx models.