### PR TITLE
ci: add riscv64 target to linux wheel build matrix

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -36,6 +36,8 @@ jobs:
             target: s390x
           - runner: ubuntu-latest
             target: ppc64le
+          - runner: ubuntu-latest
+            target: riscv64
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6


### PR DESCRIPTION
# What does this PR do?

Add `linux_riscv64` wheels to the release pipeline by including `riscv64gc-unknown-linux-gnu` as a cross-compilation target in the maturin-action matrix.

### Changes

- Add riscv64 runner entry (`ubuntu-latest`) to the `build_wheels` matrix
- Add `riscv64gc-unknown-linux-gnu` cargo target for cross-compilation
- No QEMU needed — maturin-action cross-compiles via cargo natively

Fixes #723

### Evidence

- Tested wheel: [safetensors-0.5.3-cp313-cp313-linux_riscv64.whl](https://github.com/gounthar/riscv64-python-wheels/releases/tag/v2026.03.07-cp313)
- Built natively on BananaPi F3 (SpacemiT K1, rv64imafdcv, 8 cores @ 1.6 GHz, 16 GB RAM)
- Imports and passes basic smoke test on riscv64

### Context

- maturin-action supports cross-compilation to riscv64gc-unknown-linux-gnu
- Several packages already ship riscv64 wheels: pydantic-core, watchfiles, rignore
- RISC-V hardware is shipping (SiFive, SpacemiT, Sophgo SG2044)

## AI model use

- [x] No AI model was used when making this PR.
- [ ] An AI model assisted me in developing this PR.
- [ ] Development of this PR was done by an AI model.