### PR TITLE
Add a direct Python test dependency on fsspect in the testing and testingfree extras

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -70,6 +70,7 @@ testing = [
     "pytest-benchmark>=4.0.0",
     # "python-afl>=0.7.3",
     "hypothesis>=6.70.2",
+    "fsspec",
 ]
 testingfree = [
     "safetensors[numpy]",
@@ -79,6 +80,7 @@ testingfree = [
     "pytest-benchmark>=4.0.0",
     # "python-afl>=0.7.3",
     "hypothesis>=6.70.2",
+    "fsspec",
 ]
 all = [
     "safetensors[torch]",


### PR DESCRIPTION
# What does this PR do?

Adds `fsspec` to the Python testing dependencies in the `testing` and `testingfree` extras.
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes `ReadmeTestCase.test_fsspec` failing due to missing `fsspec` when testing without PyTorch available. Even when `torch` does bring in `fsspec` as an indirect dependency, it’s better to have a direct dependency on things we import directly.