### PR TITLE
Add packaging as dep to torch extra

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -35,6 +35,7 @@ numpy = ["numpy>=1.21.6"]
 torch = [
     "safetensors[numpy]",
     "torch>=1.10",
+    "packaging",
 ]
 tensorflow = [
     "safetensors[numpy]",


### PR DESCRIPTION
# What does this PR do?

Declares the dependency on `packaging`, which is imported in safetensors.torch

Fixes #663 