### PR TITLE
Make SafetensorError pickle-able (fixes #684)

### DIFF
--- a/bindings/python/py_src/safetensors/__init__.py
+++ b/bindings/python/py_src/safetensors/__init__.py
@@ -1,6 +1,6 @@
 # Re-export this
 from ._safetensors_rust import (  # noqa: F401
-    SafetensorError,
+    SafetensorError as _RustSafetensorError,
     __version__,
     deserialize,
     safe_open,
@@ -8,3 +8,13 @@ from ._safetensors_rust import (  # noqa: F401
     serialize,
     serialize_file,
 )
+
+
+class SafetensorError(_RustSafetensorError):
+    """
+    Custom Python Exception for Safetensor errors.
+    Subclasses the Rust exception so it remains picklable (e.g. for multiprocessing).
+    """
+
+    def __reduce__(self):
+        return (SafetensorError, self.args)

--- a/bindings/python/tests/test_safetensor_error_pickle.py
+++ b/bindings/python/tests/test_safetensor_error_pickle.py
@@ -1,0 +1,24 @@
+"""
+Test that SafetensorError is picklable (fixes #684).
+"""
+import pickle
+import unittest
+
+from safetensors import SafetensorError
+
+
+class SafetensorErrorPickleTestCase(unittest.TestCase):
+    def test_safetensor_error_pickle_roundtrip_empty(self):
+        err = SafetensorError()
+        data = pickle.dumps(err)
+        restored = pickle.loads(data)
+        self.assertIsInstance(restored, SafetensorError)
+        self.assertEqual(restored.args, err.args)
+
+    def test_safetensor_error_pickle_roundtrip_with_message(self):
+        err = SafetensorError("Error while deserializing header")
+        data = pickle.dumps(err)
+        restored = pickle.loads(data)
+        self.assertIsInstance(restored, SafetensorError)
+        self.assertEqual(restored.args, err.args)
+        self.assertEqual(str(restored), str(err))


### PR DESCRIPTION
Fixes #684

**Problem:** `SafetensorError` is defined in the Rust extension (`_safetensors_rust`), so `pickle.dumps(SafetensorError())` fails (e.g. "Can't pickle: import of module 'safetensors_rust' failed"). Many integrations (multiprocessing, joblib, distributed workers) expect exceptions to be picklable.

**Solution:** Introduce a Python subclass of the Rust `SafetensorError` that implements `__reduce__`, and export it as `SafetensorError`. Exceptions raised from Rust are still caught by `except SafetensorError` (same type hierarchy). Pickling/unpickling now uses the Python class, so the Rust module is not required when unpickling.

- `bindings/python/py_src/safetensors/__init__.py`: Python `SafetensorError` subclass with `__reduce__(self) -> (SafetensorError, self.args)`.
- `bindings/python/tests/test_safetensor_error_pickle.py`: Tests for pickle round-trip (empty and with message).