### PR TITLE
Adding support for MXFP4,6.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Notes:
  - Endianness: Little-endian.
    moment.
  - Order: 'C' or row-major.
+ - Notes: Some smaller than 1 byte dtypes appeared, which make alignment tricky. Non traditional APIs might be required for those.
 
 
 ### Yet another format ?
@@ -162,6 +163,7 @@ This is my very personal and probably biased view:
   moment.
 - Order: 'C' or row-major. This seems to have won. We can add that information later if needed.
 - Stride: No striding, all tensors need to be packed before being serialized. I have yet to see a case where it seems useful to have a strided tensor stored in serialized format.
+ - Sub 1 bytes dtypes: Dtypes can now have lower than 1 byte size, this makes alignment&adressing tricky. For now, the library will simply error out whenever an operation triggers an non aligned read. Trickier API may be created later for those non standard ops. 
 
 ### Benefits
 

--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -397,6 +397,8 @@ def load(data: bytes) -> Dict[str, torch.Tensor]:
 # torch.float8 formats require 2.1; we do not support these dtypes on earlier versions
 _float8_e4m3fn = getattr(torch, "float8_e4m3fn", None)
 _float8_e5m2 = getattr(torch, "float8_e5m2", None)
+_float8_e8m0 = getattr(torch, "float8_e8m0fnu", None)
+_float4_e2m1_x2 = getattr(torch, "float4_e2m1fn_x2", None)
 
 _SIZE = {
     torch.int64: 8,
@@ -411,6 +413,8 @@ _SIZE = {
     torch.float64: 8,
     _float8_e4m3fn: 1,
     _float8_e5m2: 1,
+    _float8_e8m0: 1,
+    _float4_e2m1_x2: 1,
 }
 
 _TYPES = {

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -50,7 +50,7 @@ impl View for &PyView<'_> {
 fn prepare(tensor_dict: HashMap<String, PyBound<PyDict>>) -> PyResult<HashMap<String, PyView>> {
     let mut tensors = HashMap::with_capacity(tensor_dict.len());
     for (tensor_name, tensor_desc) in tensor_dict {
-        let shape: Vec<usize> = tensor_desc
+        let mut shape: Vec<usize> = tensor_desc
             .get_item("shape")?
             .ok_or_else(|| SafetensorError::new_err(format!("Missing `shape` in {tensor_desc}")))?
             .extract()?;
@@ -81,7 +81,7 @@ fn prepare(tensor_dict: HashMap<String, PyBound<PyDict>>) -> PyResult<HashMap<St
             "bfloat16" => Dtype::BF16,
             "float8_e4m3fn" => Dtype::F8_E4M3,
             "float8_e5m2" => Dtype::F8_E5M2,
-            "float8_e8m0fnu" => Dtype::E8M0,
+            "float8_e8m0fnu" => Dtype::F8_E8M0,
             "float4_e2m1fn_x2" => Dtype::F4,
             dtype_str => {
                 return Err(SafetensorError::new_err(format!(
@@ -650,7 +650,7 @@ impl Open {
                             Dtype::BF16 => Some(Dtype::F16),
                             Dtype::F8_E5M2 => Some(Dtype::U8),
                             Dtype::F8_E4M3 => Some(Dtype::U8),
-                            Dtype::E8M0 => Some(Dtype::U8),
+                            Dtype::F8_E8M0 => Some(Dtype::U8),
                             _ => None,
                         };
                         if let Some(intermediary_dtype) = intermediary_dtype {
@@ -1023,7 +1023,7 @@ impl PySafeSlice {
                         Dtype::BF16 => Some(Dtype::F16),
                         Dtype::F8_E5M2 => Some(Dtype::U8),
                         Dtype::F8_E4M3 => Some(Dtype::U8),
-                        Dtype::E8M0 => Some(Dtype::U8),
+                        Dtype::F8_E8M0 => Some(Dtype::U8),
                         _ => None,
                     };
                     if let Some(intermediary_dtype) = intermediary_dtype {
@@ -1231,7 +1231,7 @@ fn get_pydtype(module: &PyBound<'_, PyModule>, dtype: Dtype, is_numpy: bool) -> 
             }
             Dtype::F8_E4M3 => module.getattr(intern!(py, "float8_e4m3fn"))?.into(),
             Dtype::F8_E5M2 => module.getattr(intern!(py, "float8_e5m2"))?.into(),
-            Dtype::E8M0 => module.getattr(intern!(py, "float8_e8m0fnu"))?.into(),
+            Dtype::F8_E8M0 => module.getattr(intern!(py, "float8_e8m0fnu"))?.into(),
             Dtype::F4 => module.getattr(intern!(py, "float4_e2m1fn_x2"))?.into(),
             dtype => {
                 return Err(SafetensorError::new_err(format!(

--- a/bindings/python/src/view.rs
+++ b/bindings/python/src/view.rs
@@ -1,0 +1,143 @@
+use crate::SafetensorError;
+#[cfg(feature = "py311")]
+use pyo3::buffer::PyBuffer;
+use pyo3::prelude::*;
+#[cfg(feature = "py38")]
+use pyo3::types::PyBytes;
+use pyo3::types::PyDict;
+use pyo3::Bound as PyBound;
+use safetensors::{Dtype, View};
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+#[cfg(feature = "py38")]
+pub struct PyView<'a> {
+    shape: Vec<usize>,
+    dtype: Dtype,
+    data: PyBound<'a, PyBytes>,
+    data_len: usize,
+}
+
+#[cfg(feature = "py311")]
+pub struct PyView<'a> {
+    shape: Vec<usize>,
+    dtype: Dtype,
+    data: PyBuffer<u8>,
+    data_len: usize,
+    // Kept to keep the GIL open while we hold the buffer
+    _py: Python<'a>,
+}
+
+impl View for &PyView<'_> {
+    #[cfg(feature = "py38")]
+    fn data(&self) -> std::borrow::Cow<[u8]> {
+        Cow::Borrowed(self.data.as_bytes())
+    }
+    #[cfg(feature = "py311")]
+    fn data(&self) -> std::borrow::Cow<[u8]> {
+        // We already checked this in the Python side.
+        assert!(self.data.is_c_contiguous());
+        // XXX: Ideally we could have at least readonly tensors
+        // assert!(self.data.readonly());
+        // SAFETY:
+        // This is actually totally unsafe, PyBuffer is not immutable and could be changed from
+        // under us.
+        // This is made safer because we're still hanging to the GIL while treating
+        // this structure
+        Cow::Borrowed(unsafe {
+            std::slice::from_raw_parts(self.data.buf_ptr() as *const u8, self.data.item_count())
+        })
+    }
+    fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+    fn dtype(&self) -> Dtype {
+        self.dtype
+    }
+    fn data_len(&self) -> usize {
+        self.data_len
+    }
+}
+
+pub fn prepare(tensor_dict: HashMap<String, PyBound<PyDict>>) -> PyResult<HashMap<String, PyView>> {
+    let mut tensors = HashMap::with_capacity(tensor_dict.len());
+    for (tensor_name, tensor_desc) in &tensor_dict {
+        let mut shape: Vec<usize> = tensor_desc
+            .get_item("shape")?
+            .ok_or_else(|| SafetensorError::new_err(format!("Missing `shape` in {tensor_desc:?}")))?
+            .extract()?;
+        let pydata: PyBound<PyAny> = tensor_desc.get_item("data")?.ok_or_else(|| {
+            SafetensorError::new_err(format!("Missing `data` in {tensor_desc:?}"))
+        })?;
+
+        let pydtype = tensor_desc.get_item("dtype")?.ok_or_else(|| {
+            SafetensorError::new_err(format!("Missing `dtype` in {tensor_desc:?}"))
+        })?;
+        let dtype: String = pydtype.extract()?;
+        let dtype = match dtype.as_ref() {
+            "bool" => Dtype::BOOL,
+            "int8" => Dtype::I8,
+            "uint8" => Dtype::U8,
+            "int16" => Dtype::I16,
+            "uint16" => Dtype::U16,
+            "int32" => Dtype::I32,
+            "uint32" => Dtype::U32,
+            "int64" => Dtype::I64,
+            "uint64" => Dtype::U64,
+            "float16" => Dtype::F16,
+            "float32" => Dtype::F32,
+            "float64" => Dtype::F64,
+            "bfloat16" => Dtype::BF16,
+            "float8_e4m3fn" => Dtype::F8_E4M3,
+            "float8_e5m2" => Dtype::F8_E5M2,
+            "float8_e8m0fnu" => Dtype::E8M0,
+            "float4_e2m1fn_x2" => Dtype::F4,
+            dtype_str => {
+                return Err(SafetensorError::new_err(format!(
+                    "dtype {dtype_str} is not covered",
+                )));
+            }
+        };
+        if dtype == Dtype::F4 {
+            let n = shape.len();
+            shape[n - 1] *= 2;
+        }
+
+        #[cfg(feature = "py311")]
+        let tensor = {
+            let data: PyBuffer<u8> = pydata.extract()?;
+            if !data.is_c_contiguous() {
+                return Err(SafetensorError::new_err("Python buffer is not contiguous"));
+            }
+            // XXX Ideally this would be true.
+            // if !data.readonly() {
+            //     return Err(SafetensorError::new_err("Python buffer is not readonly"));
+            // }
+            let data_len = data.item_count();
+            let py = pydata.py();
+            PyView {
+                shape,
+                dtype,
+                data,
+                data_len,
+                _py: py,
+            }
+        };
+
+        #[cfg(feature = "py38")]
+        let tensor = {
+            let data: &[u8] = pydata.extract()?;
+            let data_len = data.len();
+            let data: PyBound<PyBytes> = pydata.extract()?;
+            PyView {
+                shape,
+                dtype,
+                data,
+                data_len,
+            }
+        };
+
+        tensors.insert(tensor_name.to_string(), tensor);
+    }
+    Ok(tensors)
+}

--- a/safetensors/benches/benchmark.rs
+++ b/safetensors/benches/benchmark.rs
@@ -7,7 +7,9 @@ use std::hint::black_box;
 fn get_sample_data() -> (Vec<u8>, Vec<usize>, Dtype) {
     let shape = vec![1000, 500];
     let dtype = Dtype::F32;
-    let n: usize = shape.iter().product::<usize>() * dtype.size(); // 4
+    let nbits = shape.iter().product::<usize>() * dtype.bitsize();
+    assert!(nbits % 8 == 0);
+    let n: usize = nbits / 8; // 4
     let data = vec![0; n];
 
     (data, shape, dtype)

--- a/safetensors/src/slice.rs
+++ b/safetensors/src/slice.rs
@@ -1,10 +1,10 @@
 //! Module handling lazy loading via iterating on slices on the original buffer.
 use crate::lib::Vec;
 use crate::tensor::TensorView;
+use core::fmt::Display;
 use core::ops::{
     Bound, Range, RangeBounds, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
 };
-use core::fmt::Display;
 
 /// Error representing invalid slicing attempt
 #[derive(Debug)]
@@ -32,8 +32,15 @@ impl Display for InvalidSlice {
             InvalidSlice::TooManySlices => {
                 write!(f, "more slicing indexes than dimensions in tensor")
             }
-            InvalidSlice::SliceOutOfRange { dim_index, asked, dim_size } => {
+            InvalidSlice::SliceOutOfRange {
+                dim_index,
+                asked,
+                dim_size,
+            } => {
                 write!(f, "index {asked} out of bounds for tensor dimension #{dim_index} of size {dim_size}")
+            }
+            InvalidSlice::MisalignedSlice => {
+                write!(f, "The slice is slicing for subbytes dtypes, and the slice does not end up at a byte boundary, this is invalid.")
             }
         }
     }

--- a/safetensors/src/slice.rs
+++ b/safetensors/src/slice.rs
@@ -21,6 +21,9 @@ pub enum InvalidSlice {
         /// The dimension size we shouldn't go over.
         dim_size: usize,
     },
+    /// For smaller than 1 byte dtypes, some slices will happen outside of the byte boundary, some special care has to be taken
+    /// and standard functions will fail
+    MisalignedSlice,
 }
 
 impl Display for InvalidSlice {
@@ -276,7 +279,8 @@ impl<'data> SliceIterator<'data> {
         let mut newshape = Vec::with_capacity(view.shape().len());
 
         // Minimum span is the span of 1 item;
-        let mut span = view.dtype().size();
+        // TODO Handle fp4 / fp6.
+        let mut span = view.dtype().bitsize();
         let mut indices = vec![];
         // Everything is row major.
         for (i, &shape) in view.shape().iter().enumerate().rev() {
@@ -324,15 +328,24 @@ impl<'data> SliceIterator<'data> {
                     if start == 0 && stop == shape {
                         // We haven't started to slice yet, just increase the span
                     } else {
-                        let offset = start * span;
-                        let small_span = stop * span - offset;
+                        if start * span % 8 != 0 {
+                            return Err(InvalidSlice::MisalignedSlice);
+                        }
+                        let offset = (start * span) / 8;
+                        if stop * span % 8 != 0 {
+                            return Err(InvalidSlice::MisalignedSlice);
+                        }
+                        let small_span = (stop * span) / 8 - offset;
                         indices.push((offset, offset + small_span));
                     }
                 } else {
                     let capacity = (stop - start) * indices.len();
                     let mut newindices = Vec::with_capacity(capacity);
                     for n in start..stop {
-                        let offset = n * span;
+                        if n * span % 8 != 0 {
+                            return Err(InvalidSlice::MisalignedSlice);
+                        }
+                        let offset = (n * span) / 8;
                         for (old_start, old_stop) in &indices {
                             newindices.push((old_start + offset, old_stop + offset));
                         }
@@ -413,6 +426,57 @@ mod tests {
         .unwrap();
         assert_eq!(iterator.remaining_byte_len(), 12);
         assert_eq!(iterator.newshape(), vec![1, 1, 3]);
+    }
+
+    #[test]
+    fn test_fp4_simple() {
+        let data: Vec<u8> = vec![0u8, 1u8];
+
+        let attn_0 = TensorView::new(Dtype::F4, vec![1, 2, 2], &data).unwrap();
+
+        let iterator = SliceIterator::new(
+            &attn_0,
+            &[TensorIndexer::Narrow(Bound::Unbounded, Bound::Unbounded)],
+        )
+        .unwrap();
+        assert_eq!(iterator.remaining_byte_len(), 2);
+        assert_eq!(iterator.newshape(), vec![1, 2, 2]);
+
+        let iterator = SliceIterator::new(
+            &attn_0,
+            &[
+                TensorIndexer::Narrow(Bound::Unbounded, Bound::Unbounded),
+                TensorIndexer::Narrow(Bound::Included(0), Bound::Excluded(1)),
+            ],
+        )
+        .unwrap();
+        assert_eq!(iterator.remaining_byte_len(), 1);
+        assert_eq!(iterator.newshape(), vec![1, 1, 2]);
+    }
+
+    #[test]
+    fn test_fp4_misaligned() {
+        let data: Vec<u8> = vec![0u8];
+
+        let attn_0 = TensorView::new(Dtype::F4, vec![1, 2], &data).unwrap();
+
+        let iterator = SliceIterator::new(
+            &attn_0,
+            &[TensorIndexer::Narrow(Bound::Unbounded, Bound::Unbounded)],
+        )
+        .unwrap();
+        assert_eq!(iterator.remaining_byte_len(), 1);
+        assert_eq!(iterator.newshape(), vec![1, 2]);
+
+        let iterator = SliceIterator::new(
+            &attn_0,
+            &[
+                TensorIndexer::Narrow(Bound::Unbounded, Bound::Unbounded),
+                TensorIndexer::Narrow(Bound::Included(0), Bound::Excluded(1)),
+            ],
+        );
+
+        assert_eq!(iterator, Err(InvalidSlice::MisalignedSlice));
     }
 
     #[test]

--- a/safetensors/src/slice.rs
+++ b/safetensors/src/slice.rs
@@ -279,7 +279,6 @@ impl<'data> SliceIterator<'data> {
         let mut newshape = Vec::with_capacity(view.shape().len());
 
         // Minimum span is the span of 1 item;
-        // TODO Handle fp4 / fp6.
         let mut span = view.dtype().bitsize();
         let mut indices = vec![];
         // Everything is row major.

--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -587,10 +587,13 @@ impl Metadata {
                 .cloned()
                 .try_fold(1usize, usize::checked_mul)
                 .ok_or(SafeTensorError::ValidationOverflow)?;
-            let nbytes = nelements
-                .checked_mul(info.dtype.size())
+            let nbits = nelements
+                .checked_mul(info.dtype.bitsize())
                 .ok_or(SafeTensorError::ValidationOverflow)?;
-            if (e - s) != nbytes {
+            let size = nbits
+                .checked_div(8)
+                .ok_or(SafeTensorError::ValidationOverflow)?;
+            if (e - s) != size {
                 return Err(SafeTensorError::TensorInvalidInfo);
             }
         }
@@ -679,7 +682,11 @@ impl<'data> TensorView<'data> {
     ) -> Result<Self, SafeTensorError> {
         let n = data.len();
         let n_elements: usize = shape.iter().product();
-        if n != n_elements * dtype.size() {
+        let size = (n_elements * dtype.bitsize())
+            .checked_div(8)
+            .ok_or(SafeTensorError::ValidationOverflow)?;
+
+        if n != size {
             Err(SafeTensorError::InvalidTensorView(dtype, shape, n))
         } else {
             Ok(Self { dtype, shape, data })
@@ -728,6 +735,18 @@ pub struct TensorInfo {
 pub enum Dtype {
     /// Boolan type
     BOOL,
+    /// MXF4 <https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf>_
+    #[allow(non_camel_case_types)]
+    F4,
+    /// MXF6 <https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf>_
+    #[allow(non_camel_case_types)]
+    F6_E2M3,
+    /// MXF6 <https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf>_
+    #[allow(non_camel_case_types)]
+    F6_E3M2,
+    /// E8M0 <https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf>_
+    #[allow(non_camel_case_types)]
+    E8M0,
     /// Unsigned byte
     U8,
     /// Signed byte
@@ -761,25 +780,37 @@ pub enum Dtype {
 }
 
 impl Dtype {
-    /// Gives out the size (in bytes) of 1 element of this dtype.
-    pub fn size(&self) -> usize {
+    /// Gives out the size (in bits) of 1 element of this dtype.
+    pub fn bitsize(&self) -> usize {
         match self {
-            Dtype::BOOL => 1,
-            Dtype::U8 => 1,
-            Dtype::I8 => 1,
-            Dtype::F8_E5M2 => 1,
-            Dtype::F8_E4M3 => 1,
-            Dtype::I16 => 2,
-            Dtype::U16 => 2,
-            Dtype::I32 => 4,
-            Dtype::U32 => 4,
-            Dtype::I64 => 8,
-            Dtype::U64 => 8,
-            Dtype::F16 => 2,
-            Dtype::BF16 => 2,
-            Dtype::F32 => 4,
-            Dtype::F64 => 8,
+            Dtype::F4 => 4,
+            Dtype::F6_E3M2 => 6,
+            Dtype::F6_E2M3 => 6,
+            Dtype::E8M0 => 8,
+            Dtype::BOOL => 8,
+            Dtype::U8 => 8,
+            Dtype::I8 => 8,
+            Dtype::F8_E5M2 => 8,
+            Dtype::F8_E4M3 => 8,
+            Dtype::I16 => 16,
+            Dtype::U16 => 16,
+            Dtype::I32 => 32,
+            Dtype::U32 => 32,
+            Dtype::I64 => 64,
+            Dtype::U64 => 64,
+            Dtype::F16 => 16,
+            Dtype::BF16 => 16,
+            Dtype::F32 => 32,
+            Dtype::F64 => 64,
         }
+    }
+    /// Gives out the size (in bytes) of 1 element of this dtype.
+    #[deprecated(
+        since = "0.6.0",
+        note = "Use `bitsize` instead as some elements have smaller than a full byte of width"
+    )]
+    pub fn size(&self) -> usize {
+        self.bitsize() / 8
     }
 }
 
@@ -821,6 +852,11 @@ mod tests {
     fn arbitrary_dtype() -> impl Strategy<Value = Dtype> {
         prop_oneof![
             Just(Dtype::BOOL),
+            Just(Dtype::F4),
+            Just(Dtype::F6_E3M2),
+            Just(Dtype::F6_E2M3),
+            Just(Dtype::F8_E5M2),
+            Just(Dtype::F8_E4M3),
             Just(Dtype::U8),
             Just(Dtype::I8),
             Just(Dtype::I16),
@@ -861,7 +897,7 @@ mod tests {
                         // This cannot overflow because the size of
                         // the vector and elements are so small.
                         let length: usize = shape.iter().product();
-                        let end = start + length * dtype.size();
+                        let end = start + length * dtype.bitsize() / 8;
                         let tensor = TensorInfo {
                             dtype: *dtype,
                             shape,
@@ -918,7 +954,7 @@ mod tests {
             for name in before.names() {
                 let tensor_before = before.tensor(name).unwrap();
                 let tensor_after = after.tensor(name).unwrap();
-                assert_eq!(tensor_after.data().as_ptr() as usize % tensor_after.dtype().size(), 0);
+                assert_eq!(tensor_after.data().as_ptr() as usize % tensor_after.dtype().bitsize().div_ceil(8), 0);
                 assert_eq!(tensor_before, tensor_after);
             }
         }
@@ -947,6 +983,40 @@ mod tests {
             ]
         );
         let _parsed = SafeTensors::deserialize(&out).unwrap();
+    }
+
+    #[test]
+    fn test_serialization_fp4() {
+        let data: Vec<u8> = vec![0u8];
+        let shape = vec![1, 2];
+        let attn_0 = TensorView::new(Dtype::F4, shape, &data).unwrap();
+        let metadata: HashMap<String, TensorView> =
+            [("attn.0".to_string(), attn_0)].into_iter().collect();
+
+        let out = serialize(&metadata, &None).unwrap();
+        assert_eq!(
+            out,
+            [
+                64, 0, 0, 0, 0, 0, 0, 0, 123, 34, 97, 116, 116, 110, 46, 48, 34, 58, 123, 34, 100,
+                116, 121, 112, 101, 34, 58, 34, 70, 52, 34, 44, 34, 115, 104, 97, 112, 101, 34, 58,
+                91, 49, 44, 50, 93, 44, 34, 100, 97, 116, 97, 95, 111, 102, 102, 115, 101, 116,
+                115, 34, 58, 91, 48, 44, 49, 93, 125, 125, 32, 32, 32, 32, 0
+            ]
+        );
+        let parsed = SafeTensors::deserialize(&out).unwrap();
+        let tensors: HashMap<_, _> = parsed.tensors().into_iter().collect();
+        assert_eq!(tensors, metadata);
+    }
+
+    #[test]
+    fn test_serialization_fp4_misaligned() {
+        let data: Vec<u8> = vec![0u8, 1u8];
+        let shape = vec![1, 3];
+        let attn_0 = TensorView::new(Dtype::F4, shape, &data);
+        assert!(matches!(
+            attn_0,
+            Err(SafeTensorError::InvalidTensorView(Dtype::F4, _shape, _size))
+        ));
     }
 
     #[test]
@@ -1005,7 +1075,10 @@ mod tests {
         );
         let parsed = SafeTensors::deserialize(&out).unwrap();
         let tensor = parsed.tensor("attn0").unwrap();
-        assert_eq!(tensor.data().as_ptr() as usize % tensor.dtype().size(), 0);
+        assert_eq!(
+            tensor.data().as_ptr() as usize % tensor.dtype().bitsize().div_ceil(8),
+            0
+        );
     }
 
     #[test]
@@ -1090,17 +1163,19 @@ mod tests {
         tensors_desc.push(("ln_f.bias".to_string(), vec![768]));
 
         let dtype = Dtype::F32;
-        let n: usize = tensors_desc
+        let n: usize = (tensors_desc
             .iter()
             .map(|(_, shape)| shape.iter().product::<usize>())
             .sum::<usize>()
-            * dtype.size(); // 4
+            * dtype.bitsize())
+        .checked_div(8)
+        .unwrap(); // 4
         let all_data = vec![0; n];
         let mut metadata = HashMap::with_capacity(tensors_desc.len());
         let mut offset = 0;
         for (name, shape) in tensors_desc {
             let n: usize = shape.iter().product();
-            let buffer = &all_data[offset..offset + n * dtype.size()];
+            let buffer = &all_data[offset..offset + (n * dtype.bitsize()) / 8];
             let tensor = TensorView::new(dtype, shape, buffer).unwrap();
             metadata.insert(name, tensor);
             offset += n;


### PR DESCRIPTION
# What does this PR do?

Adding support for new quantization types accepted by hardware manufacturers.
https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf

The spec for those dtypes is quite laxed:

> 
> Therefore, each block of 𝑘 elements can be encoded in (𝑤 + 𝑘𝑑) bits. The layout of the block in
> physical memory is not prescribed in this specification. If multiple blocks share the same scale
> factor, an implementation can compress or prune away the repeated scale factors. An
> implementation can store the scale factor 𝑋 contiguously with or separately from the k elements.

In response, safetensors doesn't make a choice either regarding block size. MXFP? are supposed to be stored in their own tensors, and the scales are store as E8M0 in another tensor, most likely having a dimension being the block size. Then implementors are in charge of putting scales and blocks close enough in the proper locations, because those are kernel dependant (so safetensors cannot make a choice here).

Regarding specifically fp4 and fp6, they introduce a new kind of issue, where some operations might be saving data outside of a byte. Since, those are normally supposed to be few and far between in real world use cases (tensors tend to be large power 2s, meaning slices tend to still be byte aligned) the parti pris here, is simply to raise errors whenever some operation is not byte aligned.

Technically, we *could* recover things, by padding/ignoring sub byte chunks, but also could invalidate the zero-copy promise (a f6 indexing within a byte, *shoud* required a bitshift of the entire array to be byte-aligned in order to become addressable).

For now this is left for future work.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue) or description of the problem this PR solves.
