### PR TITLE
Update free-threading tests for Python 3.14

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -14,7 +14,7 @@ jobs:
         # new releases get automatically tested against
         version: [
           {torch: torch==2.4, python: "3.10", arch: "x64", numpy: numpy==1.26.4},
-          {torch: torch, python: "3.13", arch: "x64", numpy: numpy}
+          {torch: torch, python: "3.14", arch: "x64", numpy: numpy}
         ]
         include:
           - os: ubuntu-latest
@@ -32,13 +32,13 @@ jobs:
           - os: macos-latest
             version:
               torch: torch
-              python: "3.13"
+              python: "3.14"
               numpy: numpy
               arch: "arm64"
           - os: windows-11-arm
             version:
               torch: torch
-              python: "3.13"
+              python: "3.14"
               numpy: numpy
               arch: "arm64"
     defaults:
@@ -96,8 +96,18 @@ jobs:
           sudo apt-get install libhdf5-dev
 
       - name: Install (tensorflow)
-        if: matrix.version.arch != 'x64-freethreaded' && matrix.os != 'windows-11-arm'
+        if: matrix.version.arch != 'x64-freethreaded' && matrix.os != 'windows-11-arm' && matrix.python != "3.14"
         run: |
+          pip install .[tensorflow]
+          # XXX: I assume this is still the case for 3.10
+          # Force reinstall of numpy, tensorflow uses numpy 2 even on 3.9
+          pip install ${{ matrix.version.numpy }}
+        shell: bash
+
+      - name: Install (tensorflow) (Python 3.14)
+        if: matrix.version.arch != 'x64-freethreaded' && matrix.os != 'windows-11-arm' && matrix.python == "3.14"
+        run: |
+          pip install tf-nightly
           pip install .[tensorflow]
           # XXX: I assume this is still the case for 3.10
           # Force reinstall of numpy, tensorflow uses numpy 2 even on 3.9

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -98,7 +98,7 @@ jobs:
           sudo apt-get install libhdf5-dev
 
       - name: Install (tensorflow)
-        if: matrix.version.arch != 'x64-freethreaded' && matrix.os != 'windows-11-arm' && matrix.python != '3.14'
+        if: matrix.version.arch != 'x64-freethreaded' && matrix.os != 'windows-11-arm' && matrix.version.python != '3.14'
         run: |
           pip install .[tensorflow]
           # XXX: I assume this is still the case for 3.10
@@ -107,7 +107,7 @@ jobs:
         shell: bash
 
       - name: Install (tensorflow) (Python 3.14)
-        if: matrix.version.arch != 'x64-freethreaded' && matrix.os != 'windows-11-arm' && matrix.python == '3.14'
+        if: matrix.version.arch != 'x64-freethreaded' && matrix.os != 'windows-11-arm' && matrix.version.python == '3.14'
         run: |
           pip install .[tf-nightly]
           # XXX: I assume this is still the case for 3.10

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -22,7 +22,6 @@ jobs:
               torch: torch
               python: "3.14"
               numpy: numpy
-              arch: "x64-freethreaded"
           - os: ubuntu-latest
             version:
               torch: torch

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -109,8 +109,7 @@ jobs:
       - name: Install (tensorflow) (Python 3.14)
         if: matrix.version.arch != 'x64-freethreaded' && matrix.os != 'windows-11-arm' && matrix.python == '3.14'
         run: |
-          pip install tf-nightly
-          pip install .[tensorflow]
+          pip install .[tf-nightly]
           # XXX: I assume this is still the case for 3.10
           # Force reinstall of numpy, tensorflow uses numpy 2 even on 3.9
           pip install ${{ matrix.version.numpy }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -148,7 +148,9 @@ jobs:
         run: |
           cargo test
           pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple ".[testing]"
-          pytest -sv tests/ --ignore=tests/test_tf_comparison.py
+          # importing msgpack._cmsgpack re-enables the GIL, so force-disable
+          # until msgpack declares support
+          PYTHON_GIL=0 pytest -sv tests/ --ignore=tests/test_tf_comparison.py
 
   test_s390x_big_endian:
     runs-on: ubuntu-latest

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -14,9 +14,15 @@ jobs:
         # new releases get automatically tested against
         version: [
           {torch: torch==2.4, python: "3.10", arch: "x64", numpy: numpy==1.26.4},
-          {torch: torch, python: "3.14", arch: "x64", numpy: numpy}
+          {torch: torch, python: "3.13", arch: "x64", numpy: numpy}
         ]
         include:
+          - os: ubuntu-latest
+            version:
+              torch: torch
+              python: "3.14"
+              numpy: numpy
+              arch: "x64-freethreaded"
           - os: ubuntu-latest
             version:
               torch: torch
@@ -32,14 +38,12 @@ jobs:
           - os: macos-latest
             version:
               torch: torch
-              python: "3.14"
+              python: "3.13"
               numpy: numpy
               arch: "arm64"
           - os: windows-11-arm
             version:
               torch: torch
-              # PyTorch doesn't ship win_arm64 3.14 wheels
-              # https://github.com/pytorch/pytorch/issues/161516
               python: "3.13"
               numpy: numpy
               arch: "arm64"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -96,7 +96,7 @@ jobs:
           sudo apt-get install libhdf5-dev
 
       - name: Install (tensorflow)
-        if: matrix.version.arch != 'x64-freethreaded' && matrix.os != 'windows-11-arm' && matrix.python != "3.14"
+        if: matrix.version.arch != 'x64-freethreaded' && matrix.os != 'windows-11-arm' && matrix.python != '3.14'
         run: |
           pip install .[tensorflow]
           # XXX: I assume this is still the case for 3.10
@@ -105,7 +105,7 @@ jobs:
         shell: bash
 
       - name: Install (tensorflow) (Python 3.14)
-        if: matrix.version.arch != 'x64-freethreaded' && matrix.os != 'windows-11-arm' && matrix.python == "3.14"
+        if: matrix.version.arch != 'x64-freethreaded' && matrix.os != 'windows-11-arm' && matrix.python == '3.14'
         run: |
           pip install tf-nightly
           pip install .[tensorflow]

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -20,7 +20,7 @@ jobs:
           - os: ubuntu-latest
             version:
               torch: torch
-              python: "3.13"
+              python: "3.14"
               numpy: numpy
               arch: "x64-freethreaded"
           - os: macos-15-intel
@@ -76,16 +76,10 @@ jobs:
         run: cargo audit -D warnings
 
       - name: Install (torch)
-        if: matrix.version.arch != 'x64-freethreaded' && matrix.os != 'windows-11-arm'
+        if: matrix.os != 'windows-11-arm'
         run: |
           pip install ${{ matrix.version.numpy }}
           pip install ${{ matrix.version.torch }}
-        shell: bash
-
-      - name: Install (torch freethreaded)
-        if: matrix.version.arch == 'x64-freethreaded'
-        run: |
-          pip install ${{ matrix.version.torch }} --index-url https://download.pytorch.org/whl/cu126
         shell: bash
 
       - name: Install (torch windows arm64)
@@ -96,7 +90,7 @@ jobs:
         shell: bash
 
       - name: Install (hdf5 non windows)
-        if: matrix.os == 'ubuntu-latest' && matrix.version.arch != 'x64-freethreaded'
+        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install libhdf5-dev
@@ -114,6 +108,14 @@ jobs:
         if: runner.os != 'Windows' && matrix.version.arch != 'x64-freethreaded'
         run:
           pip install .[jax]
+        shell: bash
+
+      - name: Install (jax, flax from source)
+        if: matrix.version.arch == 'x64-freethreaded'
+        run: |
+          # https://github.com/google/flax/issues/5027#issuecomment-3771977410
+          pip install git+https://github.com/google/flax.git
+          pip install jax jaxlib
         shell: bash
 
       - name: Install (mlx)
@@ -145,10 +147,8 @@ jobs:
         if: matrix.version.arch == 'x64-freethreaded'
         run: |
           cargo test
-          pip install ".[testingfree]"
-          pip install pytest numpy
-          pytest -sv tests/test_pt*
-          pytest -sv tests/test_simple.py
+          pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple ".[testing]"
+          pytest -sv tests/ --ignore=tests/test_tf_comparison.py
 
   test_s390x_big_endian:
     runs-on: ubuntu-latest

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -38,7 +38,9 @@ jobs:
           - os: windows-11-arm
             version:
               torch: torch
-              python: "3.14"
+              # PyTorch doesn't ship win_arm64 3.14 wheels
+              # https://github.com/pytorch/pytorch/issues/161516
+              python: "3.13"
               numpy: numpy
               arch: "arm64"
     defaults:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -101,35 +101,18 @@ jobs:
           sudo apt-get install libhdf5-dev
 
       - name: Install (tensorflow)
-        if: matrix.version.arch != 'x64-freethreaded' && matrix.os != 'windows-11-arm' && matrix.version.python != '3.14'
+        if: matrix.version.arch != 'x64-freethreaded' && matrix.os != 'windows-11-arm'
         run: |
-          pip install .[tensorflow]
-          # XXX: I assume this is still the case for 3.10
-          # Force reinstall of numpy, tensorflow uses numpy 2 even on 3.9
-          pip install ${{ matrix.version.numpy }}
-        shell: bash
-
-      - name: Install (tensorflow) (Python 3.14)
-        if: matrix.version.arch != 'x64-freethreaded' && matrix.os != 'windows-11-arm' && matrix.version.python == '3.14'
-        run: |
-          pip install .[tf-nightly]
+          pip install ".[${{ matrix.version.python == '3.14' && 'tf-nightly' || 'tensorflow' }}]"
           # XXX: I assume this is still the case for 3.10
           # Force reinstall of numpy, tensorflow uses numpy 2 even on 3.9
           pip install ${{ matrix.version.numpy }}
         shell: bash
 
       - name: Install (jax, flax)
-        if: runner.os != 'Windows' && matrix.version.arch != 'x64-freethreaded'
+        if: runner.os != 'Windows'
         run:
           pip install .[jax]
-        shell: bash
-
-      - name: Install (jax, flax from source)
-        if: matrix.version.arch == 'x64-freethreaded'
-        run: |
-          # https://github.com/google/flax/issues/5027#issuecomment-3771977410
-          pip install git+https://github.com/google/flax.git
-          pip install jax jaxlib
         shell: bash
 
       - name: Install (mlx)

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -32,6 +32,7 @@ Source = 'https://github.com/huggingface/safetensors'
 numpy = ["numpy>=1.24.6"]
 torch = ["safetensors[numpy]", "torch>=2.4"]
 tensorflow = ["safetensors[numpy]", "tensorflow>=2.11.0"]
+tf-nightly = ["safetensors[numpy]", "tf-nightly>=2.11.0"]
 # pinning tf version 2.11.0 for doc-builder
 pinned-tf = ["safetensors[numpy]", "tensorflow==2.18.0"]
 jax = ["safetensors[numpy]", "flax>=0.6.3", "jax>=0.3.25", "jaxlib>=0.3.25"]

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Typing :: Typed",
 ]
@@ -32,7 +33,7 @@ Source = 'https://github.com/huggingface/safetensors'
 numpy = ["numpy>=1.24.6"]
 torch = ["safetensors[numpy]", "torch>=2.4"]
 tensorflow = ["safetensors[numpy]", "tensorflow>=2.11.0"]
-tf-nightly = ["safetensors[numpy]", "tf-nightly>=2.11.0"]
+tf-nightly = ["safetensors[numpy]", "tf-nightly"]
 # pinning tf version 2.11.0 for doc-builder
 pinned-tf = ["safetensors[numpy]", "tensorflow==2.18.0"]
 jax = ["safetensors[numpy]", "flax>=0.6.3", "jax>=0.3.25", "jaxlib>=0.3.25"]
@@ -52,14 +53,6 @@ testing = [
   "hypothesis>=6.70.2",
   "fsspec>=2024.6.0",
   "s3fs>=2024.6.0",
-]
-testingfree = [
-  "safetensors[numpy]",
-  "setuptools_rust>=1.12.0",
-  "pytest>=9.0",
-  "pytest-benchmark>=5.2",
-  # "python-afl>=0.7.3",
-  "hypothesis>=6.70.2",
 ]
 all = [
   "safetensors[torch]",


### PR DESCRIPTION
# What does this PR do?

The test job using a free-threaded interpreter runs a limited subset of the full tests. 3.14 has improved ecosystem support so it's possible to run almost all the tests. Only tests needing tensorflow are skipped.

Towards fixing #698 and #572.

See https://github.com/ngoldbaum/safetensors/actions/runs/21296824658/job/61304498881?pr=4 for a passing CI run from my fork of safetensors.

## Implementation notes

Installing pytorch doesn't require nightlies anymore, so I deleted the special case in the CI configuration for free-threading.

Flax doesn't yet support Python 3.14 (see the issue I linked in my comment inline), so I install flax from source.

I'm using `--extra-index-url` to install h5py nightlies. There are cp314t h5py wheels available on the scientific python nightly repository.

I had to set `PYTHON_GIL=0` to work around msgpack not having support yet: https://github.com/msgpack/msgpack-python/issues/613#issuecomment-3381020635.
