### PR TITLE
Fix no-std feature configuration to auto-fallback from std to alloc

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,7 +46,7 @@ jobs:
         run: cargo test --verbose
 
       - name: Run No-STD Tests
-        run: cargo test --no-default-features --features alloc --verbose
+        run: cargo test --no-default-features --verbose
 
       - name: Run Audit
         # RUSTSEC-2021-0145 is criterion so only within benchmarks

--- a/safetensors/Cargo.toml
+++ b/safetensors/Cargo.toml
@@ -16,15 +16,18 @@ The format is 8 bytes which is an unsized int, being the size of a JSON header,
 the JSON header refers the `dtype` the `shape` and `data_offsets` which are the offsets
 for the values in the rest of the file.
 """
-exclude = [ "rust-toolchain", "target/*", "Cargo.lock"]
+exclude = ["rust-toolchain", "target/*", "Cargo.lock"]
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hashbrown = { version = "0.15.4", features = ["serde"], optional = true }
-serde = { version = "1.0", default-features = false, features = ["derive"] }
-serde_json = { version = "1.0", default-features = false }
+serde = { version = "1.0", default-features = false, features = [
+    "derive",
+    "alloc",
+] }
+serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+hashbrown = { version = "0.15.4", features = ["serde"] }
 
 [dev-dependencies]
 criterion = "0.6"
@@ -34,7 +37,8 @@ proptest = "1.7"
 [features]
 default = ["std"]
 std = ["serde/default", "serde_json/default"]
-alloc = ["serde/alloc", "serde_json/alloc", "hashbrown"]
+# Kept for backward compatibility - no-op since alloc is always available
+alloc = []
 
 [[bench]]
 name = "benchmark"

--- a/safetensors/src/lib.rs
+++ b/safetensors/src/lib.rs
@@ -8,14 +8,9 @@ pub mod tensor;
 pub use tensor::serialize_to_file;
 pub use tensor::{serialize, Dtype, SafeTensorError, SafeTensors, View};
 
-#[cfg(feature = "alloc")]
+#[cfg(not(feature = "std"))]
 #[macro_use]
 extern crate alloc;
-
-#[cfg(all(feature = "std", feature = "alloc"))]
-compile_error!("must choose either the `std` or `alloc` feature, but not both.");
-#[cfg(all(not(feature = "std"), not(feature = "alloc")))]
-compile_error!("must choose either the `std` or `alloc` feature");
 
 /// A facade around all the types we need from the `std`, `core`, and `alloc`
 /// crates. This avoids elaborate import wrangling having to happen in every


### PR DESCRIPTION
This PR addresses issue #650 by following the convention of the feature configuration for no_std support.

### Changes

- Removed mutual exclusivity between std and alloc features: Previously, the crate required exactly one of std or alloc
to be enabled, causing compilation errors when both or neither were specified
- Automatic alloc fallback: When std is not enabled, the crate now automatically uses alloc + hashbrown::HashMap
- Backward compatibility: The alloc feature is retained as a no-op for compatibility with existing downstream crates

### How it works

- Default build (cargo build): Uses std with std::collections::HashMap
- No-std build (cargo build --no-default-features): Automatically uses alloc with hashbrown::HashMap
- Explicit alloc (cargo build --no-default-features --features alloc): Still works for backward compatibility

### Testing

All tests pass in both configurations:
```
cargo test                          # std mode ✓
cargo test --no-default-features    # no-std mode ✓
cargo test --no-default-features --features alloc  # backward compat ✓
```
This aligns with common Rust ecosystem patterns where `default = ["std"]` provides standard library support, and
`--no-default-features` automatically provides `no_std` support with `alloc`.


Fixes #650
