### PR TITLE
Fix AttributeError when loading float8 dtypes through numpy path

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1469,10 +1469,35 @@ fn get_pydtype(module: &PyBound<'_, PyModule>, dtype: Dtype, is_numpy: bool) -> 
                     module.getattr(intern!(py, "bool"))?.into()
                 }
             }
-            Dtype::F8_E4M3 => module.getattr(intern!(py, "float8_e4m3fn"))?.into(),
-            Dtype::F8_E5M2 => module.getattr(intern!(py, "float8_e5m2"))?.into(),
-            Dtype::F8_E8M0 => module.getattr(intern!(py, "float8_e8m0fnu"))?.into(),
-            Dtype::F4 => module.getattr(intern!(py, "float4_e2m1fn_x2"))?.into(),
+            Dtype::F8_E4M3 => {
+                if is_numpy {
+                    // numpy does not have float8 types, map to uint8 (same width)
+                    module.getattr(intern!(py, "uint8"))?.into()
+                } else {
+                    module.getattr(intern!(py, "float8_e4m3fn"))?.into()
+                }
+            }
+            Dtype::F8_E5M2 => {
+                if is_numpy {
+                    module.getattr(intern!(py, "uint8"))?.into()
+                } else {
+                    module.getattr(intern!(py, "float8_e5m2"))?.into()
+                }
+            }
+            Dtype::F8_E8M0 => {
+                if is_numpy {
+                    module.getattr(intern!(py, "uint8"))?.into()
+                } else {
+                    module.getattr(intern!(py, "float8_e8m0fnu"))?.into()
+                }
+            }
+            Dtype::F4 => {
+                if is_numpy {
+                    module.getattr(intern!(py, "uint8"))?.into()
+                } else {
+                    module.getattr(intern!(py, "float4_e2m1fn_x2"))?.into()
+                }
+            }
             Dtype::C64 => module.getattr(intern!(py, "complex64"))?.into(),
             dtype => {
                 return Err(SafetensorError::new_err(format!(


### PR DESCRIPTION
Fixes issue where loading safetensors files with float8_e5m2 (and other float8) dtypes fails with 'AttributeError: module numpy has no attribute float8_e5m2' when using PaddlePaddle < 3.2.0.

The issue occurs because when paddle.__version__ < 3.2.0, load_file() uses numpy.load_file() which calls safe_open with framework='np'. The Rust code then tries to access numpy.float8_e5m2 which doesn't exist since NumPy doesn't have native float8 types.

Fix: Map float8 types (F8_E4M3, F8_E5M2, F8_E8M0, F4) to np.uint8 when is_numpy=True, similar to how bfloat16 is handled differently for numpy vs other frameworks. This matches the existing pattern in paddle.py where float8 types are mapped to np.uint8 (same width, byteswap is no-op).

## Changes
- Updated `get_pydtype()` in `lib.rs` to check `is_numpy` for float8 types
- Added test case `test_float8_e5m2_loading()` to verify the fix

Fix #682

