### PR TITLE
Do not force `&Option<T>` in public API; use `Option<&T>` instead

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -119,7 +119,7 @@ fn serialize<'b>(
     metadata: Option<HashMap<String, String>>,
 ) -> PyResult<PyBound<'b, PyBytes>> {
     let tensors = prepare(tensor_dict)?;
-    let out = safetensors::tensor::serialize(&tensors, &metadata)
+    let out = safetensors::tensor::serialize(&tensors, metadata)
         .map_err(|e| SafetensorError::new_err(format!("Error while serializing: {e:?}")))?;
     let pybytes = PyBytes::new(py, &out);
     Ok(pybytes)
@@ -147,8 +147,10 @@ fn serialize_file(
     metadata: Option<HashMap<String, String>>,
 ) -> PyResult<()> {
     let tensors = prepare(tensor_dict)?;
-    safetensors::tensor::serialize_to_file(&tensors, &metadata, filename.as_path())
+
+    safetensors::tensor::serialize_to_file(&tensors, metadata, filename.as_path())
         .map_err(|e| SafetensorError::new_err(format!("Error while serializing: {e:?}")))?;
+
     Ok(())
 }
 

--- a/safetensors/benches/benchmark.rs
+++ b/safetensors/benches/benchmark.rs
@@ -25,7 +25,7 @@ pub fn bench_serialize(c: &mut Criterion) {
 
     c.bench_function("Serialize 10_MB", |b| {
         b.iter(|| {
-            let _serialized = serialize(black_box(&metadata), black_box(&None));
+            let _serialized = serialize(black_box(&metadata), black_box(None));
         })
     });
 }
@@ -41,7 +41,7 @@ pub fn bench_deserialize(c: &mut Criterion) {
         metadata.insert(format!("weight{i}"), tensor);
     }
 
-    let out = serialize(&metadata, &None).unwrap();
+    let out = serialize(&metadata, None).unwrap();
 
     c.bench_function("Deserialize 10_MB", |b| {
         b.iter(|| {


### PR DESCRIPTION
# What does this PR do?

Some public functions had `&Option<T>` as one of their arguments. This is undesirable, because it forces the caller to have a literal `Option<T>` to which a reference is then taken.

If the caller only has a `T` that it does not wish to consume, this forces a clone. Taking an `Option<&T>` is more flexible, as `&Option<T>` can be converted to `Option<&T>` using the `Option::as_ref()` inherent method, and if one already has a bare `T`, then it's easy to create an `Option<&T>` by taking its address and wrapping it into `Some`.

The call site is also slightly simplified, as one no longer needs to write `&None`.
