### PR TITLE
fix: multithreaded test on windows + hard fail on thread err

### DIFF
--- a/bindings/python/setup.cfg
+++ b/bindings/python/setup.cfg
@@ -53,3 +53,5 @@ max-line-length = 119
 
 [tool:pytest]
 doctest_optionflags=NUMBER NORMALIZE_WHITESPACE ELLIPSIS
+filterwarnings =
+    error::pytest.PytestUnhandledThreadExceptionWarning

--- a/bindings/python/tests/test_multithreaded.py
+++ b/bindings/python/tests/test_multithreaded.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import tempfile
 import threading
@@ -37,9 +38,12 @@ def test_multithreaded_roundtripping_numpy():
     def save_worker(tensors, barrier):
         barrier.wait()
         for _ in range(NUM_ITERATIONS):
-            with tempfile.NamedTemporaryFile() as fp:
-                save_file_np(tensors, fp.name)
-                loaded_tensors = load_file_np(fp.name)
+            # NamedTemporaryFile can't be reopened on Windows (ERROR_SHARING_VIOLATION
+            # due to delete-on-close semantics), so use a TemporaryDirectory + path join.
+            with tempfile.TemporaryDirectory() as tmpdir:
+                path = os.path.join(tmpdir, "test.safetensors")
+                save_file_np(tensors, path)
+                loaded_tensors = load_file_np(path)
                 for name, tensor in tensors.items():
                     assert np.all(loaded_tensors[name] == tensor)
 
@@ -58,9 +62,10 @@ def test_multithreaded_roundtripping_torch():
     def save_worker(tensors, barrier):
         barrier.wait()
         for _ in range(NUM_ITERATIONS):
-            with tempfile.NamedTemporaryFile() as fp:
-                save_file_pt(tensors, fp.name)
-                loaded_tensors = load_file_pt(fp.name)
+            with tempfile.TemporaryDirectory() as tmpdir:
+                path = os.path.join(tmpdir, "test.safetensors")
+                save_file_pt(tensors, path)
+                loaded_tensors = load_file_pt(path)
                 for name, tensor in tensors.items():
                     assert torch.all(loaded_tensors[name] == tensor)
 


### PR DESCRIPTION
background thread was failing due to a reopen error on windows: it isn't possible to re-open a fail opened in readonly (namedtemporaryfile delete-on-close semantics).

two changes:
- change namedtemporaryfile to temporarydirectory + path join
- hard fail on thread execptions