### PR TITLE
feat(python): opt-in CUDA fast path for safe_open (#729)

### DIFF
--- a/bindings/python/py_src/safetensors/__init__.py
+++ b/bindings/python/py_src/safetensors/__init__.py
@@ -3,8 +3,24 @@ from ._safetensors_rust import (  # noqa: F401
     SafetensorError,
     __version__,
     deserialize,
-    safe_open,
     _safe_open_handle,
     serialize,
     serialize_file,
 )
+from ._safetensors_rust import safe_open as _rust_safe_open
+
+
+def safe_open(filename, framework, device="cpu"):
+    """Open a safetensors file lazily.
+
+    Dispatches to the Rust implementation by default. When the environment
+    variable ``SAFETENSORS_FAST_CUDA=1`` is set and the caller requests a
+    torch tensor on a CUDA device, a Python wrapper routes reads through
+    CPU + pinned memory + async transfer on a dedicated stream. See
+    ``safetensors._fast_cuda`` for details.
+    """
+    from ._fast_cuda import FastCudaSafeOpen, fast_cuda_enabled
+
+    if fast_cuda_enabled(framework, device):
+        return FastCudaSafeOpen(filename, framework=framework, device=device)
+    return _rust_safe_open(filename, framework=framework, device=device)

--- a/bindings/python/py_src/safetensors/__init__.py
+++ b/bindings/python/py_src/safetensors/__init__.py
@@ -10,6 +10,14 @@ from ._safetensors_rust import (  # noqa: F401
 from ._safetensors_rust import safe_open as _rust_safe_open
 
 
+def _looks_like_cuda(device) -> bool:
+    if isinstance(device, int):
+        return True
+    if isinstance(device, str):
+        return device.startswith("cuda")
+    return getattr(device, "type", None) == "cuda"
+
+
 def safe_open(filename, framework, device="cpu"):
     """Open a safetensors file lazily.
 
@@ -19,8 +27,10 @@ def safe_open(filename, framework, device="cpu"):
     CPU + pinned memory + async transfer on a dedicated stream. See
     ``safetensors._fast_cuda`` for details.
     """
-    from ._fast_cuda import FastCudaSafeOpen, fast_cuda_enabled
+    # Short-circuit: non-cuda callers skip the fast-path import entirely.
+    if framework == "pt" and _looks_like_cuda(device):
+        from ._fast_cuda import FastCudaSafeOpen, fast_cuda_enabled
 
-    if fast_cuda_enabled(framework, device):
-        return FastCudaSafeOpen(filename, framework=framework, device=device)
+        if fast_cuda_enabled(framework, device):
+            return FastCudaSafeOpen(filename, framework=framework, device=device)
     return _rust_safe_open(filename, framework=framework, device=device)

--- a/bindings/python/py_src/safetensors/_fast_cuda.py
+++ b/bindings/python/py_src/safetensors/_fast_cuda.py
@@ -1,0 +1,129 @@
+"""Opt-in CUDA fast path for safe_open (torch only).
+
+Enabled by setting the environment variable ``SAFETENSORS_FAST_CUDA=1``.
+
+The default ``safe_open(device="cuda")`` path in the Rust bindings copies from
+a memory-mapped file region directly into GPU memory. Each cudaMemcpy serializes
+on kernel page faults for the underlying mmap pages, preventing overlap between
+disk I/O and GPU transfer.
+
+This wrapper instead:
+
+1. Reads tensors into host memory via the existing CPU path (leveraging the
+   OS page cache and sequential readahead).
+2. Applies ``madvise(MADV_SEQUENTIAL)`` to the file so the kernel prefetches
+   aggressively during the initial read.
+3. Pins the CPU tensor and issues an async ``.to(cuda, non_blocking=True)`` on
+   a dedicated CUDA stream, synchronized when the ``safe_open`` context exits.
+
+See https://github.com/huggingface/safetensors/issues/729 for the motivating
+benchmarks.
+
+Trade-offs:
+- Peak memory increases by the size of the largest tensor (briefly held in
+  both pinned CPU RAM and GPU VRAM during transfer).
+- Caller must use ``safe_open`` as a context manager so the stream is
+  synchronized before tensors are consumed.
+- Applies only when framework=="pt" and device is a CUDA device; other cases
+  fall through to the Rust implementation unchanged.
+"""
+
+from __future__ import annotations
+
+import mmap
+import os
+from typing import Any, Union
+
+
+def _is_cuda_device(device: Union[str, int, Any]) -> bool:
+    if isinstance(device, int):
+        return True
+    if isinstance(device, str):
+        return device.startswith("cuda")
+    # torch.device("cuda") — duck-typed check without importing torch.
+    return getattr(device, "type", None) == "cuda"
+
+
+def fast_cuda_enabled(framework: str, device: Union[str, int, Any]) -> bool:
+    """Return True if the fast-CUDA path should be used for this open."""
+    if os.environ.get("SAFETENSORS_FAST_CUDA", "0") != "1":
+        return False
+    if framework != "pt":
+        return False
+    return _is_cuda_device(device)
+
+
+def _apply_madvise_sequential(filename: str) -> None:
+    """Hint the kernel to prefetch the file sequentially. Best-effort."""
+    try:
+        fd = os.open(filename, os.O_RDONLY)
+        try:
+            size = os.fstat(fd).st_size
+            if size == 0:
+                return
+            mm = mmap.mmap(fd, size, access=mmap.ACCESS_READ)
+            try:
+                if hasattr(mm, "madvise") and hasattr(mmap, "MADV_SEQUENTIAL"):
+                    mm.madvise(mmap.MADV_SEQUENTIAL)
+            finally:
+                mm.close()
+        finally:
+            os.close(fd)
+    except OSError:
+        # madvise is a hint; failure is never fatal.
+        pass
+
+
+class FastCudaSafeOpen:
+    """Python wrapper that routes CUDA reads through CPU + pin + async transfer.
+
+    Mirrors the surface of ``safetensors._safetensors_rust.safe_open`` so it
+    can be substituted transparently inside a ``with`` block.
+    """
+
+    def __init__(
+        self,
+        filename: Union[str, os.PathLike],
+        framework: str,
+        device: Union[str, int, Any] = "cpu",
+    ) -> None:
+        # Deferred import so safetensors remains usable without torch installed
+        # for callers that never hit this path.
+        import torch
+
+        from ._safetensors_rust import safe_open as _rust_safe_open
+
+        self._device = device if not isinstance(device, int) else f"cuda:{device}"
+        self._inner = _rust_safe_open(str(filename), framework=framework, device="cpu")
+        self._stream = torch.cuda.Stream()
+        _apply_madvise_sequential(str(filename))
+
+    def __enter__(self) -> "FastCudaSafeOpen":
+        self._inner.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self._stream.synchronize()
+        return self._inner.__exit__(exc_type, exc_value, traceback)
+
+    def keys(self):
+        return self._inner.keys()
+
+    def offset_keys(self):
+        return self._inner.offset_keys()
+
+    def metadata(self):
+        return self._inner.metadata()
+
+    def get_slice(self, name: str):
+        # Slicing is a lazy operation against the mmap; we do not accelerate it.
+        return self._inner.get_slice(name)
+
+    def get_tensor(self, name: str):
+        import torch
+
+        cpu_tensor = self._inner.get_tensor(name)
+        pinned = cpu_tensor.pin_memory()
+        del cpu_tensor
+        with torch.cuda.stream(self._stream):
+            return pinned.to(self._device, non_blocking=True)

--- a/bindings/python/tests/test_fast_cuda.py
+++ b/bindings/python/tests/test_fast_cuda.py
@@ -1,0 +1,99 @@
+import os
+import tempfile
+import unittest
+
+import torch
+
+from safetensors import _rust_safe_open, safe_open
+from safetensors._fast_cuda import FastCudaSafeOpen, fast_cuda_enabled
+from safetensors.torch import save_file
+
+
+class FastCudaDispatcherTest(unittest.TestCase):
+    """fast_cuda_enabled gates the fast path correctly."""
+
+    def setUp(self):
+        self._prev = os.environ.pop("SAFETENSORS_FAST_CUDA", None)
+
+    def tearDown(self):
+        if self._prev is None:
+            os.environ.pop("SAFETENSORS_FAST_CUDA", None)
+        else:
+            os.environ["SAFETENSORS_FAST_CUDA"] = self._prev
+
+    def test_disabled_by_default(self):
+        self.assertFalse(fast_cuda_enabled("pt", "cuda"))
+        self.assertFalse(fast_cuda_enabled("pt", "cuda:0"))
+        self.assertFalse(fast_cuda_enabled("pt", 0))
+
+    def test_enabled_only_for_pt_and_cuda(self):
+        os.environ["SAFETENSORS_FAST_CUDA"] = "1"
+        self.assertTrue(fast_cuda_enabled("pt", "cuda"))
+        self.assertTrue(fast_cuda_enabled("pt", "cuda:0"))
+        self.assertTrue(fast_cuda_enabled("pt", 0))
+        self.assertFalse(fast_cuda_enabled("pt", "cpu"))
+        self.assertFalse(fast_cuda_enabled("tf", "cuda"))
+        self.assertFalse(fast_cuda_enabled("jax", "cuda"))
+        self.assertFalse(fast_cuda_enabled("numpy", "cuda"))
+
+    def test_non_one_values_disable(self):
+        os.environ["SAFETENSORS_FAST_CUDA"] = "0"
+        self.assertFalse(fast_cuda_enabled("pt", "cuda"))
+        os.environ["SAFETENSORS_FAST_CUDA"] = "true"  # only "1" enables
+        self.assertFalse(fast_cuda_enabled("pt", "cuda"))
+
+    def test_dispatcher_returns_rust_class_when_disabled(self):
+        with tempfile.NamedTemporaryFile(suffix=".safetensors", delete=False) as tmp:
+            path = tmp.name
+        try:
+            save_file({"a": torch.zeros(4)}, path)
+            with safe_open(path, framework="pt", device="cpu") as f:
+                self.assertIsInstance(f, _rust_safe_open)
+        finally:
+            os.unlink(path)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required for this test")
+class FastCudaRoundTripTest(unittest.TestCase):
+    """With the env var set and CUDA available, tensors round-trip bitwise."""
+
+    def setUp(self):
+        self._prev = os.environ.pop("SAFETENSORS_FAST_CUDA", None)
+
+    def tearDown(self):
+        if self._prev is None:
+            os.environ.pop("SAFETENSORS_FAST_CUDA", None)
+        else:
+            os.environ["SAFETENSORS_FAST_CUDA"] = self._prev
+
+    def test_fast_path_matches_rust_path(self):
+        torch.manual_seed(0)
+        tensors = {
+            "a": torch.randn(64, 64, dtype=torch.float32),
+            "b": torch.randint(0, 100, (32,), dtype=torch.int32),
+            "c": torch.randn(8, dtype=torch.float16),
+        }
+        with tempfile.NamedTemporaryFile(suffix=".safetensors", delete=False) as tmp:
+            path = tmp.name
+        try:
+            save_file(tensors, path)
+
+            baseline = {}
+            with _rust_safe_open(path, framework="pt", device="cuda") as f:
+                for k in f.keys():
+                    baseline[k] = f.get_tensor(k).cpu()
+
+            os.environ["SAFETENSORS_FAST_CUDA"] = "1"
+            with safe_open(path, framework="pt", device="cuda") as f:
+                self.assertIsInstance(f, FastCudaSafeOpen)
+                fast = {k: f.get_tensor(k) for k in f.keys()}
+
+            for k, v in fast.items():
+                self.assertEqual(v.device.type, "cuda")
+                self.assertTrue(torch.equal(v.cpu(), baseline[k]))
+        finally:
+            os.unlink(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds opt-in CUDA fast path for `safe_open`, gated by `SAFETENSORS_FAST_CUDA=1` env var. Torch-only; other frameworks untouched.

Addresses #729.

## Mechanism

The default `safe_open(device="cuda")` path copies from mmap regions directly into GPU memory. Each cudaMemcpy serializes on kernel page faults, preventing overlap between disk I/O and GPU transfer. The wrapper:

1. Opens the file via the existing Rust path with `device="cpu"`.
2. Applies `madvise(MADV_SEQUENTIAL)` for aggressive kernel readahead.
3. For each `get_tensor`, pins the CPU tensor and issues `.to(cuda, non_blocking=True)` on a dedicated CUDA stream.
4. Synchronizes the stream on context exit.

## Benchmarks

RTX 5090 / Ryzen 9950X3D, loading Gemma 4 26B-A4B (~48GB safetensors):

| Path                                  | Time | Throughput |
|---------------------------------------|------|------------|
| Current `safe_open(device="cuda")`    | 576s | 85 MB/s    |
| CPU + pin + async                     | 90s  | 550 MB/s   |
| CPU + pin + async + madvise           | 52s  | 956 MB/s   |

**Environment disclosure:** benchmarks run under WSL2 / Docker Desktop on Windows (WDDM driver). I don't have bare-metal Linux hardware; the mechanism (page-fault-serialized cudaMemcpy from mmap) is platform-agnostic so the pattern should reproduce on native Linux, but I cannot confirm.

## Opt-in rationale

- Peak memory briefly grows by the size of the largest tensor (pinned CPU + GPU simultaneously during transfer).
- Correct behavior depends on caller using `safe_open` as a context manager so the stream is synced before tensors are consumed.

These trade-offs argue for opt-in rather than default. Env var keeps the public API unchanged.

## Stopgap framing

Per discussion on #729, `mfuntowicz/hmll` is the long-term direction. This PR is intended as a stopgap that can be removed when hmll provides a CUDA path. The change is isolated to the Python binding layer; the Rust core is untouched.

## Tests

- Dispatcher gating (unit, no CUDA required): 4 tests
- Round-trip equality vs. Rust path (CUDA-gated, skipped when unavailable): 1 test
- Existing torch test suite: 55 pass unchanged