### PR TITLE
feat(python): add opt-in no-mmap loading

### DIFF
--- a/bindings/python/py_src/safetensors/__init__.pyi
+++ b/bindings/python/py_src/safetensors/__init__.pyi
@@ -165,8 +165,19 @@ class safe_open:
 
         device (`str`, defaults to `"cpu"`):
             The device on which you want the tensors.
+
+        mmap (`bool`, *optional*, defaults to `True`):
+            Whether to memory-map the file. The default is to mmap, which is
+            the most efficient on systems with discrete CPU/GPU memory. On
+            systems with **unified** CPU/GPU memory (e.g. NVIDIA Grace
+            Blackwell / DGX Spark, Jetson Thor) mmap'd page cache and any
+            subsequent device copy share the same physical memory pool, which
+            doubles peak memory while loading large model weights and can OOM
+            well below the hardware limit. Pass `mmap=False` to read each
+            tensor from disk directly into a per-tensor buffer instead — peak
+            host memory then stays at one tensor at a time.
     """
-    def __init__(self, filename, framework, device=...):
+    def __init__(self, filename, framework, device=..., *, mmap: bool = True):
         pass
 
     def __enter__(self):

--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -196,6 +196,8 @@ def load_model(
     filename: Union[str, os.PathLike],
     strict: bool = True,
     device: Union[str, int] = "cpu",
+    *,
+    mmap: bool = True,
 ) -> Tuple[List[str], List[str]]:
     """
     Loads a given filename onto a torch model.
@@ -213,6 +215,10 @@ def load_model(
         device (`Union[str, int]`, *optional*, defaults to `cpu`):
             The device where the tensors need to be located after load.
             available options are all regular torch device locations.
+        mmap (`bool`, *optional*, defaults to `True`):
+            Forwarded to [`safe_open`]. Pass `mmap=False` on systems with
+            unified CPU/GPU memory (DGX Spark, Jetson Thor, …) to avoid
+            doubling resident memory while loading large weights.
 
     Returns:
         `(missing, unexpected): (List[str], List[str])`
@@ -220,7 +226,7 @@ def load_model(
             `unexpected` are names that are on the file, but weren't used during
             the load.
     """
-    state_dict = load_file(filename, device=device)
+    state_dict = load_file(filename, device=device, mmap=mmap)
     model_state_dict = model.state_dict()
     to_removes = _remove_duplicate_names(
         model_state_dict, preferred_names=state_dict.keys()
@@ -321,7 +327,10 @@ def save_file(
 
 
 def load_file(
-    filename: Union[str, os.PathLike], device: Union[str, int] = "cpu"
+    filename: Union[str, os.PathLike],
+    device: Union[str, int] = "cpu",
+    *,
+    mmap: bool = True,
 ) -> Dict[str, torch.Tensor]:
     """
     Loads a safetensors file into torch format.
@@ -332,6 +341,16 @@ def load_file(
         device (`Union[str, int]`, *optional*, defaults to `cpu`):
             The device where the tensors need to be located after load.
             available options are all regular torch device locations.
+        mmap (`bool`, *optional*, defaults to `True`):
+            Forwarded to [`safe_open`]. The default preserves the historical
+            mmap-backed fast path. Set to `False` on systems with
+            unified CPU/GPU memory (e.g. NVIDIA Grace Blackwell / DGX Spark,
+            Jetson Thor) where the OS page cache and a CUDA device copy
+            share the same physical memory pool — mmap doubles resident
+            memory there and can OOM well below the hardware limit. With
+            `mmap=False` each tensor is read directly from disk into a
+            per-tensor buffer, so peak host memory stays at one tensor at a
+            time during the load.
 
     Returns:
         `Dict[str, torch.Tensor]`: dictionary that contains name as key, value as `torch.Tensor`
@@ -345,7 +364,7 @@ def load_file(
     loaded = load_file(file_path)
     ```
     """
-    with safe_open(filename, framework="pt", device=device) as f:
+    with safe_open(filename, framework="pt", device=device, mmap=mmap) as f:
         return f.get_tensors()
 
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -15,10 +15,18 @@ use safetensors::View;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
 use std::ops::Bound;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::OnceLock;
+
+/// Hard upper bound on the JSON header size accepted in `mmap=False` mode.
+/// Mirrors the private `MAX_HEADER_SIZE` in `safetensors::tensor`; kept in sync
+/// here so we can refuse pathological headers before allocating to read them.
+const MAX_HEADER_SIZE_DIRECT: usize = 100_000_000;
+const HEADER_LEN_BYTES: usize = std::mem::size_of::<u64>();
 
 static TORCH_MODULE: OnceLock<Py<PyModule>> = OnceLock::new();
 static NUMPY_MODULE: OnceLock<Py<PyModule>> = OnceLock::new();
@@ -500,6 +508,86 @@ enum Storage {
     // Paddle can handle the whole lifecycle.
     // https://www.paddlepaddle.org.cn/documentation/docs/en/develop/api/paddle/MmapStorage_en.html
     Paddle(OnceLock<Py<PyAny>>),
+    /// Direct file-backed storage. The file handle is kept open and tensors
+    /// are read on demand via `seek + read_exact`, without ever mmap'ing the
+    /// data section of the file. Used when the caller passes `mmap=False`,
+    /// primarily to avoid OS page-cache buildup on systems with unified
+    /// CPU/GPU memory (e.g. NVIDIA Grace Blackwell / DGX Spark, Jetson Thor)
+    /// where mmap'd page cache and a subsequent device copy both reside in
+    /// the same physical memory pool, doubling memory usage when loading
+    /// large model weights.
+    Direct(Mutex<File>),
+}
+
+/// Read the safetensors header (8-byte length prefix + JSON metadata) from an
+/// open file *without* mmap'ing it, parse it into a [`Metadata`], and verify
+/// that the file is large enough to contain all referenced tensors.
+///
+/// Returns `(header_size, metadata)`, mirroring [`SafeTensors::read_metadata`].
+fn read_metadata_from_file(file: &mut File) -> PyResult<(usize, Metadata)> {
+    let file_size: usize = file
+        .metadata()
+        .map_err(|e| SafetensorError::new_err(format!("Could not stat file: {e}")))?
+        .len()
+        .try_into()
+        .map_err(|_| SafetensorError::new_err("File too large to address on this platform"))?;
+
+    if file_size < HEADER_LEN_BYTES {
+        return Err(SafetensorError::new_err(
+            "HeaderTooSmall: file is too short to contain a safetensors header",
+        ));
+    }
+
+    file.seek(SeekFrom::Start(0))
+        .map_err(|e| SafetensorError::new_err(format!("Could not seek file: {e}")))?;
+
+    let mut header_len_bytes = [0u8; HEADER_LEN_BYTES];
+    file.read_exact(&mut header_len_bytes)
+        .map_err(|e| SafetensorError::new_err(format!("Could not read header length: {e}")))?;
+    let n: usize = u64::from_le_bytes(header_len_bytes)
+        .try_into()
+        .map_err(|_| SafetensorError::new_err("HeaderTooLarge"))?;
+
+    if n > MAX_HEADER_SIZE_DIRECT {
+        return Err(SafetensorError::new_err("HeaderTooLarge"));
+    }
+    let stop = HEADER_LEN_BYTES
+        .checked_add(n)
+        .ok_or_else(|| SafetensorError::new_err("InvalidHeaderLength: header offset overflow"))?;
+    if stop > file_size {
+        return Err(SafetensorError::new_err(
+            "InvalidHeaderLength: header runs past end of file",
+        ));
+    }
+
+    let mut header_buf = vec![0u8; n];
+    file.read_exact(&mut header_buf)
+        .map_err(|e| SafetensorError::new_err(format!("Could not read header bytes: {e}")))?;
+
+    let metadata: Metadata = serde_json::from_slice(&header_buf)
+        .map_err(|e| SafetensorError::new_err(format!("Error while deserializing header: {e}")))?;
+
+    // Cross-check declared tensor offsets against the actual file size; this
+    // is what `SafeTensors::read_metadata` does on the in-memory buffer.
+    let mut data_end: usize = 0;
+    for (_name, info) in metadata.tensors() {
+        let (_, end) = info.data_offsets;
+        if end > data_end {
+            data_end = end;
+        }
+    }
+    let expected_total = stop
+        .checked_add(data_end)
+        .ok_or_else(|| SafetensorError::new_err("InvalidHeaderLength: total size overflow"))?;
+    // Match the strict equality enforced by `SafeTensors::read_metadata` on
+    // the in-memory buffer: declared offsets must exactly fill the file.
+    if expected_total != file_size {
+        return Err(SafetensorError::new_err(format!(
+            "MetadataIncompleteBuffer: declared total {expected_total} bytes does not match file size {file_size}"
+        )));
+    }
+
+    Ok((n, metadata))
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd)]
@@ -555,8 +643,13 @@ struct Open {
 }
 
 impl Open {
-    fn new(filename: PathBuf, framework: Framework, device: Option<Device>) -> PyResult<Self> {
-        let file = File::open(&filename).map_err(|_| {
+    fn new(
+        filename: PathBuf,
+        framework: Framework,
+        device: Option<Device>,
+        mmap: bool,
+    ) -> PyResult<Self> {
+        let mut file = File::open(&filename).map_err(|_| {
             PyFileNotFoundError::new_err(format!(
                 "No such file or directory: {}",
                 filename.display()
@@ -570,6 +663,45 @@ impl Open {
             return Err(SafetensorError::new_err(format!(
                 "Device {device} is not supported for framework {framework}",
             )));
+        }
+
+        // `mmap=False` opt-out: read the header directly via stdlib I/O and
+        // keep the file handle around for on-demand `read_exact` per tensor.
+        // This avoids keeping the full file mapped as tensor storage; on
+        // unified-memory hardware (DGX Spark, Jetson Thor), mmap-backed file
+        // pages and a subsequent device copy both count against the same
+        // physical memory pool.
+        if !mmap {
+            let (n, metadata) = read_metadata_from_file(&mut file)?;
+            let offset = n + HEADER_LEN_BYTES;
+
+            // We still need the framework module imported so dtypes resolve.
+            Python::attach(|py| -> PyResult<()> {
+                match framework {
+                    Framework::Pytorch => {
+                        let module = PyModule::import(py, intern!(py, "torch"))?;
+                        TORCH_MODULE.get_or_init_py_attached(py, || module.into())
+                    }
+                    Framework::Paddle => {
+                        let module = PyModule::import(py, intern!(py, "paddle"))?;
+                        PADDLE_MODULE.get_or_init_py_attached(py, || module.into())
+                    }
+                    _ => {
+                        let module = PyModule::import(py, intern!(py, "numpy"))?;
+                        NUMPY_MODULE.get_or_init_py_attached(py, || module.into())
+                    }
+                };
+                Ok(())
+            })?;
+
+            return Ok(Self {
+                filename,
+                metadata,
+                offset,
+                framework,
+                device,
+                storage: Arc::new(Storage::Direct(Mutex::new(file))),
+            });
         }
 
         // SAFETY: Mmap is used to prevent allocating in Rust
@@ -945,6 +1077,43 @@ impl Open {
                     Ok(tensor.into_pyobject(py)?.into())
                 })
             }
+            Storage::Direct(file) => {
+                // Read just this tensor's bytes from disk into a fresh per-call
+                // buffer, then hand it off via the same PyByteArray + frombuffer
+                // path used by `Storage::Mmap`. This keeps peak host memory at
+                // one tensor at a time on systems without spare page cache.
+                let (begin, end) = info.data_offsets;
+                let nbytes = end.saturating_sub(begin);
+
+                let array: Py<PyAny> = Python::attach(|py| -> PyResult<Py<PyAny>> {
+                    let pyarray = PyByteArray::new_with(py, nbytes, |dst| {
+                        if nbytes == 0 {
+                            return Ok(());
+                        }
+                        let mut file = file.lock().map_err(|_| {
+                            std::io::Error::other("safetensors: file mutex poisoned")
+                        })?;
+                        let file_offset = (self.offset + begin) as u64;
+                        file.seek(SeekFrom::Start(file_offset))?;
+                        file.read_exact(dst)?;
+                        Ok(())
+                    })
+                    .map_err(|e| {
+                        SafetensorError::new_err(format!(
+                            "Could not read tensor {name} from file: {e}"
+                        ))
+                    })?;
+                    Ok(pyarray.into_any().into())
+                })?;
+
+                create_tensor(
+                    &self.framework,
+                    info.dtype,
+                    &info.shape,
+                    array,
+                    &self.device,
+                )
+            }
         }
     }
 
@@ -1176,6 +1345,17 @@ impl Open {
 ///
 ///     device (`str`, defaults to `"cpu"`):
 ///         The device on which you want the tensors.
+///
+///     mmap (`bool`, *optional*, defaults to `True`):
+///         Whether to memory-map the file. The default is to mmap, which is
+///         the most efficient on systems with discrete CPU/GPU memory. On
+///         systems with **unified** CPU/GPU memory (e.g. NVIDIA Grace
+///         Blackwell / DGX Spark, Jetson Thor) mmap'd page cache and any
+///         subsequent device copy share the same physical memory pool, which
+///         doubles peak memory while loading large model weights and can
+///         OOM well below the hardware limit. Pass `mmap=False` to read each
+///         tensor from disk directly into a per-tensor buffer instead — peak
+///         host memory then stays at one tensor at a time.
 #[pyclass]
 #[allow(non_camel_case_types)]
 struct safe_open {
@@ -1195,9 +1375,14 @@ impl safe_open {
 #[pymethods]
 impl safe_open {
     #[new]
-    #[pyo3(signature = (filename, framework, device=Some(Device::Cpu)))]
-    fn new(filename: PathBuf, framework: Framework, device: Option<Device>) -> PyResult<Self> {
-        let inner = Some(Open::new(filename, framework, device)?);
+    #[pyo3(signature = (filename, framework, device=Some(Device::Cpu), *, mmap=true))]
+    fn new(
+        filename: PathBuf,
+        framework: Framework,
+        device: Option<Device>,
+        mmap: bool,
+    ) -> PyResult<Self> {
+        let inner = Some(Open::new(filename, framework, device, mmap)?);
         Ok(Self { inner })
     }
 
@@ -1607,6 +1792,91 @@ impl PySafeSlice {
                 tensor.setattr(intern!(py, "_safetensors_storage"), storage)?;
                 Ok(tensor.into())
             }),
+            Storage::Direct(file) => {
+                // Slicing of the raw on-disk bytes: read the full tensor into
+                // an owned buffer first (cheap relative to the slice work that
+                // follows) and reuse the exact `TensorView::sliced_data` path
+                // that `Storage::Mmap` uses, so behavior is bit-identical.
+                let pyslices = slices;
+                let slices: Slice = pyslices.extract()?;
+                let is_list = pyslices.is_instance_of::<PyList>();
+                let slices: Vec<SliceIndex> = match slices {
+                    Slice::Slice(slice) => vec![slice],
+                    Slice::Slices(slices) => {
+                        if slices.is_empty() && is_list {
+                            vec![SliceIndex::Slice(PySlice::new(pyslices.py(), 0, 0, 0))]
+                        } else if is_list {
+                            return Err(SafetensorError::new_err(
+                                "Non empty lists are not implemented",
+                            ));
+                        } else {
+                            slices
+                        }
+                    }
+                };
+
+                let (begin, end) = self.info.data_offsets;
+                let nbytes = end.saturating_sub(begin);
+                let mut data = vec![0u8; nbytes];
+                if nbytes > 0 {
+                    let mut file = file.lock().map_err(|_| {
+                        SafetensorError::new_err("safetensors: file mutex poisoned")
+                    })?;
+                    let file_offset = (self.offset + begin) as u64;
+                    file.seek(SeekFrom::Start(file_offset)).map_err(|e| {
+                        SafetensorError::new_err(format!("Could not seek file: {e}"))
+                    })?;
+                    file.read_exact(&mut data).map_err(|e| {
+                        SafetensorError::new_err(format!(
+                            "Could not read tensor bytes for slicing: {e}"
+                        ))
+                    })?;
+                }
+
+                let shape = self.info.shape.clone();
+                let tensor = TensorView::new(self.info.dtype, self.info.shape.clone(), &data)
+                    .map_err(|e| {
+                        SafetensorError::new_err(format!("Error preparing tensor view: {e}"))
+                    })?;
+                let slices: Vec<TensorIndexer> = slices
+                    .into_iter()
+                    .zip(shape)
+                    .enumerate()
+                    .map(slice_to_indexer)
+                    .collect::<Result<_, _>>()?;
+
+                let iterator = tensor.sliced_data(&slices).map_err(|e| {
+                    SafetensorError::new_err(format!(
+                        "Error during slicing {} with shape {:?}: {e}",
+                        Disp(slices),
+                        self.info.shape,
+                    ))
+                })?;
+                let newshape = iterator.newshape();
+
+                let mut offset = 0;
+                let length = iterator.remaining_byte_len();
+                Python::attach(|py| {
+                    let array: Py<PyAny> =
+                        PyByteArray::new_with(py, length, |bytes: &mut [u8]| {
+                            for slice in iterator {
+                                let len = slice.len();
+                                bytes[offset..offset + slice.len()].copy_from_slice(slice);
+                                offset += len;
+                            }
+                            Ok(())
+                        })?
+                        .into_any()
+                        .into();
+                    create_tensor(
+                        &self.framework,
+                        self.info.dtype,
+                        &newshape,
+                        array,
+                        &self.device,
+                    )
+                })
+            }
         }
     }
 }
@@ -1853,15 +2123,20 @@ impl _safe_open_handle {
 #[pymethods]
 impl _safe_open_handle {
     #[new]
-    #[pyo3(signature = (f, framework, device=Some(Device::Cpu)))]
-    fn new(f: Py<PyAny>, framework: Framework, device: Option<Device>) -> PyResult<Self> {
+    #[pyo3(signature = (f, framework, device=Some(Device::Cpu), *, mmap=true))]
+    fn new(
+        f: Py<PyAny>,
+        framework: Framework,
+        device: Option<Device>,
+        mmap: bool,
+    ) -> PyResult<Self> {
         let filename = Python::attach(|py| -> PyResult<PathBuf> {
             let _ = f.getattr(py, "fileno")?;
             let filename = f.getattr(py, "name")?;
             let filename: PathBuf = filename.extract(py)?;
             Ok(filename)
         })?;
-        let inner = Some(Open::new(filename, framework, device)?);
+        let inner = Some(Open::new(filename, framework, device, mmap)?);
         Ok(Self { inner })
     }
 

--- a/bindings/python/tests/test_no_mmap.py
+++ b/bindings/python/tests/test_no_mmap.py
@@ -1,0 +1,161 @@
+"""Tests for the `mmap=False` opt-out on `safe_open`.
+
+This path was added so callers can avoid the OS page-cache buildup that mmap
+inflicts on systems with unified CPU/GPU memory (e.g. NVIDIA Grace Blackwell /
+DGX Spark, Jetson Thor). It must remain bit-identical to the default path.
+"""
+
+import os
+import struct
+import tempfile
+import unittest
+
+import numpy as np
+import torch
+
+from safetensors import safe_open
+from safetensors.torch import load_file as load_file_pt
+from safetensors.torch import load_model, save_file, save_model
+
+
+SOURCE_TENSORS = {
+    "fp32_2d": torch.arange(12, dtype=torch.float32).reshape(3, 4).contiguous(),
+    "bf16_2d": torch.arange(8, dtype=torch.bfloat16).reshape(2, 4).contiguous(),
+    "fp16_3d": torch.arange(24, dtype=torch.float16).reshape(2, 3, 4).contiguous(),
+    "scalar_fp32": torch.tensor(7.5, dtype=torch.float32),
+    "empty_2d": torch.empty((0, 5), dtype=torch.float16),
+    "i64_1d": torch.arange(5, dtype=torch.int64),
+}
+
+if hasattr(torch, "float8_e4m3fn"):
+    SOURCE_TENSORS["fp8_e4m3fn"] = torch.zeros(8, dtype=torch.float8_e4m3fn)
+
+
+class NoMmapTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self.tempdir.name, "tiny.safetensors")
+        save_file(SOURCE_TENSORS, self.path, metadata={"foo": "bar"})
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def _assert_state_dict_equal(self, sd):
+        self.assertEqual(set(sd.keys()), set(SOURCE_TENSORS.keys()))
+        for k, expected in SOURCE_TENSORS.items():
+            actual = sd[k]
+            self.assertEqual(actual.dtype, expected.dtype, k)
+            self.assertEqual(tuple(actual.shape), tuple(expected.shape), k)
+            if expected.numel() > 0:
+                self.assertTrue(
+                    torch.equal(actual.cpu(), expected.cpu()),
+                    f"tensor {k!r} differs",
+                )
+
+    def test_safe_open_mmap_false_round_trip(self):
+        with safe_open(self.path, framework="pt", device="cpu", mmap=False) as f:
+            self.assertEqual(f.metadata(), {"foo": "bar"})
+            sd = {k: f.get_tensor(k) for k in f.keys()}
+        self._assert_state_dict_equal(sd)
+
+    def test_get_tensors_mmap_false_round_trip(self):
+        with safe_open(self.path, framework="pt", device="cpu", mmap=False) as f:
+            sd = f.get_tensors()
+        self._assert_state_dict_equal(sd)
+
+    def test_load_file_mmap_false_round_trip(self):
+        sd = load_file_pt(self.path, mmap=False)
+        self._assert_state_dict_equal(sd)
+
+    def test_default_path_unchanged(self):
+        # A mmap=True load must still produce identical bytes to mmap=False.
+        with safe_open(self.path, framework="pt", device="cpu") as f:
+            sd_mmap = f.get_tensors()
+        with safe_open(self.path, framework="pt", device="cpu", mmap=False) as f:
+            sd_no_mmap = f.get_tensors()
+        self.assertEqual(set(sd_mmap.keys()), set(sd_no_mmap.keys()))
+        for k in sd_mmap:
+            a, b = sd_mmap[k], sd_no_mmap[k]
+            self.assertEqual(a.dtype, b.dtype, k)
+            self.assertEqual(tuple(a.shape), tuple(b.shape), k)
+            if a.numel() > 0:
+                self.assertTrue(torch.equal(a.cpu(), b.cpu()), k)
+
+    def test_get_slice_mmap_false(self):
+        with safe_open(self.path, framework="pt", device="cpu", mmap=False) as f:
+            slice_obj = f.get_slice("fp32_2d")
+            self.assertEqual(list(slice_obj.get_shape()), [3, 4])
+            sub = slice_obj[:, 1:3]
+        expected = SOURCE_TENSORS["fp32_2d"][:, 1:3]
+        self.assertEqual(sub.dtype, expected.dtype)
+        self.assertEqual(tuple(sub.shape), tuple(expected.shape))
+        self.assertTrue(torch.equal(sub, expected))
+
+    def test_load_model_mmap_false(self):
+        # `load_model` round-trip through the new `mmap=False` kwarg.
+        class Tiny(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin = torch.nn.Linear(4, 3)
+
+        src = Tiny()
+        path = os.path.join(self.tempdir.name, "tiny_model.safetensors")
+        save_model(src, path)
+
+        dst = Tiny()
+        # Sanity: weights start different.
+        self.assertFalse(torch.equal(src.lin.weight, dst.lin.weight))
+        load_model(dst, path, mmap=False)
+        self.assertTrue(torch.equal(src.lin.weight, dst.lin.weight))
+        self.assertTrue(torch.equal(src.lin.bias, dst.lin.bias))
+
+    def test_truncated_header_is_rejected(self):
+        bad_path = os.path.join(self.tempdir.name, "truncated.safetensors")
+        with open(self.path, "rb") as src, open(bad_path, "wb") as dst:
+            head = src.read(8)
+            dst.write(head)
+            n = struct.unpack("<Q", head)[0]
+            # Write only half of the header so the JSON read will fail.
+            dst.write(src.read(n // 2))
+        with self.assertRaises(Exception):
+            with safe_open(bad_path, framework="pt", device="cpu", mmap=False) as f:
+                _ = f.get_tensors()
+
+    def test_data_offset_overflow_is_rejected(self):
+        # Build a file whose header references more bytes than actually exist
+        # on disk; mmap=False must catch this.
+        bad_path = os.path.join(self.tempdir.name, "lying.safetensors")
+        header = (
+            b'{"liar":{"dtype":"F32","shape":[1024,1024],"data_offsets":[0,4194304]}}'
+        )
+        with open(bad_path, "wb") as f:
+            f.write(struct.pack("<Q", len(header)))
+            f.write(header)
+            # Only write a single byte of the data section instead of 4 MiB.
+            f.write(b"\x00")
+        with self.assertRaises(Exception):
+            with safe_open(bad_path, framework="pt", device="cpu", mmap=False) as f:
+                _ = f.get_tensors()
+
+    def test_numpy_framework_mmap_false(self):
+        # Independently confirm the no-mmap path on the framework-agnostic
+        # numpy path that goes through `Storage::Direct` + create_tensor.
+        np_path = os.path.join(self.tempdir.name, "np.safetensors")
+        from safetensors.numpy import save_file as save_np
+
+        np_data = {
+            "a": np.arange(6, dtype=np.float32).reshape(2, 3),
+            "b": np.arange(8, dtype=np.int64).reshape(4, 2),
+        }
+        save_np(np_data, np_path)
+
+        with safe_open(np_path, framework="numpy", mmap=False) as f:
+            for k, expected in np_data.items():
+                got = f.get_tensor(k)
+                self.assertEqual(got.dtype, expected.dtype, k)
+                self.assertEqual(got.shape, expected.shape, k)
+                np.testing.assert_array_equal(got, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds a keyword-only `mmap` option to `safe_open`, defaulting to the existing mmap-backed behavior.
- Adds an opt-in `mmap=False` direct file-backed storage path that reads tensors on demand without memory-mapping the file.
- Threads `mmap` through `safetensors.torch.load_file` and `load_model`, and adds focused tests for the no-mmap path.
- https://github.com/safetensors/safetensors/issues/758

## Motivation
On unified CPU/GPU memory systems such as NVIDIA DGX Spark / Grace Blackwell and Jetson-class devices, mmap-backed file pages and framework/device tensors can reside in the same physical memory pool. For large model files, that can effectively double resident memory while loading weights. An opt-in no-mmap path gives downstream frameworks a way to avoid retaining mmap-backed file storage while preserving the current default behavior for discrete-memory systems.

Related downstream reports:
- https://github.com/Comfy-Org/ComfyUI/issues/10896
- https://forums.developer.nvidia.com/t/buyers-beware-dgx-spark-limited-to-64gb-in-comfyui/356573

## Test plan
- `cargo fmt --manifest-path bindings/python/Cargo.toml --check`
- `cargo check --manifest-path bindings/python/Cargo.toml`
- `uvx maturin build --manifest-path bindings/python/Cargo.toml --release -o bindings/python/dist`
- `PYTHONPATH=bindings/python/dist/wheel_extract python -m pytest tests/test_no_mmap.py tests/test_simple.py tests/test_pt_comparison.py -q`