### PR TITLE
feat: bump version to `0.8.0-dev.0`

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safetensors-python"
-version = "0.7.0-dev.0"
+version = "0.8.0-dev.0"
 edition = "2021"
 rust-version = "1.74"
 

--- a/safetensors/Cargo.toml
+++ b/safetensors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safetensors"
-version = "0.7.0-dev.0"
+version = "0.8.0-dev.0"
 edition = "2021"
 rust-version = "1.80"
 homepage = "https://github.com/huggingface/safetensors"


### PR DESCRIPTION
Bumping to `0.8.0-dev.0` due to the API change in the `serialize` and `serialize_file` functions.