### PR TITLE
Make API more idiomatic, simplify code, improve style

### DIFF
--- a/safetensors/Cargo.toml
+++ b/safetensors/Cargo.toml
@@ -2,7 +2,7 @@
 name = "safetensors"
 version = "0.5.3-dev.0"
 edition = "2021"
-rust-version = "1.74"
+rust-version = "1.80"
 homepage = "https://github.com/huggingface/safetensors"
 repository = "https://github.com/huggingface/safetensors"
 documentation = "https://docs.rs/safetensors/"
@@ -22,14 +22,14 @@ exclude = [ "rust-toolchain", "target/*", "Cargo.lock"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hashbrown = { version = "0.15.2", features = ["serde"], optional = true }
+hashbrown = { version = "0.15.3", features = ["serde"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false }
 
 [dev-dependencies]
-criterion = "0.5"
-memmap2 = "0.9"
-proptest = "1.4"
+criterion = "0.6"
+memmap2 = "0.9.5"
+proptest = "1.6"
 
 [features]
 default = ["std"]

--- a/safetensors/benches/benchmark.rs
+++ b/safetensors/benches/benchmark.rs
@@ -26,7 +26,7 @@ pub fn bench_serialize(c: &mut Criterion) {
 
     c.bench_function("Serialize 10_MB", |b| {
         b.iter(|| {
-            let _serialized = serialize(black_box(&metadata), black_box(&None));
+            let _serialized = serialize(black_box(&metadata), black_box(None));
         })
     });
 }
@@ -42,7 +42,7 @@ pub fn bench_deserialize(c: &mut Criterion) {
         metadata.insert(format!("weight{i}"), tensor);
     }
 
-    let out = serialize(&metadata, &None).unwrap();
+    let out = serialize(&metadata, None).unwrap();
 
     c.bench_function("Deserialize 10_MB", |b| {
         b.iter(|| {

--- a/safetensors/benches/benchmark.rs
+++ b/safetensors/benches/benchmark.rs
@@ -1,6 +1,7 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use safetensors::tensor::*;
 use std::collections::HashMap;
+use std::hint::black_box;
 
 // Returns a sample data of size 2_MB
 fn get_sample_data() -> (Vec<u8>, Vec<usize>, Dtype) {

--- a/safetensors/src/slice.rs
+++ b/safetensors/src/slice.rs
@@ -1,6 +1,7 @@
 //! Module handling lazy loading via iterating on slices on the original buffer.
-use crate::lib::{String, ToString, Vec};
+use crate::lib::Vec;
 use crate::tensor::TensorView;
+use core::fmt::Display;
 use core::ops::{
     Bound, Range, RangeBounds, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
 };
@@ -29,14 +30,13 @@ pub enum TensorIndexer {
     Select(usize),
     /// This is a regular slice, purely indexing a chunk of the tensor
     Narrow(Bound<usize>, Bound<usize>),
-    //IndexSelect(Tensor),
 }
 
-fn display_bound(bound: &Bound<usize>) -> String {
+fn display_bound(bound: &Bound<usize>) -> &dyn Display {
     match bound {
-        Bound::Unbounded => "".to_string(),
-        Bound::Excluded(n) => format!("{n}"),
-        Bound::Included(n) => format!("{n}"),
+        Bound::Unbounded => &"",
+        Bound::Excluded(n) => n,
+        Bound::Included(n) => n,
     }
 }
 
@@ -59,20 +59,6 @@ impl From<usize> for TensorIndexer {
         TensorIndexer::Select(index)
     }
 }
-
-// impl From<&[usize]> for TensorIndexer {
-//     fn from(index: &[usize]) -> Self {
-//         let tensor = index.into();
-//         TensorIndexer::IndexSelect(tensor)
-//     }
-// }
-//
-// impl From<Vec<usize>> for TensorIndexer {
-//     fn from(index: Vec<usize>) -> Self {
-//         let tensor = Tensor::of_slice(&index);
-//         TensorIndexer::IndexSelect(tensor)
-//     }
-// }
 
 macro_rules! impl_from_range {
     ($range_type:ty) => {
@@ -340,7 +326,7 @@ impl<'data> SliceIterator<'data> {
     pub fn remaining_byte_len(&self) -> usize {
         self.indices
             .iter()
-            .map(|(start, stop)| (stop - start))
+            .map(|(start, stop)| stop - start)
             .sum()
     }
 


### PR DESCRIPTION
# What does this PR do?

There are a number of issues with the current code style, for example:

- The API sometimes forces sub-optimal choices (e.g. the use of `&Option<T>` forces the caller to have an owned `T`, whereas `Option<&T>` doesn't, and can be obtained from an `Option<T>` via `Option::<T>::as_ref()`)
- The implementation was sometimes overly verbose (e.g. heavily nested `if let` "triangles of hell", which can be replaced by `let … else` and early returns)
- There have been some notable omissions (e.g. the `source()` method on `impl Error for SafeTensorsError`)
- Some dependencies (notably, Criterion) were out-of-date and the code used deprecated functions

This PR fixes the aforementioned stylistic and API issues. Note that some of these _are_ technically breaking change, but since the library is still relatively young, and hasn't reached 1.0 yet, this should not be a problem.
