### PR TITLE
Do not error with InvalidOffset if multiple tensors are tied to the exact same data

### DIFF
--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -512,18 +512,18 @@ impl Metadata {
     }
 
     fn validate(&self) -> Result<usize, SafeTensorError> {
-        let mut start = 0;
+        let (mut prev, mut start) = (0, 0);
         for (i, info) in self.tensors.iter().enumerate() {
-            let (s, e) = info.data_offsets;
-            if s != start || e < s {
                 let tensor_name = self
                     .index_map
                     .iter()
                     .find_map(|(name, &index)| if index == i { Some(&name[..]) } else { None })
                     .unwrap_or("no_tensor");
+            let (s, e) = info.data_offsets;
+            if (s != start && (s, e) != (prev, start)) || e < s {
                 return Err(SafeTensorError::InvalidOffset(tensor_name.to_string()));
             }
-            start = e;
+            (prev, start) = (s, e);
             let nelements: usize = info
                 .shape
                 .iter()


### PR DESCRIPTION
This changes the conditions in which an `InvalidOffset` is thrown such that it is accepted for multiple tensor names in the header to refer to the same data.

This lets files constructed to represent tied weights load successfully.

I am new to Rust and encountered this error while writing my own safetensors encoder at https://huggingface.co/datasets/baffo32/llm_logits/blob/main/_safetensors.py . I added a hashing function to deduplicate tensors, but then learned that the official safetensors implementation throws an error for such files.

This is a very simple change that only changes what file structures are valid but does not otherwise add support for tied weights. It might be reasonable to issue a warning if tied weights are encountered in a file, as they would be duplicated if naively uploaded to a GPU separately.