### PR TITLE
[MPS] Fast load of the tensors

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@2f8115f4d677905552b45ae1a67c799759fc8001  # main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@2430c1ec91d04667414e2fa31ecfc36c153ea391  # main
     with:
       commit_sha: ${{ github.sha }}
       package: safetensors

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@2f8115f4d677905552b45ae1a67c799759fc8001  # main
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@2430c1ec91d04667414e2fa31ecfc36c153ea391  # main
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/delete_doc_comment.yml
+++ b/.github/workflows/delete_doc_comment.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   delete:
-    uses: huggingface/doc-builder/.github/workflows/delete_doc_comment.yml@2f8115f4d677905552b45ae1a67c799759fc8001  # main
+    uses: huggingface/doc-builder/.github/workflows/delete_doc_comment.yml@2430c1ec91d04667414e2fa31ecfc36c153ea391  # main
     secrets:
       comment_bot_token: ${{ secrets.COMMENT_BOT_TOKEN }}

--- a/.github/workflows/delete_doc_comment_trigger.yml
+++ b/.github/workflows/delete_doc_comment_trigger.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   delete:
-    uses: huggingface/doc-builder/.github/workflows/delete_doc_comment_trigger.yml@2f8115f4d677905552b45ae1a67c799759fc8001  # main
+    uses: huggingface/doc-builder/.github/workflows/delete_doc_comment_trigger.yml@2430c1ec91d04667414e2fa31ecfc36c153ea391  # main
     with:
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@2f8115f4d677905552b45ae1a67c799759fc8001  # main
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@2430c1ec91d04667414e2fa31ecfc36c153ea391  # main
     with:
       package_name: safetensors
     secrets:

--- a/bindings/python/benches/bench_mps_load.py
+++ b/bindings/python/benches/bench_mps_load.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import argparse
+import contextlib
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import torch
+
+from safetensors.torch import load_file, save_file
+
+
+def create_llm(total_gb: float) -> dict[str, torch.Tensor]:
+    H, I, V, BPE = 4096, 12288, 151936, 2
+    Q, KV = 32 * 128, 8 * 128
+    fixed = (2 * V * H + H) * BPE
+    per_layer = (H * Q + 2 * H * KV + Q * H + 3 * H * I + 2 * H) * BPE
+    n = max(1, int((total_gb * 1024 ** 3 - fixed) / per_layer))
+    d = torch.bfloat16
+    t: dict[str, torch.Tensor] = {
+        "model.embed_tokens.weight": torch.empty((V, H), dtype=d),
+        "model.norm.weight": torch.empty((H,), dtype=d),
+        "lm_head.weight": torch.empty((V, H), dtype=d),
+    }
+    for i in range(n):
+        p = f"model.layers.{i}"
+        t[f"{p}.self_attn.q_proj.weight"] = torch.empty((Q, H), dtype=d)
+        t[f"{p}.self_attn.k_proj.weight"] = torch.empty((KV, H), dtype=d)
+        t[f"{p}.self_attn.v_proj.weight"] = torch.empty((KV, H), dtype=d)
+        t[f"{p}.self_attn.o_proj.weight"] = torch.empty((H, Q), dtype=d)
+        t[f"{p}.mlp.gate_proj.weight"] = torch.empty((I, H), dtype=d)
+        t[f"{p}.mlp.up_proj.weight"] = torch.empty((I, H), dtype=d)
+        t[f"{p}.mlp.down_proj.weight"] = torch.empty((H, I), dtype=d)
+        t[f"{p}.input_layernorm.weight"] = torch.empty((H,), dtype=d)
+        t[f"{p}.post_attention_layernorm.weight"] = torch.empty((H,), dtype=d)
+    print(f"  {n} layers, {len(t)} tensors")
+    return t
+
+
+@contextlib.contextmanager
+def force_slow():
+    saved = torch.mps.__dict__.pop("_host_alias_storage", None)
+    try:
+        yield
+    finally:
+        if saved is not None:
+            torch.mps._host_alias_storage = saved
+
+
+def purge() -> bool:
+    return subprocess.run(
+        ["sudo", "-n", "purge"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=30,
+    ).returncode == 0
+
+
+def time_one(path: str, fast: bool) -> float:
+    torch.mps.synchronize()
+    t0 = time.perf_counter()
+    ctx = contextlib.nullcontext() if fast else force_slow()
+    with ctx:
+        out = load_file(path, device="mps")
+    torch.mps.synchronize()
+    dt = time.perf_counter() - t0
+    for v in list(out.values())[:3]:
+        if v.numel():
+            v.flatten()[:1].item()
+    return dt
+
+
+def bench(path: str, iters: int, cold: bool) -> None:
+    n = os.path.getsize(path)
+    print(f"\nFile: {path}  ({n / 1024 ** 3:.2f} GB)\nwarmup...")
+    time_one(path, False); time_one(path, True)
+
+    rows = []
+    for label, fast in (("slow (safe_open)", False), ("fast (MPSBulkLoad)", True)):
+        ts = []
+        for i in range(iters):
+            if cold and not purge():
+                print("  ! sudo -n purge failed, results are warm-cache")
+                cold = False
+            dt = time_one(path, fast)
+            ts.append(dt)
+            print(f"  {label:20s} {i+1}/{iters}: {dt:6.3f}s  ({n/dt/1024**3:5.2f} GB/s)")
+        rows.append((label, min(ts), sum(ts) / len(ts)))
+
+    print(f"\n  {'path':22s} {'best':>8s} {'mean':>8s} {'GB/s':>8s}")
+    for lbl, b, m in rows:
+        print(f"  {lbl:22s} {b:6.3f}s {m:6.3f}s {n/b/1024**3:8.2f}")
+    print(f"\n  speedup: {rows[0][1] / rows[1][1]:.2f}x")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--file", type=Path, required=True)
+    p.add_argument("--gb", type=float, default=16.0)
+    p.add_argument("--iters", type=int, default=3)
+    p.add_argument("--cold", action="store_true")
+    a = p.parse_args()
+
+    if not torch.backends.mps.is_available():
+        sys.exit("MPS not available")
+    if not hasattr(torch.mps, "_host_alias_storage"):
+        sys.exit("needs torch.mps._host_alias_storage (pytorch #180961)")
+
+    path = str(a.file)
+    if not os.path.exists(path):
+        print(f"Generating {path} ({a.gb} GB target) ...")
+        t0 = time.perf_counter()
+        save_file(create_llm(a.gb), path)
+        print(f"  wrote {os.path.getsize(path) / 1024 ** 3:.2f} GB "
+              f"in {time.perf_counter() - t0:.1f}s")
+    bench(path, a.iters, a.cold)
+
+
+if __name__ == "__main__":
+    main()

--- a/bindings/python/benches/bench_mps_load.py
+++ b/bindings/python/benches/bench_mps_load.py
@@ -14,11 +14,11 @@ from safetensors.torch import load_file, save_file
 
 
 def create_llm(total_gb: float) -> dict[str, torch.Tensor]:
-    H, I, V, BPE = 4096, 12288, 151936, 2
+    H, I, V, BPE = 4096, 12288, 151936, 2  # noqa: E741
     Q, KV = 32 * 128, 8 * 128
     fixed = (2 * V * H + H) * BPE
     per_layer = (H * Q + 2 * H * KV + Q * H + 3 * H * I + 2 * H) * BPE
-    n = max(1, int((total_gb * 1024 ** 3 - fixed) / per_layer))
+    n = max(1, int((total_gb * 1024**3 - fixed) / per_layer))
     d = torch.bfloat16
     t: dict[str, torch.Tensor] = {
         "model.embed_tokens.weight": torch.empty((V, H), dtype=d),
@@ -51,10 +51,15 @@ def force_slow():
 
 
 def purge() -> bool:
-    return subprocess.run(
-        ["sudo", "-n", "purge"],
-        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=30,
-    ).returncode == 0
+    return (
+        subprocess.run(
+            ["sudo", "-n", "purge"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=30,
+        ).returncode
+        == 0
+    )
 
 
 def time_one(path: str, fast: bool) -> float:
@@ -73,8 +78,9 @@ def time_one(path: str, fast: bool) -> float:
 
 def bench(path: str, iters: int, cold: bool) -> None:
     n = os.path.getsize(path)
-    print(f"\nFile: {path}  ({n / 1024 ** 3:.2f} GB)\nwarmup...")
-    time_one(path, False); time_one(path, True)
+    print(f"\nFile: {path}  ({n / 1024**3:.2f} GB)\nwarmup...")
+    time_one(path, False)
+    time_one(path, True)
 
     rows = []
     for label, fast in (("slow (safe_open)", False), ("fast (MPSBulkLoad)", True)):
@@ -85,12 +91,14 @@ def bench(path: str, iters: int, cold: bool) -> None:
                 cold = False
             dt = time_one(path, fast)
             ts.append(dt)
-            print(f"  {label:20s} {i+1}/{iters}: {dt:6.3f}s  ({n/dt/1024**3:5.2f} GB/s)")
+            print(
+                f"  {label:20s} {i + 1}/{iters}: {dt:6.3f}s  ({n / dt / 1024**3:5.2f} GB/s)"
+            )
         rows.append((label, min(ts), sum(ts) / len(ts)))
 
     print(f"\n  {'path':22s} {'best':>8s} {'mean':>8s} {'GB/s':>8s}")
     for lbl, b, m in rows:
-        print(f"  {lbl:22s} {b:6.3f}s {m:6.3f}s {n/b/1024**3:8.2f}")
+        print(f"  {lbl:22s} {b:6.3f}s {m:6.3f}s {n / b / 1024**3:8.2f}")
     print(f"\n  speedup: {rows[0][1] / rows[1][1]:.2f}x")
 
 
@@ -112,8 +120,10 @@ def main() -> None:
         print(f"Generating {path} ({a.gb} GB target) ...")
         t0 = time.perf_counter()
         save_file(create_llm(a.gb), path)
-        print(f"  wrote {os.path.getsize(path) / 1024 ** 3:.2f} GB "
-              f"in {time.perf_counter() - t0:.1f}s")
+        print(
+            f"  wrote {os.path.getsize(path) / 1024**3:.2f} GB "
+            f"in {time.perf_counter() - t0:.1f}s"
+        )
     bench(path, a.iters, a.cold)
 
 

--- a/bindings/python/benches/bench_mps_load_cold.sh
+++ b/bindings/python/benches/bench_mps_load_cold.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+PYTHON="${PYTHON:-/Users/salia/Desktop/pytorch/.venv/bin/python}"
+SIZE_GB="${SIZE_GB:-16}"
+ITERS="${ITERS:-3}"
+CACHE_FILE="${CACHE_FILE:-/tmp/mps_bench_llm_${SIZE_GB}gb.safetensors}"
+
+sudo -v
+( while true; do sudo -n true; sleep 30; done ) &
+trap "kill $! 2>/dev/null || true" EXIT INT TERM
+
+exec "$PYTHON" benches/bench_mps_load.py \
+    --file "$CACHE_FILE" --gb "$SIZE_GB" --iters "$ITERS" --cold "$@"

--- a/bindings/python/benches/bench_mps_load_cold.sh
+++ b/bindings/python/benches/bench_mps_load_cold.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-PYTHON="${PYTHON:-/Users/salia/Desktop/pytorch/.venv/bin/python}"
+PYTHON="${PYTHON:-python3}"
 SIZE_GB="${SIZE_GB:-16}"
 ITERS="${ITERS:-3}"
 CACHE_FILE="${CACHE_FILE:-/tmp/mps_bench_llm_${SIZE_GB}gb.safetensors}"

--- a/bindings/python/py_src/safetensors/__init__.py
+++ b/bindings/python/py_src/safetensors/__init__.py
@@ -9,3 +9,9 @@ from ._safetensors_rust import (  # noqa: F401
     serialize,
     serialize_file,
 )
+
+try:
+    from ._safetensors_rust import mps_load_safetensors  # noqa: F401
+except ImportError:
+    # Only built on macOS targets.
+    mps_load_safetensors = None

--- a/bindings/python/py_src/safetensors/__init__.py
+++ b/bindings/python/py_src/safetensors/__init__.py
@@ -9,9 +9,3 @@ from ._safetensors_rust import (  # noqa: F401
     serialize,
     serialize_file,
 )
-
-try:
-    from ._safetensors_rust import mps_load_safetensors  # noqa: F401
-except ImportError:
-    # Only built on macOS targets.
-    mps_load_safetensors = None

--- a/bindings/python/py_src/safetensors/__init__.pyi
+++ b/bindings/python/py_src/safetensors/__init__.pyi
@@ -11,7 +11,10 @@
 # That generator emits typed stubs directly from Rust
 # signatures — no hand-editing, no drift.
 import os
-from typing import Dict, List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Union
+
+if TYPE_CHECKING:
+    import torch
 
 __version__: str
 
@@ -28,6 +31,18 @@ def deserialize(bytes):
         (`List[str, Dict[str, Dict[str, any]]]`):
             The deserialized content is like:
                 [("tensor_name", {"shape": [2, 3], "dtype": "F32", "data": b"\0\0.." }), (...)]
+    """
+    pass
+
+@staticmethod
+def mps_load_safetensors(filename: Union[str, "os.PathLike[str]"]) -> Dict[str, "torch.Tensor"]:
+    """
+    macOS/MPS only. Parses the safetensors header, bulk-allocates every tensor
+    on the MPS device, then releases the GIL and uses multiple OS threads that
+    each call `pread(2)` to fill the pre-allocated unified-memory buffers in
+    parallel. Mirrors pytorch/pytorch#179190 (`MPSBulkLoad.mm`).
+
+    Returns a `{name: torch.Tensor(device='mps')}` dict.
     """
     pass
 

--- a/bindings/python/py_src/safetensors/__init__.pyi
+++ b/bindings/python/py_src/safetensors/__init__.pyi
@@ -42,7 +42,7 @@ def mps_load_safetensors(
     macOS/MPS only. Parses the safetensors header, bulk-allocates every tensor
     on the MPS device, then releases the GIL and uses multiple OS threads that
     each call `pread(2)` to fill the pre-allocated unified-memory buffers in
-    parallel. Mirrors pytorch/pytorch#179190 (`MPSBulkLoad.mm`).
+    parallel.
 
     Returns a `{name: torch.Tensor(device='mps')}` dict.
     """

--- a/bindings/python/py_src/safetensors/__init__.pyi
+++ b/bindings/python/py_src/safetensors/__init__.pyi
@@ -35,7 +35,9 @@ def deserialize(bytes):
     pass
 
 @staticmethod
-def mps_load_safetensors(filename: Union[str, "os.PathLike[str]"]) -> Dict[str, "torch.Tensor"]:
+def mps_load_safetensors(
+    filename: Union[str, "os.PathLike[str]"],
+) -> Dict[str, "torch.Tensor"]:
     """
     macOS/MPS only. Parses the safetensors header, bulk-allocates every tensor
     on the MPS device, then releases the GIL and uses multiple OS threads that

--- a/bindings/python/py_src/safetensors/__init__.pyi
+++ b/bindings/python/py_src/safetensors/__init__.pyi
@@ -11,10 +11,7 @@
 # That generator emits typed stubs directly from Rust
 # signatures — no hand-editing, no drift.
 import os
-from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Union
-
-if TYPE_CHECKING:
-    import torch
+from typing import Dict, List, Optional, Sequence, Union
 
 __version__: str
 
@@ -31,20 +28,6 @@ def deserialize(bytes):
         (`List[str, Dict[str, Dict[str, any]]]`):
             The deserialized content is like:
                 [("tensor_name", {"shape": [2, 3], "dtype": "F32", "data": b"\0\0.." }), (...)]
-    """
-    pass
-
-@staticmethod
-def mps_load_safetensors(
-    filename: Union[str, "os.PathLike[str]"],
-) -> Dict[str, "torch.Tensor"]:
-    """
-    macOS/MPS only. Parses the safetensors header, bulk-allocates every tensor
-    on the MPS device, then releases the GIL and uses multiple OS threads that
-    each call `pread(2)` to fill the pre-allocated unified-memory buffers in
-    parallel.
-
-    Returns a `{name: torch.Tensor(device='mps')}` dict.
     """
     pass
 
@@ -238,6 +221,31 @@ class safe_open:
 
         with safe_open("model.safetensors", framework="pt", device=0) as f:
             tensor = f.get_tensor("embedding")
+
+        ```
+        """
+        pass
+
+    def get_tensors(self):
+        """
+        Returns every tensor in the file as a dict keyed by name.
+
+        Equivalent to iterating `offset_keys()` and calling `get_tensor` on
+        each, but specific `framework` + `device` combinations can take an
+        internal fast path (e.g. MPS with PyTorch ≥ 2.10's
+        `_host_alias_storage` bulk-allocates and fills tensors with parallel
+        `pread(2)`).
+
+        Returns:
+            (`Dict[str, Tensor]`):
+                A dict of all tensors in the file.
+
+        Example:
+        ```python
+        from safetensors import safe_open
+
+        with safe_open("model.safetensors", framework="pt", device="mps") as f:
+            state_dict = f.get_tensors()
 
         ```
         """

--- a/bindings/python/py_src/safetensors/flax.py
+++ b/bindings/python/py_src/safetensors/flax.py
@@ -119,11 +119,8 @@ def load_file(filename: Union[str, os.PathLike]) -> Dict[str, Array]:
     loaded = load_file(file_path)
     ```
     """
-    result = {}
     with safe_open(filename, framework="flax") as f:
-        for k in f.offset_keys():
-            result[k] = f.get_tensor(k)
-    return result
+        return f.get_tensors()
 
 
 def _np2jnp(numpy_dict: Dict[str, np.ndarray]) -> Dict[str, Array]:

--- a/bindings/python/py_src/safetensors/mlx.py
+++ b/bindings/python/py_src/safetensors/mlx.py
@@ -120,11 +120,8 @@ def load_file(filename: Union[str, os.PathLike]) -> Dict[str, mx.array]:
     loaded = load_file(file_path)
     ```
     """
-    result = {}
     with safe_open(filename, framework="mlx") as f:
-        for k in f.offset_keys():
-            result[k] = f.get_tensor(k)
-    return result
+        return f.get_tensors()
 
 
 def _np2mx(numpy_dict: Dict[str, np.ndarray]) -> Dict[str, mx.array]:

--- a/bindings/python/py_src/safetensors/numpy.py
+++ b/bindings/python/py_src/safetensors/numpy.py
@@ -142,11 +142,8 @@ def load_file(filename: Union[str, os.PathLike]) -> Dict[str, np.ndarray]:
     loaded = load_file(file_path)
     ```
     """
-    result = {}
     with safe_open(filename, framework="np") as f:
-        for k in f.offset_keys():
-            result[k] = f.get_tensor(k)
-    return result
+        return f.get_tensors()
 
 
 _TYPES = {

--- a/bindings/python/py_src/safetensors/paddle.py
+++ b/bindings/python/py_src/safetensors/paddle.py
@@ -141,15 +141,11 @@ def load_file(
     loaded = load_file(file_path)
     ```
     """
-    result = {}
     if paddle.__version__ >= "3.2.0":
         with safe_open(filename, framework="paddle", device=device) as f:
-            for k in f.offset_keys():
-                result[k] = f.get_tensor(k)
-    else:
-        flat = numpy.load_file(filename)
-        result = _np2paddle(flat, device)
-    return result
+            return f.get_tensors()
+    flat = numpy.load_file(filename)
+    return _np2paddle(flat, device)
 
 
 def _np2paddle(

--- a/bindings/python/py_src/safetensors/tensorflow.py
+++ b/bindings/python/py_src/safetensors/tensorflow.py
@@ -120,11 +120,8 @@ def load_file(filename: Union[str, os.PathLike]) -> Dict[str, tf.Tensor]:
     loaded = load_file(file_path)
     ```
     """
-    result = {}
     with safe_open(filename, framework="tf") as f:
-        for k in f.offset_keys():
-            result[k] = f.get_tensor(k)
-    return result
+        return f.get_tensors()
 
 
 def _np2tf(numpy_dict: Dict[str, np.ndarray]) -> Dict[str, tf.Tensor]:

--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -323,9 +323,9 @@ def save_file(
 
 def _is_mps_device(device: Union[str, int, torch.device]) -> bool:
     if isinstance(device, torch.device):
-        return device.type == "mps"
+        return device.type == "mps" and device.index in (None, 0)
     if isinstance(device, str):
-        return device == "mps" or device.startswith("mps:")
+        return device == "mps" or device == "mps:0"
     return False
 
 
@@ -354,19 +354,13 @@ def load_file(
     loaded = load_file(file_path)
     ```
     """
-    # Fast path: parse the header, bulk-allocate every tensor on the MPS device,
-    # then release the GIL and fill the pre-allocated MPS (shared-storage)
-    # buffers in parallel with pread(2). Modeled on
-    # https://github.com/pytorch/pytorch/issues/179190 (MPSBulkLoad.mm).
-    # Requires `torch.mps._writable_shared_buffer_ptr`, which exposes the
-    # writable MTLBuffer contents pointer; without it the loader would have
-    # to double-allocate (MPS + CPU staging), so we defer to the standard
-    # path on stock PyTorch.
+    # Fast path: parallel pread straight into MPS buffers via host-alias storage
+    # (pytorch/pytorch#179190, PR #180961). Falls through on stock PyTorch.
     if (
         _is_mps_device(device)
         and _mps_load_safetensors is not None
         and hasattr(torch, "mps")
-        and hasattr(torch.mps, "_writable_shared_buffer_ptr")
+        and hasattr(torch.mps, "_host_alias_storage")
     ):
         return _mps_load_safetensors(os.fspath(filename))
     result = {}

--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -355,7 +355,6 @@ def load_file(
     ```
     """
     # Fast path: parallel pread straight into MPS buffers via host-alias storage
-    # (pytorch/pytorch#179190, PR #180961). Falls through on stock PyTorch.
     if (
         _is_mps_device(device)
         and _mps_load_safetensors is not None

--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -7,6 +7,7 @@ import torch
 from safetensors import (
     TensorSpec,
     deserialize,
+    mps_load_safetensors as _mps_load_safetensors,
     safe_open,
     serialize,
     serialize_file,
@@ -320,6 +321,14 @@ def save_file(
     )
 
 
+def _is_mps_device(device: Union[str, int, torch.device]) -> bool:
+    if isinstance(device, torch.device):
+        return device.type == "mps"
+    if isinstance(device, str):
+        return device == "mps" or device.startswith("mps:")
+    return False
+
+
 def load_file(
     filename: Union[str, os.PathLike], device: Union[str, int] = "cpu"
 ) -> Dict[str, torch.Tensor]:
@@ -345,6 +354,21 @@ def load_file(
     loaded = load_file(file_path)
     ```
     """
+    # Fast path: parse the header, bulk-allocate every tensor on the MPS device,
+    # then release the GIL and fill the pre-allocated MPS (shared-storage)
+    # buffers in parallel with pread(2). Modeled on
+    # https://github.com/pytorch/pytorch/issues/179190 (MPSBulkLoad.mm).
+    # Requires `torch.mps._writable_shared_buffer_ptr`, which exposes the
+    # writable MTLBuffer contents pointer; without it the loader would have
+    # to double-allocate (MPS + CPU staging), so we defer to the standard
+    # path on stock PyTorch.
+    if (
+        _is_mps_device(device)
+        and _mps_load_safetensors is not None
+        and hasattr(torch, "mps")
+        and hasattr(torch.mps, "_writable_shared_buffer_ptr")
+    ):
+        return _mps_load_safetensors(os.fspath(filename))
     result = {}
     with safe_open(filename, framework="pt", device=device) as f:
         for k in f.offset_keys():

--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -7,7 +7,6 @@ import torch
 from safetensors import (
     TensorSpec,
     deserialize,
-    mps_load_safetensors as _mps_load_safetensors,
     safe_open,
     serialize,
     serialize_file,
@@ -321,14 +320,6 @@ def save_file(
     )
 
 
-def _is_mps_device(device: Union[str, int, torch.device]) -> bool:
-    if isinstance(device, torch.device):
-        return device.type == "mps" and device.index in (None, 0)
-    if isinstance(device, str):
-        return device == "mps" or device == "mps:0"
-    return False
-
-
 def load_file(
     filename: Union[str, os.PathLike], device: Union[str, int] = "cpu"
 ) -> Dict[str, torch.Tensor]:
@@ -354,19 +345,8 @@ def load_file(
     loaded = load_file(file_path)
     ```
     """
-    # Fast path: parallel pread straight into MPS buffers via host-alias storage
-    if (
-        _is_mps_device(device)
-        and _mps_load_safetensors is not None
-        and hasattr(torch, "mps")
-        and hasattr(torch.mps, "_host_alias_storage")
-    ):
-        return _mps_load_safetensors(os.fspath(filename))
-    result = {}
     with safe_open(filename, framework="pt", device=device) as f:
-        for k in f.offset_keys():
-            result[k] = f.get_tensor(k)
-    return result
+        return f.get_tensors()
 
 
 def load(data: bytes) -> Dict[str, torch.Tensor]:

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1715,7 +1715,7 @@ impl _safe_open_handle {
 
 /// Bulk-allocates MPS tensors, then parallel-`pread`s straight into their
 /// host-aliased MTLBuffers (via `torch.mps._host_alias_storage`). Caller
-/// must confirm the API exists. See pytorch/pytorch#179190.
+/// must confirm the API exists. See pytorch/pytorch#180961.
 #[cfg(target_os = "macos")]
 #[pyfunction]
 fn mps_load_safetensors(py: Python<'_>, filename: PathBuf) -> PyResult<Py<PyDict>> {

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -33,7 +33,7 @@ static PADDLE_MODULE: OnceLock<Py<PyModule>> = OnceLock::new();
 /// The dtype string is validated at construction; an unknown dtype raises
 /// immediately rather than failing further inside the serializer.
 ///
-/// `shape` is the logical (header) shape — the number of elements along each
+/// `shape` is the logical (header) shape - the number of elements along each
 /// axis as recorded in the safetensors header. For packed dtypes like
 /// `float4_e2m1fn_x2` (two F4 values per byte), callers may pass the storage
 /// shape reported by their framework (e.g. `torch.Size`); the constructor
@@ -86,7 +86,7 @@ impl TensorSpec {
         format!("{}", self.dtype)
     }
 
-    /// The tensor's logical shape — the element-count shape recorded in the
+    /// The tensor's logical shape - the element-count shape recorded in the
     /// safetensors header. For packed dtypes like `float4_e2m1fn_x2`, this is
     /// the last-dim-doubled version of whatever was passed to the constructor.
     #[getter]
@@ -1713,23 +1713,9 @@ impl _safe_open_handle {
     }
 }
 
-/// Parallel safetensors loader targeting Apple Silicon MPS.
-///
-/// Approach modeled on pytorch/pytorch#179190 (`MPSBulkLoad.mm`):
-///
-/// 1. parse the safetensors header,
-/// 2. bulk-allocate every output tensor directly on MPS and, for each one,
-///    call `torch.mps._writable_shared_buffer_ptr(tensor)` to get the
-///    host-writable MTLBuffer `[contents]` pointer — this is the allocator
-///    hook the MPS bulk-loader PR added,
-/// 3. `torch.mps.synchronize()` to flush any pending GPU work,
-/// 4. release the GIL and fan `pread(2)` out across OS threads, writing
-///    straight into the shared-storage MTLBuffers (no CPU staging copy),
-/// 5. `torch.mps.synchronize()` so subsequent GPU reads see the CPU writes.
-///
-/// Callers are expected to check that `torch.mps._writable_shared_buffer_ptr`
-/// exists before dispatching here — the Python `load_file` wrapper handles
-/// that and falls back to the standard `safe_open` path on stock PyTorch.
+/// Bulk-allocates MPS tensors, then parallel-`pread`s straight into their
+/// host-aliased MTLBuffers (via `torch.mps._host_alias_storage`). Caller
+/// must confirm the API exists. See pytorch/pytorch#179190.
 #[cfg(target_os = "macos")]
 #[pyfunction]
 fn mps_load_safetensors(py: Python<'_>, filename: PathBuf) -> PyResult<Py<PyDict>> {
@@ -1740,7 +1726,7 @@ fn mps_load_safetensors(py: Python<'_>, filename: PathBuf) -> PyResult<Py<PyDict
         name: String,
         file_offset: u64,
         nbytes: usize,
-        // Host-writable ptr into the MTLBuffer contents backing the tensor.
+        // Host-writable MTLBuffer pointer.
         write_ptr: usize,
     }
 
@@ -1759,13 +1745,14 @@ fn mps_load_safetensors(py: Python<'_>, filename: PathBuf) -> PyResult<Py<PyDict
 
     let torch = PyModule::import(py, intern!(py, "torch"))?;
     let mps_mod = torch.getattr(intern!(py, "mps"))?;
-    let writable_ptr_fn = mps_mod.getattr(intern!(py, "_writable_shared_buffer_ptr"))?;
+    let host_alias_fn = mps_mod.getattr(intern!(py, "_host_alias_storage"))?;
     let mps_device: Py<PyAny> = "mps".into_pyobject(py)?.into();
 
-    // Bulk-allocate every tensor on MPS and grab its writable storage pointer
-    // in one GIL acquisition.
+    // Allocate every tensor and collect host-alias pointers under the GIL.
     let keys = metadata.offset_keys();
     let mut mps_tensors: Vec<PyBound<'_, PyAny>> = Vec::with_capacity(keys.len());
+    // Aliases pin the source MPS storages; keep alive across parallel writes.
+    let mut host_aliases: Vec<PyBound<'_, PyAny>> = Vec::with_capacity(keys.len());
     let mut jobs: Vec<Job> = Vec::with_capacity(keys.len());
     for name in keys {
         let info = metadata.info(&name).ok_or_else(|| {
@@ -1773,9 +1760,7 @@ fn mps_load_safetensors(py: Python<'_>, filename: PathBuf) -> PyResult<Py<PyDict
         })?;
         let dtype_obj: Py<PyAny> = get_pydtype(&torch, info.dtype, false)?;
 
-        // Packed dtypes (F4: two elements per byte) record the logical element
-        // count in the safetensors header, but torch stores them at half the
-        // last-dim length. Mirror the halving done by the `safe_open` path.
+        // F4 stores two elements per byte; torch shape halves the last dim.
         let mut torch_shape = info.shape.clone();
         if info.dtype == Dtype::F4 {
             let n = torch_shape.len();
@@ -1802,11 +1787,15 @@ fn mps_load_safetensors(py: Python<'_>, filename: PathBuf) -> PyResult<Py<PyDict
         let write_ptr: usize = if nbytes == 0 {
             0
         } else {
-            writable_ptr_fn.call1((tensor.clone(),))?.extract()?
+            let mps_storage = tensor.call_method0(intern!(py, "untyped_storage"))?;
+            let cpu_alias = host_alias_fn.call1((mps_storage,))?;
+            let ptr: usize = cpu_alias.call_method0(intern!(py, "data_ptr"))?.extract()?;
+            host_aliases.push(cpu_alias);
+            ptr
         };
         if nbytes > 0 && write_ptr == 0 {
             return Err(SafetensorError::new_err(format!(
-                "torch.mps._writable_shared_buffer_ptr returned 0 for tensor {name} \
+                "torch.mps._host_alias_storage returned a null data_ptr for tensor {name} \
                  (non-shared-storage MPS allocation?)",
             )));
         }
@@ -1822,19 +1811,14 @@ fn mps_load_safetensors(py: Python<'_>, filename: PathBuf) -> PyResult<Py<PyDict
 
     drop(mmap);
 
-    // Flush any GPU work that might have been queued so CPU writes below
-    // don't race in-flight ops on the freshly-allocated buffers.
+    // Drain in-flight GPU work before writing through the CPU alias.
     let _ = mps_mod.call_method0(intern!(py, "synchronize"));
 
     let read_result: Result<(), (String, std::io::Error)> = py.detach(|| {
         let jobs = &jobs;
         let file = &file;
         let next = AtomicUsize::new(0);
-        // Cap worker count. `available_parallelism()` includes E-cores on
-        // Apple silicon; the upstream PyTorch MPS loader pins GCD to
-        // `QOS_CLASS_USER_INITIATED` which sticks to P-cores. std can't
-        // express that, so cap at 8 — past that, parallel pread is SSD-bound
-        // rather than CPU-bound on Apple silicon.
+        // Cap at 8: beyond P-core count reads are SSD-bound on Apple silicon.
         let n_workers = std::thread::available_parallelism()
             .map(|n| n.get())
             .unwrap_or(4)
@@ -1855,10 +1839,8 @@ fn mps_load_safetensors(py: Python<'_>, filename: PathBuf) -> PyResult<Py<PyDict
                         if job.nbytes == 0 {
                             continue;
                         }
-                        // SAFETY: `write_ptr` is the MTLBuffer `[contents]`
-                        // pointer of an MPS tensor kept alive by `mps_tensors`
-                        // until after `py.detach` returns. Each job owns a
-                        // distinct tensor so workers never alias.
+                        // SAFETY: each job owns a distinct tensor kept alive
+                        // by `mps_tensors` until after `py.detach` returns.
                         let buf = unsafe {
                             std::slice::from_raw_parts_mut(
                                 job.write_ptr as *mut u8,
@@ -1888,13 +1870,16 @@ fn mps_load_safetensors(py: Python<'_>, filename: PathBuf) -> PyResult<Py<PyDict
         )));
     }
 
-    // Synchronize so subsequent GPU reads see the CPU writes.
+    // Make CPU writes visible to subsequent GPU reads.
     let _ = mps_mod.call_method0(intern!(py, "synchronize"));
 
     let result = PyDict::new(py);
     for (job, tensor) in jobs.iter().zip(mps_tensors.into_iter()) {
         result.set_item(&job.name, tensor)?;
     }
+
+    // Drop aliases after synchronize so pinned MPS storages outlive writes.
+    drop(host_aliases);
 
     Ok(result.into())
 }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1812,7 +1812,7 @@ fn mps_load_safetensors(py: Python<'_>, filename: PathBuf) -> PyResult<Py<PyDict
     drop(mmap);
 
     // Drain in-flight GPU work before writing through the CPU alias.
-    let _ = mps_mod.call_method0(intern!(py, "synchronize"));
+    mps_mod.call_method0(intern!(py, "synchronize"))?;
 
     let read_result: Result<(), (String, std::io::Error)> = py.detach(|| {
         let jobs = &jobs;
@@ -1868,7 +1868,7 @@ fn mps_load_safetensors(py: Python<'_>, filename: PathBuf) -> PyResult<Py<PyDict
     }
 
     // Make CPU writes visible to subsequent GPU reads.
-    let _ = mps_mod.call_method0(intern!(py, "synchronize"));
+    mps_mod.call_method0(intern!(py, "synchronize"))?;
 
     let result = PyDict::new(py);
     for (job, tensor) in jobs.iter().zip(mps_tensors) {

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1707,12 +1707,200 @@ impl _safe_open_handle {
     }
 }
 
+/// Parallel safetensors loader targeting Apple Silicon MPS.
+///
+/// Approach modeled on pytorch/pytorch#179190 (`MPSBulkLoad.mm`):
+///
+/// 1. parse the safetensors header,
+/// 2. bulk-allocate every output tensor directly on MPS and, for each one,
+///    call `torch.mps._writable_shared_buffer_ptr(tensor)` to get the
+///    host-writable MTLBuffer `[contents]` pointer — this is the allocator
+///    hook the MPS bulk-loader PR added,
+/// 3. `torch.mps.synchronize()` to flush any pending GPU work,
+/// 4. release the GIL and fan `pread(2)` out across OS threads, writing
+///    straight into the shared-storage MTLBuffers (no CPU staging copy),
+/// 5. `torch.mps.synchronize()` so subsequent GPU reads see the CPU writes.
+///
+/// Callers are expected to check that `torch.mps._writable_shared_buffer_ptr`
+/// exists before dispatching here — the Python `load_file` wrapper handles
+/// that and falls back to the standard `safe_open` path on stock PyTorch.
+#[cfg(target_os = "macos")]
+#[pyfunction]
+fn mps_load_safetensors(py: Python<'_>, filename: PathBuf) -> PyResult<Py<PyDict>> {
+    use std::os::unix::fs::FileExt;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct Job {
+        name: String,
+        file_offset: u64,
+        nbytes: usize,
+        // Host-writable ptr into the MTLBuffer contents backing the tensor.
+        write_ptr: usize,
+    }
+
+    let file = File::open(&filename).map_err(|e| {
+        PyFileNotFoundError::new_err(format!("Could not open {}: {e}", filename.display()))
+    })?;
+    let mmap = unsafe {
+        MmapOptions::new().map(&file).map_err(|e| {
+            SafetensorError::new_err(format!("Could not mmap {}: {e}", filename.display()))
+        })?
+    };
+    let (header_len, metadata) = SafeTensors::read_metadata(&mmap).map_err(|e| {
+        SafetensorError::new_err(format!("Could not read safetensors header: {e:?}"))
+    })?;
+    let data_start = header_len + 8;
+
+    let torch = PyModule::import(py, intern!(py, "torch"))?;
+    let mps_mod = torch.getattr(intern!(py, "mps"))?;
+    let writable_ptr_fn = mps_mod.getattr(intern!(py, "_writable_shared_buffer_ptr"))?;
+    let mps_device: Py<PyAny> = "mps".into_pyobject(py)?.into();
+
+    // Bulk-allocate every tensor on MPS and grab its writable storage pointer
+    // in one GIL acquisition.
+    let keys = metadata.offset_keys();
+    let mut mps_tensors: Vec<PyBound<'_, PyAny>> = Vec::with_capacity(keys.len());
+    let mut jobs: Vec<Job> = Vec::with_capacity(keys.len());
+    for name in keys {
+        let info = metadata.info(&name).ok_or_else(|| {
+            SafetensorError::new_err(format!("Missing tensor info for {name}"))
+        })?;
+        let dtype_obj: Py<PyAny> = get_pydtype(&torch, info.dtype, false)?;
+
+        // Packed dtypes (F4: two elements per byte) record the logical element
+        // count in the safetensors header, but torch stores them at half the
+        // last-dim length. Mirror the halving done by the `safe_open` path.
+        let mut torch_shape = info.shape.clone();
+        if info.dtype == Dtype::F4 {
+            let n = torch_shape.len();
+            if n == 0 || torch_shape[n - 1] % 2 != 0 {
+                return Err(SafetensorError::new_err(format!(
+                    "f4_x2 dtype requires the last dim be divisible by 2 in torch: got {:?}",
+                    info.shape,
+                )));
+            }
+            torch_shape[n - 1] /= 2;
+        }
+        let shape_obj: Py<PyAny> = torch_shape.into_pyobject(py)?.into();
+
+        let kwargs = [
+            (intern!(py, "dtype"), dtype_obj),
+            (intern!(py, "device"), mps_device.clone_ref(py)),
+        ]
+        .into_py_dict(py)?;
+        let tensor = torch.call_method("empty", (shape_obj,), Some(&kwargs))?;
+
+        let (begin, end) = info.data_offsets;
+        let nbytes = end - begin;
+
+        let write_ptr: usize = if nbytes == 0 {
+            0
+        } else {
+            writable_ptr_fn.call1((tensor.clone(),))?.extract()?
+        };
+        if nbytes > 0 && write_ptr == 0 {
+            return Err(SafetensorError::new_err(format!(
+                "torch.mps._writable_shared_buffer_ptr returned 0 for tensor {name} \
+                 (non-shared-storage MPS allocation?)",
+            )));
+        }
+
+        jobs.push(Job {
+            name: name.clone(),
+            file_offset: (data_start + begin) as u64,
+            nbytes,
+            write_ptr,
+        });
+        mps_tensors.push(tensor);
+    }
+
+    drop(mmap);
+
+    // Flush any GPU work that might have been queued so CPU writes below
+    // don't race in-flight ops on the freshly-allocated buffers.
+    let _ = mps_mod.call_method0(intern!(py, "synchronize"));
+
+    let read_result: Result<(), (String, std::io::Error)> = py.detach(|| {
+        let jobs = &jobs;
+        let file = &file;
+        let next = AtomicUsize::new(0);
+        // Cap worker count. `available_parallelism()` includes E-cores on
+        // Apple silicon; the upstream PyTorch MPS loader pins GCD to
+        // `QOS_CLASS_USER_INITIATED` which sticks to P-cores. std can't
+        // express that, so cap at 8 — past that, parallel pread is SSD-bound
+        // rather than CPU-bound on Apple silicon.
+        let n_workers = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(4)
+            .min(8)
+            .min(jobs.len().max(1));
+
+        std::thread::scope(|s| -> Result<(), (String, std::io::Error)> {
+            let mut handles = Vec::with_capacity(n_workers);
+            for _ in 0..n_workers {
+                let next = &next;
+                handles.push(s.spawn(move || -> Result<(), (String, std::io::Error)> {
+                    loop {
+                        let i = next.fetch_add(1, Ordering::Relaxed);
+                        if i >= jobs.len() {
+                            return Ok(());
+                        }
+                        let job = &jobs[i];
+                        if job.nbytes == 0 {
+                            continue;
+                        }
+                        // SAFETY: `write_ptr` is the MTLBuffer `[contents]`
+                        // pointer of an MPS tensor kept alive by `mps_tensors`
+                        // until after `py.detach` returns. Each job owns a
+                        // distinct tensor so workers never alias.
+                        let buf = unsafe {
+                            std::slice::from_raw_parts_mut(
+                                job.write_ptr as *mut u8,
+                                job.nbytes,
+                            )
+                        };
+                        file.read_exact_at(buf, job.file_offset)
+                            .map_err(|e| (job.name.clone(), e))?;
+                    }
+                }));
+            }
+            for h in handles {
+                h.join().map_err(|_| {
+                    (
+                        "<worker panic>".to_string(),
+                        std::io::Error::other("worker panicked"),
+                    )
+                })??;
+            }
+            Ok(())
+        })
+    });
+
+    if let Err((name, e)) = read_result {
+        return Err(SafetensorError::new_err(format!(
+            "pread failed for tensor {name}: {e}"
+        )));
+    }
+
+    // Synchronize so subsequent GPU reads see the CPU writes.
+    let _ = mps_mod.call_method0(intern!(py, "synchronize"));
+
+    let result = PyDict::new(py);
+    for (job, tensor) in jobs.iter().zip(mps_tensors.into_iter()) {
+        result.set_item(&job.name, tensor)?;
+    }
+
+    Ok(result.into())
+}
+
 /// A Python module implemented in Rust.
 #[pymodule(gil_used = false)]
 fn _safetensors_rust(m: &PyBound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(serialize, m)?)?;
     m.add_function(wrap_pyfunction!(serialize_file, m)?)?;
     m.add_function(wrap_pyfunction!(deserialize, m)?)?;
+    #[cfg(target_os = "macos")]
+    m.add_function(wrap_pyfunction!(mps_load_safetensors, m)?)?;
     m.add_class::<TensorSpec>()?;
     m.add_class::<safe_open>()?;
     m.add_class::<_safe_open_handle>()?;

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -27,6 +27,9 @@ static FLAX_MODULE: OnceLock<Py<PyModule>> = OnceLock::new();
 static MLX_MODULE: OnceLock<Py<PyModule>> = OnceLock::new();
 static PADDLE_MODULE: OnceLock<Py<PyModule>> = OnceLock::new();
 
+#[cfg(target_os = "macos")]
+static MPS_HOST_ALIAS_AVAILABLE: OnceLock<bool> = OnceLock::new();
+
 /// Describes a single tensor passed to [`serialize`] / [`serialize_file`].
 ///
 /// Constructed from Python as `TensorSpec(dtype, shape, data_ptr, data_len)`.
@@ -542,6 +545,7 @@ impl Version {
 }
 
 struct Open {
+    filename: PathBuf,
     metadata: Metadata,
     offset: usize,
     framework: Framework,
@@ -689,6 +693,7 @@ impl Open {
         let storage = Arc::new(storage);
 
         Ok(Self {
+            filename,
             metadata,
             offset,
             framework,
@@ -942,6 +947,189 @@ impl Open {
         }
     }
 
+    /// Returns every tensor in the file as a `{name: Tensor}` dict.
+    ///
+    /// Default behavior is a sequential loop over `get_tensor`; specific
+    /// framework/device combinations can take an internal fast path (e.g.
+    /// MPS with `torch.mps._host_alias_storage` allocates all tensors
+    /// on-device and fills them with parallel `pread(2)` calls).
+    pub fn get_tensors(&self) -> PyResult<Py<PyDict>> {
+        #[cfg(target_os = "macos")]
+        if self.framework == Framework::Pytorch
+            && self.device == Device::Mps
+            && mps_host_alias_available()?
+        {
+            return self.get_tensors_mps_fast();
+        }
+
+        Python::attach(|py| -> PyResult<Py<PyDict>> {
+            let dict = PyDict::new(py);
+            for name in self.metadata.offset_keys() {
+                let tensor = self.get_tensor(&name)?;
+                dict.set_item(&name, tensor)?;
+            }
+            Ok(dict.into())
+        })
+    }
+
+    /// Bulk-allocates MPS tensors, then parallel-`pread`s straight into
+    /// their host-aliased MTLBuffers. Requires `torch.mps._host_alias_storage`
+    /// (pytorch/pytorch#180961); caller must have verified.
+    #[cfg(target_os = "macos")]
+    fn get_tensors_mps_fast(&self) -> PyResult<Py<PyDict>> {
+        use std::os::unix::fs::FileExt;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        // Only populated for non-empty tensors; zero-byte tensors are
+        // allocated as torch.empty and skipped entirely
+        struct Job {
+            name: String,
+            file_offset: u64,
+            nbytes: usize,
+            // Host-writable MTLBuffer pointer
+            write_ptr: usize,
+        }
+
+        let file = File::open(&self.filename).map_err(|e| {
+            PyFileNotFoundError::new_err(format!("Could not open {}: {e}", self.filename.display()))
+        })?;
+
+        Python::attach(|py| -> PyResult<Py<PyDict>> {
+            let torch = get_module(py, &TORCH_MODULE)?;
+            let mps_mod = torch.getattr(intern!(py, "mps"))?;
+            let host_alias_fn = mps_mod.getattr(intern!(py, "_host_alias_storage"))?;
+            let mps_device: Py<PyAny> = "mps".into_pyobject(py)?.into();
+
+            let keys = self.metadata.offset_keys();
+            let mut entries: Vec<(String, PyBound<'_, PyAny>)> = Vec::with_capacity(keys.len());
+            // Aliases pin the source MPS storages; keep alive across parallel writes.
+            let mut host_aliases: Vec<PyBound<'_, PyAny>> = Vec::with_capacity(keys.len());
+            let mut jobs: Vec<Job> = Vec::with_capacity(keys.len());
+
+            for name in keys {
+                let info = self.metadata.info(&name).ok_or_else(|| {
+                    SafetensorError::new_err(format!("Missing tensor info for {name}"))
+                })?;
+                let dtype_obj: Py<PyAny> = get_pydtype(torch, info.dtype, false)?;
+
+                // F4 stores two elements per byte; torch shape halves the last dim.
+                let mut torch_shape = info.shape.clone();
+                if info.dtype == Dtype::F4 {
+                    let n = torch_shape.len();
+                    if n == 0 || torch_shape[n - 1] % 2 != 0 {
+                        return Err(SafetensorError::new_err(format!(
+                            "f4_x2 dtype requires the last dim be divisible by 2 in torch: got {:?}",
+                            info.shape,
+                        )));
+                    }
+                    torch_shape[n - 1] /= 2;
+                }
+                let shape_obj: Py<PyAny> = torch_shape.into_pyobject(py)?.into();
+
+                let kwargs = [
+                    (intern!(py, "dtype"), dtype_obj),
+                    (intern!(py, "device"), mps_device.clone_ref(py)),
+                ]
+                .into_py_dict(py)?;
+                let tensor = torch.call_method("empty", (shape_obj,), Some(&kwargs))?;
+
+                let (begin, end) = info.data_offsets;
+                let nbytes = end - begin;
+
+                if nbytes > 0 {
+                    let mps_storage = tensor.call_method0(intern!(py, "untyped_storage"))?;
+                    let cpu_alias = host_alias_fn.call1((mps_storage,))?;
+                    let write_ptr: usize =
+                        cpu_alias.call_method0(intern!(py, "data_ptr"))?.extract()?;
+                    if write_ptr == 0 {
+                        return Err(SafetensorError::new_err(format!(
+                            "torch.mps._host_alias_storage returned a null data_ptr for tensor \
+                             {name} (non-shared-storage MPS allocation?)",
+                        )));
+                    }
+                    host_aliases.push(cpu_alias);
+                    jobs.push(Job {
+                        name: name.clone(),
+                        file_offset: (self.offset + begin) as u64,
+                        nbytes,
+                        write_ptr,
+                    });
+                }
+                entries.push((name, tensor));
+            }
+
+            // Drain in-flight GPU work before writing through the CPU alias.
+            mps_mod.call_method0(intern!(py, "synchronize"))?;
+
+            let read_result: Result<(), (String, std::io::Error)> = py.detach(|| {
+                let jobs = &jobs;
+                let file = &file;
+                let next = AtomicUsize::new(0);
+                // Cap: beyond P-core count reads are SSD-bound on Apple silicon.
+                const MAX_WORKERS: usize = 8;
+                let n_workers = std::thread::available_parallelism()
+                    .map_or(4, |n| n.get())
+                    .min(MAX_WORKERS)
+                    .min(jobs.len());
+
+                std::thread::scope(|s| -> Result<(), (String, std::io::Error)> {
+                    let mut handles = Vec::with_capacity(n_workers);
+                    for _ in 0..n_workers {
+                        let next = &next;
+                        handles.push(s.spawn(move || -> Result<(), (String, std::io::Error)> {
+                            loop {
+                                let i = next.fetch_add(1, Ordering::Relaxed);
+                                if i >= jobs.len() {
+                                    return Ok(());
+                                }
+                                let job = &jobs[i];
+                                // SAFETY: each job's (write_ptr, nbytes) comes from a
+                                // distinct torch.empty allocation on MPS, so the target
+                                // ranges are disjoint; the tensors outlive py.detach.
+                                let buf = unsafe {
+                                    std::slice::from_raw_parts_mut(
+                                        job.write_ptr as *mut u8,
+                                        job.nbytes,
+                                    )
+                                };
+                                file.read_exact_at(buf, job.file_offset)
+                                    .map_err(|e| (job.name.clone(), e))?;
+                            }
+                        }));
+                    }
+                    for h in handles {
+                        h.join().map_err(|_| {
+                            (
+                                "<worker panic>".to_string(),
+                                std::io::Error::other("worker panicked"),
+                            )
+                        })??;
+                    }
+                    Ok(())
+                })
+            });
+
+            if let Err((name, e)) = read_result {
+                return Err(SafetensorError::new_err(format!(
+                    "pread failed for tensor {name}: {e}"
+                )));
+            }
+
+            // Make CPU writes visible to subsequent GPU reads.
+            mps_mod.call_method0(intern!(py, "synchronize"))?;
+
+            let result = PyDict::new(py);
+            for (name, tensor) in entries {
+                result.set_item(name, tensor)?;
+            }
+
+            // Drop aliases after synchronize so pinned MPS storages outlive writes.
+            drop(host_aliases);
+
+            Ok(result.into())
+        })
+    }
+
     /// Returns a full slice view object
     ///
     /// Args:
@@ -1058,6 +1246,29 @@ impl safe_open {
     /// ```
     pub fn get_tensor(&self, name: &str) -> PyResult<Py<PyAny>> {
         self.inner()?.get_tensor(name)
+    }
+
+    /// Returns every tensor in the file as a dict keyed by name.
+    ///
+    /// Equivalent to iterating `offset_keys()` and calling `get_tensor` on
+    /// each, but specific `framework` + `device` combinations take an
+    /// internal fast path (e.g. MPS with PyTorch ≥ 2.10's
+    /// `_host_alias_storage` bulk-allocates and fills tensors with parallel
+    /// `pread(2)`).
+    ///
+    /// Returns:
+    ///     (`Dict[str, Tensor]`):
+    ///         A dict of all tensors in the file.
+    ///
+    /// Example:
+    /// ```python
+    /// from safetensors import safe_open
+    ///
+    /// with safe_open("model.safetensors", framework="pt", device="mps") as f:
+    ///     state_dict = f.get_tensors()
+    /// ```
+    pub fn get_tensors(&self) -> PyResult<Py<PyDict>> {
+        self.inner()?.get_tensors()
     }
 
     /// Returns a full slice view object
@@ -1410,6 +1621,25 @@ fn get_module<'a>(
     Ok(module)
 }
 
+/// Whether this torch build exposes `torch.mps._host_alias_storage`
+/// (pytorch/pytorch#180961). Cached after the first call since the answer
+/// doesn't change at runtime. Torch must already be imported
+/// (guaranteed when `Open::new` ran with `Framework::Pytorch`).
+#[cfg(target_os = "macos")]
+fn mps_host_alias_available() -> PyResult<bool> {
+    if let Some(&cached) = MPS_HOST_ALIAS_AVAILABLE.get() {
+        return Ok(cached);
+    }
+    let available = Python::attach(|py| -> PyResult<bool> {
+        let torch = get_module(py, &TORCH_MODULE)?;
+        torch
+            .getattr(intern!(py, "mps"))?
+            .hasattr(intern!(py, "_host_alias_storage"))
+    })?;
+    let _ = MPS_HOST_ALIAS_AVAILABLE.set(available);
+    Ok(available)
+}
+
 fn create_tensor<'a>(
     framework: &'a Framework,
     dtype: Dtype,
@@ -1682,6 +1912,13 @@ impl _safe_open_handle {
         self.inner()?.get_tensor(name)
     }
 
+    /// Returns every tensor in the file as a dict keyed by name.
+    ///
+    /// See `safe_open.get_tensors` for the fast-path behavior.
+    pub fn get_tensors(&self) -> PyResult<Py<PyDict>> {
+        self.inner()?.get_tensors()
+    }
+
     /// Returns a full slice view object
     ///
     /// Args:
@@ -1713,182 +1950,12 @@ impl _safe_open_handle {
     }
 }
 
-/// Bulk-allocates MPS tensors, then parallel-`pread`s straight into their
-/// host-aliased MTLBuffers (via `torch.mps._host_alias_storage`). Caller
-/// must confirm the API exists. See pytorch/pytorch#180961.
-#[cfg(target_os = "macos")]
-#[pyfunction]
-fn mps_load_safetensors(py: Python<'_>, filename: PathBuf) -> PyResult<Py<PyDict>> {
-    use std::os::unix::fs::FileExt;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
-    struct Job {
-        name: String,
-        file_offset: u64,
-        nbytes: usize,
-        // Host-writable MTLBuffer pointer.
-        write_ptr: usize,
-    }
-
-    let file = File::open(&filename).map_err(|e| {
-        PyFileNotFoundError::new_err(format!("Could not open {}: {e}", filename.display()))
-    })?;
-    let mmap = unsafe {
-        MmapOptions::new().map(&file).map_err(|e| {
-            SafetensorError::new_err(format!("Could not mmap {}: {e}", filename.display()))
-        })?
-    };
-    let (header_len, metadata) = SafeTensors::read_metadata(&mmap).map_err(|e| {
-        SafetensorError::new_err(format!("Could not read safetensors header: {e:?}"))
-    })?;
-    let data_start = header_len + 8;
-
-    let torch = PyModule::import(py, intern!(py, "torch"))?;
-    let mps_mod = torch.getattr(intern!(py, "mps"))?;
-    let host_alias_fn = mps_mod.getattr(intern!(py, "_host_alias_storage"))?;
-    let mps_device: Py<PyAny> = "mps".into_pyobject(py)?.into();
-
-    // Allocate every tensor and collect host-alias pointers under the GIL.
-    let keys = metadata.offset_keys();
-    let mut mps_tensors: Vec<PyBound<'_, PyAny>> = Vec::with_capacity(keys.len());
-    // Aliases pin the source MPS storages; keep alive across parallel writes.
-    let mut host_aliases: Vec<PyBound<'_, PyAny>> = Vec::with_capacity(keys.len());
-    let mut jobs: Vec<Job> = Vec::with_capacity(keys.len());
-    for name in keys {
-        let info = metadata
-            .info(&name)
-            .ok_or_else(|| SafetensorError::new_err(format!("Missing tensor info for {name}")))?;
-        let dtype_obj: Py<PyAny> = get_pydtype(&torch, info.dtype, false)?;
-
-        // F4 stores two elements per byte; torch shape halves the last dim.
-        let mut torch_shape = info.shape.clone();
-        if info.dtype == Dtype::F4 {
-            let n = torch_shape.len();
-            if n == 0 || torch_shape[n - 1] % 2 != 0 {
-                return Err(SafetensorError::new_err(format!(
-                    "f4_x2 dtype requires the last dim be divisible by 2 in torch: got {:?}",
-                    info.shape,
-                )));
-            }
-            torch_shape[n - 1] /= 2;
-        }
-        let shape_obj: Py<PyAny> = torch_shape.into_pyobject(py)?.into();
-
-        let kwargs = [
-            (intern!(py, "dtype"), dtype_obj),
-            (intern!(py, "device"), mps_device.clone_ref(py)),
-        ]
-        .into_py_dict(py)?;
-        let tensor = torch.call_method("empty", (shape_obj,), Some(&kwargs))?;
-
-        let (begin, end) = info.data_offsets;
-        let nbytes = end - begin;
-
-        let write_ptr: usize = if nbytes == 0 {
-            0
-        } else {
-            let mps_storage = tensor.call_method0(intern!(py, "untyped_storage"))?;
-            let cpu_alias = host_alias_fn.call1((mps_storage,))?;
-            let ptr: usize = cpu_alias.call_method0(intern!(py, "data_ptr"))?.extract()?;
-            host_aliases.push(cpu_alias);
-            ptr
-        };
-        if nbytes > 0 && write_ptr == 0 {
-            return Err(SafetensorError::new_err(format!(
-                "torch.mps._host_alias_storage returned a null data_ptr for tensor {name} \
-                 (non-shared-storage MPS allocation?)",
-            )));
-        }
-
-        jobs.push(Job {
-            name: name.clone(),
-            file_offset: (data_start + begin) as u64,
-            nbytes,
-            write_ptr,
-        });
-        mps_tensors.push(tensor);
-    }
-
-    drop(mmap);
-
-    // Drain in-flight GPU work before writing through the CPU alias.
-    mps_mod.call_method0(intern!(py, "synchronize"))?;
-
-    let read_result: Result<(), (String, std::io::Error)> = py.detach(|| {
-        let jobs = &jobs;
-        let file = &file;
-        let next = AtomicUsize::new(0);
-        // Cap at 8: beyond P-core count reads are SSD-bound on Apple silicon.
-        let n_workers = std::thread::available_parallelism()
-            .map(|n| n.get())
-            .unwrap_or(4)
-            .min(8)
-            .min(jobs.len().max(1));
-
-        std::thread::scope(|s| -> Result<(), (String, std::io::Error)> {
-            let mut handles = Vec::with_capacity(n_workers);
-            for _ in 0..n_workers {
-                let next = &next;
-                handles.push(s.spawn(move || -> Result<(), (String, std::io::Error)> {
-                    loop {
-                        let i = next.fetch_add(1, Ordering::Relaxed);
-                        if i >= jobs.len() {
-                            return Ok(());
-                        }
-                        let job = &jobs[i];
-                        if job.nbytes == 0 {
-                            continue;
-                        }
-                        // SAFETY: each job owns a distinct tensor kept alive
-                        // by `mps_tensors` until after `py.detach` returns.
-                        let buf = unsafe {
-                            std::slice::from_raw_parts_mut(job.write_ptr as *mut u8, job.nbytes)
-                        };
-                        file.read_exact_at(buf, job.file_offset)
-                            .map_err(|e| (job.name.clone(), e))?;
-                    }
-                }));
-            }
-            for h in handles {
-                h.join().map_err(|_| {
-                    (
-                        "<worker panic>".to_string(),
-                        std::io::Error::other("worker panicked"),
-                    )
-                })??;
-            }
-            Ok(())
-        })
-    });
-
-    if let Err((name, e)) = read_result {
-        return Err(SafetensorError::new_err(format!(
-            "pread failed for tensor {name}: {e}"
-        )));
-    }
-
-    // Make CPU writes visible to subsequent GPU reads.
-    mps_mod.call_method0(intern!(py, "synchronize"))?;
-
-    let result = PyDict::new(py);
-    for (job, tensor) in jobs.iter().zip(mps_tensors) {
-        result.set_item(&job.name, tensor)?;
-    }
-
-    // Drop aliases after synchronize so pinned MPS storages outlive writes.
-    drop(host_aliases);
-
-    Ok(result.into())
-}
-
 /// A Python module implemented in Rust.
 #[pymodule(gil_used = false)]
 fn _safetensors_rust(m: &PyBound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(serialize, m)?)?;
     m.add_function(wrap_pyfunction!(serialize_file, m)?)?;
     m.add_function(wrap_pyfunction!(deserialize, m)?)?;
-    #[cfg(target_os = "macos")]
-    m.add_function(wrap_pyfunction!(mps_load_safetensors, m)?)?;
     m.add_class::<TensorSpec>()?;
     m.add_class::<safe_open>()?;
     m.add_class::<_safe_open_handle>()?;

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -33,7 +33,7 @@ static PADDLE_MODULE: OnceLock<Py<PyModule>> = OnceLock::new();
 /// The dtype string is validated at construction; an unknown dtype raises
 /// immediately rather than failing further inside the serializer.
 ///
-/// `shape` is the logical (header) shape - the number of elements along each
+/// `shape` is the logical (header) shape — the number of elements along each
 /// axis as recorded in the safetensors header. For packed dtypes like
 /// `float4_e2m1fn_x2` (two F4 values per byte), callers may pass the storage
 /// shape reported by their framework (e.g. `torch.Size`); the constructor
@@ -86,7 +86,7 @@ impl TensorSpec {
         format!("{}", self.dtype)
     }
 
-    /// The tensor's logical shape - the element-count shape recorded in the
+    /// The tensor's logical shape — the element-count shape recorded in the
     /// safetensors header. For packed dtypes like `float4_e2m1fn_x2`, this is
     /// the last-dim-doubled version of whatever was passed to the constructor.
     #[getter]
@@ -1755,9 +1755,9 @@ fn mps_load_safetensors(py: Python<'_>, filename: PathBuf) -> PyResult<Py<PyDict
     let mut host_aliases: Vec<PyBound<'_, PyAny>> = Vec::with_capacity(keys.len());
     let mut jobs: Vec<Job> = Vec::with_capacity(keys.len());
     for name in keys {
-        let info = metadata.info(&name).ok_or_else(|| {
-            SafetensorError::new_err(format!("Missing tensor info for {name}"))
-        })?;
+        let info = metadata
+            .info(&name)
+            .ok_or_else(|| SafetensorError::new_err(format!("Missing tensor info for {name}")))?;
         let dtype_obj: Py<PyAny> = get_pydtype(&torch, info.dtype, false)?;
 
         // F4 stores two elements per byte; torch shape halves the last dim.
@@ -1842,10 +1842,7 @@ fn mps_load_safetensors(py: Python<'_>, filename: PathBuf) -> PyResult<Py<PyDict
                         // SAFETY: each job owns a distinct tensor kept alive
                         // by `mps_tensors` until after `py.detach` returns.
                         let buf = unsafe {
-                            std::slice::from_raw_parts_mut(
-                                job.write_ptr as *mut u8,
-                                job.nbytes,
-                            )
+                            std::slice::from_raw_parts_mut(job.write_ptr as *mut u8, job.nbytes)
                         };
                         file.read_exact_at(buf, job.file_offset)
                             .map_err(|e| (job.name.clone(), e))?;
@@ -1874,7 +1871,7 @@ fn mps_load_safetensors(py: Python<'_>, filename: PathBuf) -> PyResult<Py<PyDict
     let _ = mps_mod.call_method0(intern!(py, "synchronize"));
 
     let result = PyDict::new(py);
-    for (job, tensor) in jobs.iter().zip(mps_tensors.into_iter()) {
+    for (job, tensor) in jobs.iter().zip(mps_tensors) {
         result.set_item(&job.name, tensor)?;
     }
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -545,6 +545,7 @@ impl Version {
 }
 
 struct Open {
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
     filename: PathBuf,
     metadata: Metadata,
     offset: usize,

--- a/bindings/python/tests/test_pt_comparison.py
+++ b/bindings/python/tests/test_pt_comparison.py
@@ -260,6 +260,47 @@ class TorchTestCase(unittest.TestCase):
             assert reloaded["test"].device == torch.device("cuda:0")
             self.assertTrue(torch.equal(torch.arange(4).view((2, 2)), reloaded["test"]))
 
+    @unittest.skipIf(
+        not (hasattr(torch.backends, "mps") and torch.backends.mps.is_available()),
+        "MPS is not available",
+    )
+    def test_mps(self):
+        data = {
+            "test1": torch.arange(16, dtype=torch.float32).reshape(4, 4),
+            "test2": torch.arange(8, dtype=torch.float16).reshape(2, 4),
+            "test3": torch.tensor([True, False, True, False]),
+            "empty": torch.empty((0, 4), dtype=torch.float32),
+        }
+        local = "./tests/data/out_safe_pt_mmap_small_mps.safetensors"
+        save_file(data, local)
+
+        reloaded = load_file(local, device="mps")
+        for k, v in data.items():
+            self.assertEqual(reloaded[k].device.type, "mps")
+            self.assertTrue(torch.equal(v.to("mps"), reloaded[k]))
+
+    @unittest.skipIf(
+        not (hasattr(torch.backends, "mps") and torch.backends.mps.is_available()),
+        "MPS is not available",
+    )
+    @unittest.skipIf(
+        not hasattr(torch, "float4_e2m1fn_x2"), "float4_e2m1fn_x2 requires torch 2.8"
+    )
+    def test_mps_fp4(self):
+        # Packed dtype: safetensors records the logical element count, torch
+        # stores it at half the last-dim length. The MPS loader must halve the
+        # last dim before calling torch.empty; otherwise the resulting tensor
+        # is 2x the correct storage and only half the bytes get filled.
+        data = {
+            "packed": torch.empty(2, 4, device="cpu", dtype=torch.float4_e2m1fn_x2),
+        }
+        local = "./tests/data/out_safe_pt_mmap_small_mps_fp4.safetensors"
+        save_file(data, local)
+        reloaded = load_file(local, device="mps")
+        self.assertEqual(reloaded["packed"].dtype, torch.float4_e2m1fn_x2)
+        self.assertEqual(reloaded["packed"].device.type, "mps")
+        self.assertEqual(tuple(reloaded["packed"].shape), (2, 4))
+
     @unittest.skipIf(not npu_present, "Npu is not available")
     def test_npu(self):
         data = {


### PR DESCRIPTION
# What does this PR do?

Implements fast loading of safetensors onto MPS. New API from PyTorch allows us to grab the host-wrieable pointer via `torch.mps._host_alias_storage` and parallel `preads` straight to the MTLBuffers.

Falls back to the existing `safe_open` path when the torch API is missing or on non-macOS.

## Speedup (Tested on M5 Pro)

- 2 GB warm: 7 → 50 GB/s (~5×)
- 16 GB cold: 2.83 → 6.81 GB/s (2.4×)
