### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
     with:
       commit_sha: ${{ github.sha }}
       package: safetensors

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@main
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -12,15 +12,15 @@ jobs:
         working-directory: ./safetensors
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install Rust Stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           components: llvm-tools-preview
           override: true
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
 
       - name: Install cargo-llvm-cov for Ubuntu
         run: cargo install cargo-llvm-cov
@@ -29,7 +29,7 @@ jobs:
         run: cargo llvm-cov --release --lcov --output-path lcov.info
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
           working-directory: ./safetensors

--- a/.github/workflows/delete_doc_comment.yml
+++ b/.github/workflows/delete_doc_comment.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   delete:
-    uses: huggingface/doc-builder/.github/workflows/delete_doc_comment.yml@main
+    uses: huggingface/doc-builder/.github/workflows/delete_doc_comment.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
     secrets:
       comment_bot_token: ${{ secrets.COMMENT_BOT_TOKEN }}

--- a/.github/workflows/delete_doc_comment_trigger.yml
+++ b/.github/workflows/delete_doc_comment_trigger.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   delete:
-    uses: huggingface/doc-builder/.github/workflows/delete_doc_comment_trigger.yml@main
+    uses: huggingface/doc-builder/.github/workflows/delete_doc_comment_trigger.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
     with:
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/python-bench.yml
+++ b/.github/workflows/python-bench.yml
@@ -17,14 +17,14 @@ jobs:
     name: Performance regression check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           components: rustfmt, clippy
 
       - name: Install Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"
           architecture: "x64"
@@ -42,13 +42,13 @@ jobs:
           uv run pytest --benchmark-json output.json benches/
       # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5
         with:
           path: ./cache
           key: ${{ runner.os }}-benchmark
       # Run `github-action-benchmark` action
       - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372  # v1
         with:
           # What benchmark tool the output.txt came from
           tool: 'pytest'

--- a/.github/workflows/python-release-conda.yml
+++ b/.github/workflows/python-release-conda.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install miniconda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167  # v3
         with:
           auto-update-conda: true
           miniconda-version: "latest"
@@ -33,7 +33,7 @@ jobs:
         run: conda info
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Setup conda env
         shell: bash -l {0}
@@ -80,7 +80,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install miniconda
         run: |
@@ -102,7 +102,7 @@ jobs:
           conda info
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Setup conda env
         shell: bash -l {0}

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -46,19 +46,19 @@ jobs:
             arch: riscv64
             target: riscv64gc-unknown-linux-gnu
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: 3.x
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --manifest-path bindings/python/Cargo.toml
           sccache: 'true'
           manylinux: auto
       - name: Upload wheels
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: wheels-linux-${{ matrix.platform.arch }}
           path: dist
@@ -77,19 +77,19 @@ jobs:
           - runner: ubuntu-latest
             target: armv7
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: 3.x
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --manifest-path bindings/python/Cargo.toml
           sccache: 'true'
           manylinux: musllinux_1_2
       - name: Upload wheels
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: wheels-musllinux-${{ matrix.platform.target }}
           path: dist
@@ -106,19 +106,19 @@ jobs:
           - runner: windows-11-arm
             target: arm64
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: 3.x
           architecture: ${{ matrix.platform.target }}
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
         with:
           target: ${{ matrix.platform.target == 'arm64' && 'aarch64-pc-windows-msvc' || matrix.platform.target }}
           args: --release --out dist --manifest-path bindings/python/Cargo.toml
           sccache: 'true'
       - name: Upload wheels
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: wheels-windows-${{ matrix.platform.target }}
           path: dist
@@ -133,18 +133,18 @@ jobs:
           - runner: macos-14
             target: aarch64
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: 3.x
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --manifest-path bindings/python/Cargo.toml
           sccache: 'true'
       - name: Upload wheels
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: wheels-macos-${{ matrix.platform.target }}
           path: dist
@@ -152,14 +152,14 @@ jobs:
   sdist:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Build sdist
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
         with:
           command: sdist
           args: --out dist --manifest-path bindings/python/Cargo.toml
       - name: Upload sdist
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: wheels-sdist
           path: dist
@@ -177,14 +177,14 @@ jobs:
       # Used to generate artifact attestation
       attestations: write
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a  # v3
         with:
           subject-path: 'wheels-*/*'
       - name: Publish to PyPI
         if: "startsWith(github.ref, 'refs/tags/')"
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN_DIST}}
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -46,22 +46,22 @@ jobs:
         working-directory: ./bindings/python
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           components: rustfmt, clippy
 
       - name: Cargo install audit
         run: cargo install cargo-audit
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           workspaces: "bindings/python"
 
       - name: Install Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: ${{ matrix.version.python }}
           architecture: ${{ matrix.version.arch }}
@@ -157,11 +157,11 @@ jobs:
       packages: write
     name: Test bigendian - S390X
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
       - name: Can push to GHCR?
         id: canpush
         shell: bash
@@ -169,7 +169,7 @@ jobs:
           echo "value=${{ github.event.pull_request.head.repo.fork == false }}" >> "$GITHUB_OUTPUT"
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -185,13 +185,13 @@ jobs:
             type=sha
       - name: Login to Registry
         if: steps.canpush.outputs.value == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Test big endian
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           platforms: linux/s390x
           file: Dockerfile.s390x.test

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         fetch-depth: 0
     - name: Secret Scanning
-      uses: trufflesecurity/trufflehog@main
+      uses: trufflesecurity/trufflehog@6bd2d14f7a4bc1e569fa3550efa7ec632a4fa67b  # main
       with:
         extra_args: --results=verified,unknown
 

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@main
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
     with:
       package_name: safetensors
     secrets:


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `python-release.yml` | `actions/checkout` | `v6` | `v6.0.2` | `de0fac2e4500…` |
| `python-release.yml` | `actions/setup-python` | `v6` | `v6` | `a309ff8b426b…` |
| `python-release.yml` | `PyO3/maturin-action` | `v1` | `v1` | `04ac600d27cd…` |
| `python-release.yml` | `actions/upload-artifact` | `v6` | `v6` | `b7c566a772e6…` |
| `python-release.yml` | `actions/checkout` | `v6` | `v6.0.2` | `de0fac2e4500…` |
| `python-release.yml` | `actions/setup-python` | `v6` | `v6` | `a309ff8b426b…` |
| `python-release.yml` | `PyO3/maturin-action` | `v1` | `v1` | `04ac600d27cd…` |
| `python-release.yml` | `actions/upload-artifact` | `v6` | `v6` | `b7c566a772e6…` |
| `python-release.yml` | `actions/checkout` | `v6` | `v6.0.2` | `de0fac2e4500…` |
| `python-release.yml` | `actions/setup-python` | `v6` | `v6` | `a309ff8b426b…` |
| `python-release.yml` | `PyO3/maturin-action` | `v1` | `v1` | `04ac600d27cd…` |
| `python-release.yml` | `actions/upload-artifact` | `v6` | `v6` | `b7c566a772e6…` |
| `python-release.yml` | `actions/checkout` | `v6` | `v6.0.2` | `de0fac2e4500…` |
| `python-release.yml` | `actions/setup-python` | `v6` | `v6` | `a309ff8b426b…` |
| `python-release.yml` | `PyO3/maturin-action` | `v1` | `v1` | `04ac600d27cd…` |
| `python-release.yml` | `actions/upload-artifact` | `v6` | `v6` | `b7c566a772e6…` |
| `python-release.yml` | `actions/checkout` | `v6` | `v6.0.2` | `de0fac2e4500…` |
| `python-release.yml` | `PyO3/maturin-action` | `v1` | `v1` | `04ac600d27cd…` |
| `python-release.yml` | `actions/upload-artifact` | `v6` | `v6` | `b7c566a772e6…` |
| `python-release.yml` | `actions/download-artifact` | `v7` | `v7` | `37930b1c2aba…` |
| `python-release.yml` | `actions/attest-build-provenance` | `v3` | `v3` | `977bb373ede9…` |
| `python-release.yml` | `PyO3/maturin-action` | `v1` | `v1` | `04ac600d27cd…` |
| `python-bench.yml` | `actions/checkout` | `v6` | `v6.0.2` | `de0fac2e4500…` |
| `python-bench.yml` | `dtolnay/rust-toolchain` | `stable` | `stable` | `29eef336d9b2…` |
| `python-bench.yml` | `actions/setup-python` | `v6` | `v6` | `a309ff8b426b…` |
| `python-bench.yml` | `actions/cache` | `v5` | `v5` | `668228422ae6…` |
| `python-bench.yml` | `benchmark-action/github-action-benchmark` | `v1` | `v1` | `a60cea5bc7b4…` |
| `python-release-conda.yml` | `actions/checkout` | `v6` | `v6.0.2` | `de0fac2e4500…` |
| `python-release-conda.yml` | `conda-incubator/setup-miniconda` | `v3` | `v3` | `fc2d68f6413e…` |
| `python-release-conda.yml` | `dtolnay/rust-toolchain` | `stable` | `stable` | `29eef336d9b2…` |
| `python-release-conda.yml` | `actions/checkout` | `v6` | `v6.0.2` | `de0fac2e4500…` |
| `python-release-conda.yml` | `dtolnay/rust-toolchain` | `stable` | `stable` | `29eef336d9b2…` |
| `codecov.yml` | `actions/checkout` | `v6` | `v6.0.2` | `de0fac2e4500…` |
| `codecov.yml` | `dtolnay/rust-toolchain` | `stable` | `stable` | `29eef336d9b2…` |
| `codecov.yml` | `Swatinem/rust-cache` | `v2` | `v2` | `e18b497796c1…` |
| `codecov.yml` | `codecov/codecov-action` | `v5` | `v5` | `75cd11691c0f…` |
| `python.yml` | `actions/checkout` | `v6` | `v6.0.2` | `de0fac2e4500…` |
| `python.yml` | `dtolnay/rust-toolchain` | `stable` | `stable` | `29eef336d9b2…` |
| `python.yml` | `Swatinem/rust-cache` | `v2` | `v2` | `e18b497796c1…` |
| `python.yml` | `actions/setup-python` | `v6` | `v6` | `a309ff8b426b…` |
| `python.yml` | `actions/checkout` | `v6` | `v6.0.2` | `de0fac2e4500…` |
| `python.yml` | `docker/setup-qemu-action` | `v3` | `v3` | `c7c53464625b…` |
| `python.yml` | `docker/setup-buildx-action` | `v3` | `v3` | `8d2750c68a42…` |
| `python.yml` | `docker/metadata-action` | `v5` | `v5` | `c299e40c6544…` |
| `python.yml` | `docker/login-action` | `v3` | `v3` | `c94ce9fb4685…` |
| `python.yml` | `docker/build-push-action` | `v6` | `v6` | `10e90e3645ea…` |
| `build_documentation.yml` | `huggingface/doc-builder/.github/workflows/build_main_documentation.yml` | `main` | `main` | `90b4ee2c10b8…` |
| `build_pr_documentation.yml` | `huggingface/doc-builder/.github/workflows/build_pr_documentation.yml` | `main` | `main` | `90b4ee2c10b8…` |
| `delete_doc_comment.yml` | `huggingface/doc-builder/.github/workflows/delete_doc_comment.yml` | `main` | `main` | `90b4ee2c10b8…` |
| `delete_doc_comment_trigger.yml` | `huggingface/doc-builder/.github/workflows/delete_doc_comment_trigger.yml` | `main` | `main` | `90b4ee2c10b8…` |
| `upload_pr_documentation.yml` | `huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml` | `main` | `main` | `90b4ee2c10b8…` |
| `trufflehog.yml` | `actions/checkout` | `v6` | `v6.0.2` | `de0fac2e4500…` |
| `trufflehog.yml` | `trufflesecurity/trufflehog` | `main` | `main` | `6bd2d14f7a4b…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#248