### PR TITLE
fix typo in serialize_file doc-string

### DIFF
--- a/bindings/python/py_src/safetensors/__init__.pyi
+++ b/bindings/python/py_src/safetensors/__init__.pyi
@@ -36,7 +36,7 @@ def serialize(tensor_dict, metadata=None):
 @staticmethod
 def serialize_file(tensor_dict, filename, metadata=None):
     """
-    Serializes raw data.
+    Serializes raw data into file.
 
     Args:
         tensor_dict (`Dict[str, Dict[Any]]`):
@@ -48,8 +48,8 @@ def serialize_file(tensor_dict, filename, metadata=None):
             The optional purely text annotations
 
     Returns:
-        (`bytes`):
-            The serialized content.
+        (`NoneType`):
+            On success return None.
     """
     pass
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -127,7 +127,7 @@ fn serialize<'b>(
     Ok(pybytes)
 }
 
-/// Serializes raw data.
+/// Serializes raw data into file.
 ///
 /// Args:
 ///     tensor_dict (`Dict[str, Dict[Any]]`):
@@ -139,8 +139,8 @@ fn serialize<'b>(
 ///         The optional purely text annotations
 ///
 /// Returns:
-///     (`bytes`):
-///         The serialized content.
+///     (`NoneType`):
+///         On success return None
 #[pyfunction]
 #[pyo3(signature = (tensor_dict, filename, metadata=None))]
 fn serialize_file(


### PR DESCRIPTION
# What does this PR do?

function ``serialize_file`` within `binding/python/src/lib.rs` contains a doc-string typo 

### Now
```rust
/// Serializes raw data into file.
///
/// Args:
///     tensor_dict (`Dict[str, Dict[Any]]`):
///         The tensor dict is like:
///             {"tensor_name": {"dtype": "F32", "shape": [2, 3], "data": b"\0\0"}}
///     filename (`str`, or `os.PathLike`):
///         The name of the file to write into.
///     metadata (`Dict[str, str]`, *optional*):
///         The optional purely text annotations
///
/// Returns:
///     (`NoneType`):
///         On success return None
```

### Previous
```rust
/// Serializes raw data.
///
/// Args:
///     tensor_dict (`Dict[str, Dict[Any]]`):
///         The tensor dict is like:
///             {"tensor_name": {"dtype": "F32", "shape": [2, 3], "data": b"\0\0"}}
///     filename (`str`, or `os.PathLike`):
///         The name of the file to write into.
///     metadata (`Dict[str, str]`, *optional*):
///         The optional purely text annotations
///
/// Returns:
///     (`bytes`):
///         The serialized content.
```