### PR TITLE
Simplify code and make it more robust

### DIFF
--- a/safetensors/src/slice.rs
+++ b/safetensors/src/slice.rs
@@ -340,7 +340,7 @@ impl<'data> SliceIterator<'data> {
     pub fn remaining_byte_len(&self) -> usize {
         self.indices
             .iter()
-            .map(|(start, stop)| (stop - start))
+            .map(|(start, stop)| stop - start)
             .sum()
     }
 


### PR DESCRIPTION
# What does this PR do?

Make code more idiomatic, slightly more performant, less prone to some programming errors, and in other cases, simpler, using a couple of small changes:

- remove some unnecessary parentheses
- remove some unnecessary allocations (such as an identity vec-to-vec transform of the form `.into_iter().collect()`)
- replace manual impl of `next_multiple_of()` with the actual std function
- use `serde_json::to_vec()` instead of `to_string().into_bytes()`
- clean up some generic signatures
- extract the often-repeated magic number `8` into a named constant, `HEADER_SIZE_LEN`
- remove some redundant lifetime parameters and explicit annotations
- be explicit in comparing the size (and alignment) of data types when sorting tensors
- replace double negatives of the form `if negative_condition { Err(…) } else { Ok(…) }` with the condition un-negated and the branches flipped
- remove deep nesting and use early returns in some cases instead
- replace some instances of explicit size checking logic
- eta-reduce unnecessary closures: `|f| f.to_le_bytes()` -> `f32::to_le_bytes`
- 