### PR TITLE
Update hashbrown dependency to 0.16

### DIFF
--- a/safetensors/Cargo.toml
+++ b/safetensors/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0", default-features = false, features = [
     "alloc",
 ] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
-hashbrown = { version = "0.15.4", features = ["serde"] }
+hashbrown = { version = "0.16", features = ["serde"] }
 
 [dev-dependencies]
 criterion = "0.6"


### PR DESCRIPTION
# What does this PR do?

Update the hashbrown dependency to 0.16.