### PR TITLE
fix(torch): cover f8 & f4 in big endian & unskip tests

### DIFF
--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -505,6 +505,8 @@ def _to_ndarray(tensor: torch.Tensor):
             _float8_e4m3fnuz: np.uint8,
             _float8_e5m2: np.uint8,
             _float8_e5m2fnuz: np.uint8,
+            _float8_e8m0: np.uint8,
+            _float4_e2m1_x2: np.uint8,
             torch.complex64: np.complex64,
         }
         npdtype = NPDTYPES[tensor.dtype]

--- a/bindings/python/tests/test_pt_comparison.py
+++ b/bindings/python/tests/test_pt_comparison.py
@@ -101,23 +101,42 @@ class TorchTestCase(unittest.TestCase):
             b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80\xbf\x00\x00\x80?",
         )
 
-    def test_odd_dtype_fp8(self):
+    def test_odd_dtype_fp8_e4m3fn(self):
         if not hasattr(torch, "float8_e4m3fn"):
             return  # torch.float8_e4m3fn requires 2.1
 
-        data = {
-            "test1": torch.tensor([-0.5], dtype=torch.float8_e4m3fn),
-            "test2": torch.tensor([-0.5], dtype=torch.float8_e5m2),
-        }
-        local = "./tests/data/out_safe_pt_mmap_small.safetensors"
+        data = {"test": torch.tensor([-0.5], dtype=torch.float8_e4m3fn)}
+        local = "./tests/data/out_safe_pt_mmap_small_e4m3fn.safetensors"
 
         save_file(data, local)
         reloaded = load_file(local)
-        # note: PyTorch doesn't implement torch.equal for float8 so we just compare the single element
-        self.assertEqual(reloaded["test1"].dtype, torch.float8_e4m3fn)
-        self.assertEqual(reloaded["test1"].item(), -0.5)
-        self.assertEqual(reloaded["test2"].dtype, torch.float8_e5m2)
-        self.assertEqual(reloaded["test2"].item(), -0.5)
+        self.assertEqual(reloaded["test"].dtype, torch.float8_e4m3fn)
+        self.assertEqual(reloaded["test"].item(), -0.5)
+
+    def test_odd_dtype_fp8_e5m2(self):
+        if not hasattr(torch, "float8_e5m2"):
+            return  # torch.float8_e5m2 requires 2.1
+
+        data = {"test": torch.tensor([-0.5], dtype=torch.float8_e5m2)}
+        local = "./tests/data/out_safe_pt_mmap_small_e5m2.safetensors"
+
+        save_file(data, local)
+        reloaded = load_file(local)
+        self.assertEqual(reloaded["test"].dtype, torch.float8_e5m2)
+        self.assertEqual(reloaded["test"].item(), -0.5)
+
+    def test_odd_dtype_fp8_e8m0(self):
+        if not hasattr(torch, "float8_e8m0fnu"):
+            return  # torch.float8_e8m0fnu requires 2.8
+
+        # E8M0 only represents positive powers of 2, so pick one that casts without loss.
+        data = {"test": torch.tensor([0.5], dtype=torch.float8_e8m0fnu)}
+        local = "./tests/data/out_safe_pt_mmap_small_e8m0.safetensors"
+
+        save_file(data, local)
+        reloaded = load_file(local)
+        self.assertEqual(reloaded["test"].dtype, torch.float8_e8m0fnu)
+        self.assertEqual(reloaded["test"].item(), 0.5)
 
     def test_odd_dtype_fp8_fnuz(self):
         if not hasattr(torch, "float8_e4m3fnuz"):

--- a/bindings/python/tests/test_pt_comparison.py
+++ b/bindings/python/tests/test_pt_comparison.py
@@ -102,8 +102,8 @@ class TorchTestCase(unittest.TestCase):
         )
 
     def test_odd_dtype_fp8(self):
-        if not hasattr(torch, "float8"):
-            return  # torch.float8 requires 2.1
+        if not hasattr(torch, "float8_e4m3fn"):
+            return  # torch.float8_e4m3fn requires 2.1
 
         data = {
             "test1": torch.tensor([-0.5], dtype=torch.float8_e4m3fn),
@@ -142,8 +142,8 @@ class TorchTestCase(unittest.TestCase):
         self.assertEqual(reloaded["test2"].item(), 0.5)
 
     def test_odd_dtype_fp4(self):
-        if not hasattr(torch, "float4"):
-            return  # torch.float4 requires 2.8
+        if not hasattr(torch, "float4_e2m1fn_x2"):
+            return  # torch.float4_e2m1fn_x2 requires 2.8
 
         test1 = torch.tensor([0.0], dtype=torch.float8_e8m0fnu)
         test2 = torch.empty(2, 2, device="cpu", dtype=torch.float4_e2m1fn_x2)


### PR DESCRIPTION
Two tests were skipped after the hasattr PR fix landed, `float8` and `float4` are not real torch dtypes.

`torch.float8_e8m0fnu` and `torch.float4_e2m1fn_x2` were missing the `NPDTYPES` table, it would've raised a `KeyError` on s390x.

