### PR TITLE
feat: add `backend` with pread file

### DIFF
--- a/bindings/python/benches/test_pt.py
+++ b/bindings/python/benches/test_pt.py
@@ -64,11 +64,11 @@ def test_pt_sf_load_cpu(benchmark):
         assert torch.allclose(v, tv)
 
 
-def test_pt_sf_load_cpu_read_file(benchmark):
+def test_pt_sf_load_cpu_pread(benchmark):
     weights = create_gpt2(12)
     with tempfile.NamedTemporaryFile(delete=False) as f:
         save_file(weights, f.name)
-        result = benchmark(load_file, f.name, backend="read_file")
+        result = benchmark(load_file, f.name, backend="pread")
     os.unlink(f.name)
 
     for k, v in weights.items():
@@ -101,12 +101,12 @@ def test_pt_sf_load_cpu_small(benchmark):
         assert torch.allclose(v, tv)
 
 
-def test_pt_sf_load_cpu_small_read_file(benchmark):
+def test_pt_sf_load_cpu_small_pread(benchmark):
     weights = create_lora(500)
 
     with tempfile.NamedTemporaryFile(delete=False) as f:
         save_file(weights, f.name)
-        result = benchmark(load_file, f.name, backend="read_file")
+        result = benchmark(load_file, f.name, backend="pread")
     os.unlink(f.name)
 
     for k, v in weights.items():
@@ -145,11 +145,11 @@ def test_pt_sf_load_gpu(benchmark):
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires cuda")
-def test_pt_sf_load_gpu_read_file(benchmark):
+def test_pt_sf_load_gpu_pread(benchmark):
     weights = create_gpt2(12)
     with tempfile.NamedTemporaryFile(delete=False) as f:
         save_file(weights, f.name)
-        result = benchmark(load_file, f.name, device="cuda:0", backend="read_file")
+        result = benchmark(load_file, f.name, device="cuda:0", backend="pread")
     os.unlink(f.name)
 
     for k, v in weights.items():
@@ -198,16 +198,16 @@ def test_pt_sf_load_mps(benchmark):
     not hasattr(torch.backends, "mps") or not torch.backends.mps.is_available(),
     reason="requires mps",
 )
-def test_pt_sf_load_mps_read_file(benchmark):
+def test_pt_sf_load_mps_pread(benchmark):
     # NOTE: on MPS, get_tensors() takes the host-alias bulk fast path
     # whenever `torch.mps._host_alias_storage` is available — regardless of
     # the `backend` kwarg. This bench therefore exercises the bulk path on
-    # supported torch builds. To benchmark the per-tensor read_file code on
-    # MPS specifically, use `benches/bench_mps_load.py` with `force_slow()`.
+    # supported torch builds. To benchmark the per-tensor pread code on MPS
+    # specifically, use `benches/bench_mps_load.py` with `force_slow()`.
     weights = create_gpt2(12)
     with tempfile.NamedTemporaryFile(delete=False) as f:
         save_file(weights, f.name)
-        result = benchmark(load_file, f.name, device="mps", backend="read_file")
+        result = benchmark(load_file, f.name, device="mps", backend="pread")
     os.unlink(f.name)
 
     for k, v in weights.items():

--- a/bindings/python/benches/test_pt.py
+++ b/bindings/python/benches/test_pt.py
@@ -64,6 +64,18 @@ def test_pt_sf_load_cpu(benchmark):
         assert torch.allclose(v, tv)
 
 
+def test_pt_sf_load_cpu_read_file(benchmark):
+    weights = create_gpt2(12)
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        save_file(weights, f.name)
+        result = benchmark(load_file, f.name, backend="read_file")
+    os.unlink(f.name)
+
+    for k, v in weights.items():
+        tv = result[k]
+        assert torch.allclose(v, tv)
+
+
 def test_pt_pt_load_cpu_small(benchmark):
     weights = create_lora(500)
     with tempfile.NamedTemporaryFile(delete=False) as f:
@@ -82,6 +94,19 @@ def test_pt_sf_load_cpu_small(benchmark):
     with tempfile.NamedTemporaryFile(delete=False) as f:
         save_file(weights, f.name)
         result = benchmark(load_file, f.name)
+    os.unlink(f.name)
+
+    for k, v in weights.items():
+        tv = result[k]
+        assert torch.allclose(v, tv)
+
+
+def test_pt_sf_load_cpu_small_read_file(benchmark):
+    weights = create_lora(500)
+
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        save_file(weights, f.name)
+        result = benchmark(load_file, f.name, backend="read_file")
     os.unlink(f.name)
 
     for k, v in weights.items():
@@ -119,6 +144,20 @@ def test_pt_sf_load_gpu(benchmark):
         assert torch.allclose(v, tv)
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires cuda")
+def test_pt_sf_load_gpu_read_file(benchmark):
+    weights = create_gpt2(12)
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        save_file(weights, f.name)
+        result = benchmark(load_file, f.name, device="cuda:0", backend="read_file")
+    os.unlink(f.name)
+
+    for k, v in weights.items():
+        v = v.cuda()
+        tv = result[k]
+        assert torch.allclose(v, tv)
+
+
 @pytest.mark.skipif(
     not hasattr(torch.backends, "mps") or not torch.backends.mps.is_available(),
     reason="requires mps",
@@ -147,6 +186,28 @@ def test_pt_sf_load_mps(benchmark):
     with tempfile.NamedTemporaryFile(delete=False) as f:
         save_file(weights, f.name)
         result = benchmark(load_file, f.name, device="mps")
+    os.unlink(f.name)
+
+    for k, v in weights.items():
+        v = v.to(device="mps")
+        tv = result[k]
+        assert torch.allclose(v, tv)
+
+
+@pytest.mark.skipif(
+    not hasattr(torch.backends, "mps") or not torch.backends.mps.is_available(),
+    reason="requires mps",
+)
+def test_pt_sf_load_mps_read_file(benchmark):
+    # NOTE: on MPS, get_tensors() takes the host-alias bulk fast path
+    # whenever `torch.mps._host_alias_storage` is available — regardless of
+    # the `backend` kwarg. This bench therefore exercises the bulk path on
+    # supported torch builds. To benchmark the per-tensor read_file code on
+    # MPS specifically, use `benches/bench_mps_load.py` with `force_slow()`.
+    weights = create_gpt2(12)
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        save_file(weights, f.name)
+        result = benchmark(load_file, f.name, device="mps", backend="read_file")
     os.unlink(f.name)
 
     for k, v in weights.items():

--- a/bindings/python/py_src/safetensors/__init__.pyi
+++ b/bindings/python/py_src/safetensors/__init__.pyi
@@ -165,8 +165,12 @@ class safe_open:
 
         device (`str`, defaults to `"cpu"`):
             The device on which you want the tensors.
+
+        backend (`str`, *keyword-only*, defaults to `"mmap"`):
+            Storage backend used to serve tensor bytes. `"mmap"` (default) and
+            `"read_file"` uses `pread(2)` to read tensor bytes.
     """
-    def __init__(self, filename, framework, device=...):
+    def __init__(self, filename, framework, device=..., *, backend: str = "mmap"):
         pass
 
     def __enter__(self):

--- a/bindings/python/py_src/safetensors/__init__.pyi
+++ b/bindings/python/py_src/safetensors/__init__.pyi
@@ -168,7 +168,7 @@ class safe_open:
 
         backend (`str`, *keyword-only*, defaults to `"mmap"`):
             Storage backend used to serve tensor bytes. `"mmap"` (default) and
-            `"read_file"` uses `pread(2)` to read tensor bytes.
+            `"pread"` uses `pread(2)` to read tensor bytes.
     """
     def __init__(self, filename, framework, device=..., *, backend: str = "mmap"):
         pass

--- a/bindings/python/py_src/safetensors/flax.py
+++ b/bindings/python/py_src/safetensors/flax.py
@@ -99,13 +99,18 @@ def load(data: bytes) -> Dict[str, Array]:
     return _np2jnp(flat)
 
 
-def load_file(filename: Union[str, os.PathLike]) -> Dict[str, Array]:
+def load_file(
+    filename: Union[str, os.PathLike], *, backend: str = "mmap"
+) -> Dict[str, Array]:
     """
     Loads a safetensors file into flax format.
 
     Args:
         filename (`str`, or `os.PathLike`)):
             The name of the file which contains the tensors
+        backend (`str`, *optional*, defaults to `"mmap"`):
+            Storage backend used to serve tensor bytes. `"mmap"` (default)
+            and `"read_file"` uses `pread(2)` to read tensor bytes.
 
     Returns:
         `Dict[str, Array]`: dictionary that contains name as key, value as `Array`
@@ -119,7 +124,7 @@ def load_file(filename: Union[str, os.PathLike]) -> Dict[str, Array]:
     loaded = load_file(file_path)
     ```
     """
-    with safe_open(filename, framework="flax") as f:
+    with safe_open(filename, framework="flax", backend=backend) as f:
         return f.get_tensors()
 
 

--- a/bindings/python/py_src/safetensors/flax.py
+++ b/bindings/python/py_src/safetensors/flax.py
@@ -110,7 +110,7 @@ def load_file(
             The name of the file which contains the tensors
         backend (`str`, *optional*, defaults to `"mmap"`):
             Storage backend used to serve tensor bytes. `"mmap"` (default)
-            and `"read_file"` uses `pread(2)` to read tensor bytes.
+            and `"pread"` uses `pread(2)` to read tensor bytes.
 
     Returns:
         `Dict[str, Array]`: dictionary that contains name as key, value as `Array`

--- a/bindings/python/py_src/safetensors/mlx.py
+++ b/bindings/python/py_src/safetensors/mlx.py
@@ -111,7 +111,7 @@ def load_file(
             The name of the file which contains the tensors
         backend (`str`, *optional*, defaults to `"mmap"`):
             Storage backend used to serve tensor bytes. `"mmap"` (default)
-            and `"read_file"` uses `pread(2)` to read tensor bytes.
+            and `"pread"` uses `pread(2)` to read tensor bytes.
 
     Returns:
         `Dict[str, mx.array]`: dictionary that contains name as key, value as `mx.array`

--- a/bindings/python/py_src/safetensors/mlx.py
+++ b/bindings/python/py_src/safetensors/mlx.py
@@ -100,13 +100,18 @@ def load(data: bytes) -> Dict[str, mx.array]:
     return _np2mx(flat)
 
 
-def load_file(filename: Union[str, os.PathLike]) -> Dict[str, mx.array]:
+def load_file(
+    filename: Union[str, os.PathLike], *, backend: str = "mmap"
+) -> Dict[str, mx.array]:
     """
     Loads a safetensors file into MLX format.
 
     Args:
         filename (`str`, or `os.PathLike`)):
             The name of the file which contains the tensors
+        backend (`str`, *optional*, defaults to `"mmap"`):
+            Storage backend used to serve tensor bytes. `"mmap"` (default)
+            and `"read_file"` uses `pread(2)` to read tensor bytes.
 
     Returns:
         `Dict[str, mx.array]`: dictionary that contains name as key, value as `mx.array`
@@ -120,7 +125,7 @@ def load_file(filename: Union[str, os.PathLike]) -> Dict[str, mx.array]:
     loaded = load_file(file_path)
     ```
     """
-    with safe_open(filename, framework="mlx") as f:
+    with safe_open(filename, framework="mlx", backend=backend) as f:
         return f.get_tensors()
 
 

--- a/bindings/python/py_src/safetensors/numpy.py
+++ b/bindings/python/py_src/safetensors/numpy.py
@@ -122,13 +122,18 @@ def load(data: bytes) -> Dict[str, np.ndarray]:
     return _view2np(flat)
 
 
-def load_file(filename: Union[str, os.PathLike]) -> Dict[str, np.ndarray]:
+def load_file(
+    filename: Union[str, os.PathLike], *, backend: str = "mmap"
+) -> Dict[str, np.ndarray]:
     """
     Loads a safetensors file into numpy format.
 
     Args:
         filename (`str`, or `os.PathLike`)):
             The name of the file which contains the tensors
+        backend (`str`, *optional*, defaults to `"mmap"`):
+            Storage backend used to serve tensor bytes. `"mmap"` (default)
+            and `"read_file"` uses `pread(2)` to read tensor bytes.
 
     Returns:
         `Dict[str, np.ndarray]`: dictionary that contains name as key, value as `np.ndarray`
@@ -142,7 +147,7 @@ def load_file(filename: Union[str, os.PathLike]) -> Dict[str, np.ndarray]:
     loaded = load_file(file_path)
     ```
     """
-    with safe_open(filename, framework="np") as f:
+    with safe_open(filename, framework="np", backend=backend) as f:
         return f.get_tensors()
 
 

--- a/bindings/python/py_src/safetensors/numpy.py
+++ b/bindings/python/py_src/safetensors/numpy.py
@@ -133,7 +133,7 @@ def load_file(
             The name of the file which contains the tensors
         backend (`str`, *optional*, defaults to `"mmap"`):
             Storage backend used to serve tensor bytes. `"mmap"` (default)
-            and `"read_file"` uses `pread(2)` to read tensor bytes.
+            and `"pread"` uses `pread(2)` to read tensor bytes.
 
     Returns:
         `Dict[str, np.ndarray]`: dictionary that contains name as key, value as `np.ndarray`

--- a/bindings/python/py_src/safetensors/paddle.py
+++ b/bindings/python/py_src/safetensors/paddle.py
@@ -117,7 +117,7 @@ def load(data: bytes, device: str = "cpu") -> Dict[str, paddle.Tensor]:
 
 
 def load_file(
-    filename: Union[str, os.PathLike], device="cpu"
+    filename: Union[str, os.PathLike], device="cpu", *, backend: str = "mmap"
 ) -> Dict[str, paddle.Tensor]:
     """
     Loads a safetensors file into paddle format.
@@ -128,6 +128,9 @@ def load_file(
         device (`Union[Dict[str, any], str]`, *optional*, defaults to `cpu`):
             The device where the tensors need to be located after load.
             available options are all regular paddle device locations
+        backend (`str`, *optional*, defaults to `"mmap"`):
+            Storage backend used to serve tensor bytes. `"mmap"` (default)
+            and `"read_file"` uses `pread(2)` to read tensor bytes.
 
     Returns:
         `Dict[str, paddle.Tensor]`: dictionary that contains name as key, value as `paddle.Tensor`
@@ -142,9 +145,11 @@ def load_file(
     ```
     """
     if paddle.__version__ >= "3.2.0":
-        with safe_open(filename, framework="paddle", device=device) as f:
+        with safe_open(
+            filename, framework="paddle", device=device, backend=backend
+        ) as f:
             return f.get_tensors()
-    flat = numpy.load_file(filename)
+    flat = numpy.load_file(filename, backend=backend)
     return _np2paddle(flat, device)
 
 

--- a/bindings/python/py_src/safetensors/paddle.py
+++ b/bindings/python/py_src/safetensors/paddle.py
@@ -130,7 +130,7 @@ def load_file(
             available options are all regular paddle device locations
         backend (`str`, *optional*, defaults to `"mmap"`):
             Storage backend used to serve tensor bytes. `"mmap"` (default)
-            and `"read_file"` uses `pread(2)` to read tensor bytes.
+            and `"pread"` uses `pread(2)` to read tensor bytes.
 
     Returns:
         `Dict[str, paddle.Tensor]`: dictionary that contains name as key, value as `paddle.Tensor`

--- a/bindings/python/py_src/safetensors/tensorflow.py
+++ b/bindings/python/py_src/safetensors/tensorflow.py
@@ -100,13 +100,18 @@ def load(data: bytes) -> Dict[str, tf.Tensor]:
     return _np2tf(flat)
 
 
-def load_file(filename: Union[str, os.PathLike]) -> Dict[str, tf.Tensor]:
+def load_file(
+    filename: Union[str, os.PathLike], *, backend: str = "mmap"
+) -> Dict[str, tf.Tensor]:
     """
     Loads a safetensors file into tensorflow format.
 
     Args:
         filename (`str`, or `os.PathLike`)):
             The name of the file which contains the tensors
+        backend (`str`, *optional*, defaults to `"mmap"`):
+            Storage backend used to serve tensor bytes. `"mmap"` (default)
+            and `"read_file"` uses `pread(2)` to read tensor bytes.
 
     Returns:
         `Dict[str, tf.Tensor]`: dictionary that contains name as key, value as `tf.Tensor`
@@ -120,7 +125,7 @@ def load_file(filename: Union[str, os.PathLike]) -> Dict[str, tf.Tensor]:
     loaded = load_file(file_path)
     ```
     """
-    with safe_open(filename, framework="tf") as f:
+    with safe_open(filename, framework="tf", backend=backend) as f:
         return f.get_tensors()
 
 

--- a/bindings/python/py_src/safetensors/tensorflow.py
+++ b/bindings/python/py_src/safetensors/tensorflow.py
@@ -111,7 +111,7 @@ def load_file(
             The name of the file which contains the tensors
         backend (`str`, *optional*, defaults to `"mmap"`):
             Storage backend used to serve tensor bytes. `"mmap"` (default)
-            and `"read_file"` uses `pread(2)` to read tensor bytes.
+            and `"pread"` uses `pread(2)` to read tensor bytes.
 
     Returns:
         `Dict[str, tf.Tensor]`: dictionary that contains name as key, value as `tf.Tensor`

--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -196,6 +196,8 @@ def load_model(
     filename: Union[str, os.PathLike],
     strict: bool = True,
     device: Union[str, int] = "cpu",
+    *,
+    backend: str = "mmap",
 ) -> Tuple[List[str], List[str]]:
     """
     Loads a given filename onto a torch model.
@@ -213,6 +215,9 @@ def load_model(
         device (`Union[str, int]`, *optional*, defaults to `cpu`):
             The device where the tensors need to be located after load.
             available options are all regular torch device locations.
+        backend (`str`, *optional*, defaults to `"mmap"`):
+            Storage backend used to serve tensor bytes. `"mmap"` (default)
+            and `"read_file"` uses `pread(2)` to read tensor bytes.
 
     Returns:
         `(missing, unexpected): (List[str], List[str])`
@@ -220,7 +225,7 @@ def load_model(
             `unexpected` are names that are on the file, but weren't used during
             the load.
     """
-    state_dict = load_file(filename, device=device)
+    state_dict = load_file(filename, device=device, backend=backend)
     model_state_dict = model.state_dict()
     to_removes = _remove_duplicate_names(
         model_state_dict, preferred_names=state_dict.keys()
@@ -321,7 +326,10 @@ def save_file(
 
 
 def load_file(
-    filename: Union[str, os.PathLike], device: Union[str, int] = "cpu"
+    filename: Union[str, os.PathLike],
+    device: Union[str, int] = "cpu",
+    *,
+    backend: str = "mmap",
 ) -> Dict[str, torch.Tensor]:
     """
     Loads a safetensors file into torch format.
@@ -332,6 +340,9 @@ def load_file(
         device (`Union[str, int]`, *optional*, defaults to `cpu`):
             The device where the tensors need to be located after load.
             available options are all regular torch device locations.
+        backend (`str`, *optional*, defaults to `"mmap"`):
+            Storage backend used to serve tensor bytes. `"mmap"` (default)
+            and `"read_file"` uses `pread(2)` to read tensor bytes.
 
     Returns:
         `Dict[str, torch.Tensor]`: dictionary that contains name as key, value as `torch.Tensor`
@@ -345,7 +356,7 @@ def load_file(
     loaded = load_file(file_path)
     ```
     """
-    with safe_open(filename, framework="pt", device=device) as f:
+    with safe_open(filename, framework="pt", device=device, backend=backend) as f:
         return f.get_tensors()
 
 

--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -217,7 +217,7 @@ def load_model(
             available options are all regular torch device locations.
         backend (`str`, *optional*, defaults to `"mmap"`):
             Storage backend used to serve tensor bytes. `"mmap"` (default)
-            and `"read_file"` uses `pread(2)` to read tensor bytes.
+            and `"pread"` uses `pread(2)` to read tensor bytes.
 
     Returns:
         `(missing, unexpected): (List[str], List[str])`
@@ -342,7 +342,7 @@ def load_file(
             available options are all regular torch device locations.
         backend (`str`, *optional*, defaults to `"mmap"`):
             Storage backend used to serve tensor bytes. `"mmap"` (default)
-            and `"read_file"` uses `pread(2)` to read tensor bytes.
+            and `"pread"` uses `pread(2)` to read tensor bytes.
 
     Returns:
         `Dict[str, torch.Tensor]`: dictionary that contains name as key, value as `torch.Tensor`

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -334,16 +334,17 @@ fn slice_to_indexer(
 enum Backend {
     Mmap,
     /// Keeps the file handle open and serves each `get_tensor` /
-    /// `get_slice` via `pread(2)`, dispatching on `(framework, device)` to
-    /// write directly into a destination buffer chosen for performance.
-    ReadFile,
+    /// `get_slice` via `pread(2)` (or its Windows equivalent),
+    /// dispatching on `(framework, device)` to write directly into a
+    /// destination buffer chosen for performance.
+    Pread,
 }
 
 impl fmt::Display for Backend {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match *self {
             Backend::Mmap => "mmap",
-            Backend::ReadFile => "read_file",
+            Backend::Pread => "pread",
         })
     }
 }
@@ -355,9 +356,9 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Backend {
         let name: String = ob.extract()?;
         match &name[..] {
             "mmap" => Ok(Backend::Mmap),
-            "read_file" => Ok(Backend::ReadFile),
+            "pread" => Ok(Backend::Pread),
             name => Err(SafetensorError::new_err(format!(
-                "backend {name:?} is invalid (expected one of: \"mmap\", \"read_file\")"
+                "backend {name:?} is invalid (expected one of: \"mmap\", \"pread\")"
             ))),
         }
     }
@@ -537,7 +538,7 @@ enum Storage {
     /// Holds an open file handle and
     /// serves each tensor via `pread(2)` into a fresh per-tensor host
     /// buffer, with framework/device-specific buffer choices for performance.
-    ReadFile(Arc<File>),
+    Pread(Arc<File>),
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd)]
@@ -643,14 +644,14 @@ impl Open {
             Ok(())
         })?;
 
-        if backend == Backend::ReadFile {
+        if backend == Backend::Pread {
             return Ok(Self {
                 filename,
                 metadata,
                 offset,
                 framework,
                 device,
-                storage: Arc::new(Storage::ReadFile(Arc::new(file))),
+                storage: Arc::new(Storage::Pread(Arc::new(file))),
             });
         }
 
@@ -1008,11 +1009,11 @@ impl Open {
                     Ok(tensor.into_pyobject(py)?.into())
                 })
             }
-            Storage::ReadFile(file) => self.get_tensor_read_file(name, info, file),
+            Storage::Pread(file) => self.get_tensor_pread(name, info, file),
         }
     }
 
-    fn get_tensor_read_file(
+    fn get_tensor_pread(
         &self,
         name: &str,
         info: &TensorInfo,
@@ -1056,7 +1057,7 @@ impl Open {
 
         Python::attach(|py| -> PyResult<Py<PyAny>> {
             let torch = get_module(py, &TORCH_MODULE)?;
-            let dest = prepare_torch_pinned_cpu_dest(py, torch, info.dtype, &info.shape, nbytes)?;
+            let dest = PinnedCpuDest::new(py, torch, info.dtype, &info.shape, nbytes)?;
 
             if nbytes > 0 {
                 let write_ptr = dest.write_ptr;
@@ -1073,7 +1074,7 @@ impl Open {
                             dst.copy_from_slice(src);
                         });
                     }
-                    Storage::ReadFile(file) => {
+                    Storage::Pread(file) => {
                         let file_offset = (self.offset + begin) as u64;
                         let read_result: std::io::Result<()> = py.detach(|| {
                             // SAFETY: write_ptr/nbytes name `dest.tensor`'s
@@ -1180,7 +1181,7 @@ impl Open {
                 let (begin, end) = info.data_offsets;
                 let nbytes = end - begin;
 
-                let dest = prepare_mps_dest(py, torch, &name, info.dtype, &info.shape, nbytes)?;
+                let dest = MpsDest::new(py, torch, &name, info.dtype, &info.shape, nbytes)?;
                 if let Some(alias) = dest.host_alias {
                     host_aliases.push(alias);
                     jobs.push(PreadJob {
@@ -1546,7 +1547,7 @@ impl PySafeSlice {
                     ..self.info.data_offsets.1 + self.offset];
                 self.slice_bytes_to_tensor(slices, data)
             }
-            Storage::ReadFile(file) => {
+            Storage::Pread(file) => {
                 let (begin, end) = self.info.data_offsets;
                 let nbytes = end - begin;
                 let mut data = vec![0u8; nbytes];
@@ -1741,6 +1742,15 @@ struct PreadJob {
     write_ptr: usize,
 }
 
+/// Portable positional read: fills `buf` from `file` starting at `offset`.
+///
+/// **Thread-safety:** safe to call concurrently from multiple threads on the
+/// same `File`. Both backends (Unix `pread`, Windows `ReadFile` with an
+/// `OVERLAPPED` offset) take the read position as an explicit parameter and
+/// do not consult the file handle's seek cursor. Windows does still update
+/// the synchronous handle's internal cursor as a side-effect (so it ends up
+/// at an unspecified position after concurrent calls), but we never read
+/// from that cursor — every call passes its own `offset`.
 fn read_exact_at(file: &File, buf: &mut [u8], offset: u64) -> std::io::Result<()> {
     #[cfg(unix)]
     {
@@ -1848,52 +1858,54 @@ struct MpsDest<'py> {
     write_ptr: usize,
 }
 
-/// Allocate `torch.empty(...,device="mps")` and acquire a CPU-writable host
-/// alias to its storage.
 #[cfg(target_os = "macos")]
-fn prepare_mps_dest<'py>(
-    py: Python<'py>,
-    torch: &PyBound<'py, PyModule>,
-    name: &str,
-    dtype: Dtype,
-    logical_shape: &[usize],
-    nbytes: usize,
-) -> PyResult<MpsDest<'py>> {
-    let dtype_obj: Py<PyAny> = get_pydtype(torch, dtype, false)?;
-    let storage_shape = torch_storage_shape(dtype, logical_shape)?;
-    let shape_obj: Py<PyAny> = storage_shape.into_pyobject(py)?.into();
-    let device_obj: Py<PyAny> = "mps".into_pyobject(py)?.into();
-    let kwargs = [
-        (intern!(py, "dtype"), dtype_obj),
-        (intern!(py, "device"), device_obj),
-    ]
-    .into_py_dict(py)?;
-    let tensor = torch.call_method("empty", (shape_obj,), Some(&kwargs))?;
+impl<'py> MpsDest<'py> {
+    /// Allocate `torch.empty(...,device="mps")` and acquire a CPU-writable
+    /// host alias to its storage.
+    fn new(
+        py: Python<'py>,
+        torch: &PyBound<'py, PyModule>,
+        name: &str,
+        dtype: Dtype,
+        logical_shape: &[usize],
+        nbytes: usize,
+    ) -> PyResult<Self> {
+        let dtype_obj: Py<PyAny> = get_pydtype(torch, dtype, false)?;
+        let storage_shape = torch_storage_shape(dtype, logical_shape)?;
+        let shape_obj: Py<PyAny> = storage_shape.into_pyobject(py)?.into();
+        let device_obj: Py<PyAny> = "mps".into_pyobject(py)?.into();
+        let kwargs = [
+            (intern!(py, "dtype"), dtype_obj),
+            (intern!(py, "device"), device_obj),
+        ]
+        .into_py_dict(py)?;
+        let tensor = torch.call_method("empty", (shape_obj,), Some(&kwargs))?;
 
-    if nbytes == 0 {
-        return Ok(MpsDest {
+        if nbytes == 0 {
+            return Ok(Self {
+                tensor,
+                host_alias: None,
+                write_ptr: 0,
+            });
+        }
+
+        let mps_storage = tensor.call_method0(intern!(py, "untyped_storage"))?;
+        let mps_mod = torch.getattr(intern!(py, "mps"))?;
+        let host_alias_fn = mps_mod.getattr(intern!(py, "_host_alias_storage"))?;
+        let cpu_alias = host_alias_fn.call1((mps_storage,))?;
+        let write_ptr: usize = cpu_alias.call_method0(intern!(py, "data_ptr"))?.extract()?;
+        if write_ptr == 0 {
+            return Err(SafetensorError::new_err(format!(
+                "torch.mps._host_alias_storage returned a null data_ptr for tensor \
+                 {name} (non-shared-storage MPS allocation?)",
+            )));
+        }
+        Ok(Self {
             tensor,
-            host_alias: None,
-            write_ptr: 0,
-        });
+            host_alias: Some(cpu_alias),
+            write_ptr,
+        })
     }
-
-    let mps_storage = tensor.call_method0(intern!(py, "untyped_storage"))?;
-    let mps_mod = torch.getattr(intern!(py, "mps"))?;
-    let host_alias_fn = mps_mod.getattr(intern!(py, "_host_alias_storage"))?;
-    let cpu_alias = host_alias_fn.call1((mps_storage,))?;
-    let write_ptr: usize = cpu_alias.call_method0(intern!(py, "data_ptr"))?.extract()?;
-    if write_ptr == 0 {
-        return Err(SafetensorError::new_err(format!(
-            "torch.mps._host_alias_storage returned a null data_ptr for tensor \
-             {name} (non-shared-storage MPS allocation?)",
-        )));
-    }
-    Ok(MpsDest {
-        tensor,
-        host_alias: Some(cpu_alias),
-        write_ptr,
-    })
 }
 
 /// Pre-allocated pinned-CPU torch destination.
@@ -1902,37 +1914,39 @@ struct PinnedCpuDest<'py> {
     write_ptr: usize,
 }
 
-/// Allocate `torch.empty(...,device="cpu", pin_memory=True)` and extract the
-/// data pointer for direct pread.
-fn prepare_torch_pinned_cpu_dest<'py>(
-    py: Python<'py>,
-    torch: &PyBound<'py, PyModule>,
-    dtype: Dtype,
-    logical_shape: &[usize],
-    nbytes: usize,
-) -> PyResult<PinnedCpuDest<'py>> {
-    let dtype_obj: Py<PyAny> = get_pydtype(torch, dtype, false)?;
-    let storage_shape = torch_storage_shape(dtype, logical_shape)?;
-    let shape_obj: Py<PyAny> = storage_shape.into_pyobject(py)?.into();
-    let cpu_device: Py<PyAny> = "cpu".into_pyobject(py)?.into();
-    let pin: Py<PyAny> = PyBool::new(py, true).to_owned().into_any().into();
-    let kwargs = [
-        (intern!(py, "dtype"), dtype_obj),
-        (intern!(py, "device"), cpu_device),
-        (intern!(py, "pin_memory"), pin),
-    ]
-    .into_py_dict(py)?;
-    let tensor = torch.call_method("empty", (shape_obj,), Some(&kwargs))?;
+impl<'py> PinnedCpuDest<'py> {
+    /// Allocate `torch.empty(...,device="cpu", pin_memory=True)` and extract
+    /// the data pointer for direct pread.
+    fn new(
+        py: Python<'py>,
+        torch: &PyBound<'py, PyModule>,
+        dtype: Dtype,
+        logical_shape: &[usize],
+        nbytes: usize,
+    ) -> PyResult<Self> {
+        let dtype_obj: Py<PyAny> = get_pydtype(torch, dtype, false)?;
+        let storage_shape = torch_storage_shape(dtype, logical_shape)?;
+        let shape_obj: Py<PyAny> = storage_shape.into_pyobject(py)?.into();
+        let cpu_device: Py<PyAny> = "cpu".into_pyobject(py)?.into();
+        let pin: Py<PyAny> = PyBool::new(py, true).to_owned().into_any().into();
+        let kwargs = [
+            (intern!(py, "dtype"), dtype_obj),
+            (intern!(py, "device"), cpu_device),
+            (intern!(py, "pin_memory"), pin),
+        ]
+        .into_py_dict(py)?;
+        let tensor = torch.call_method("empty", (shape_obj,), Some(&kwargs))?;
 
-    if nbytes == 0 {
-        return Ok(PinnedCpuDest {
-            tensor,
-            write_ptr: 0,
-        });
+        if nbytes == 0 {
+            return Ok(Self {
+                tensor,
+                write_ptr: 0,
+            });
+        }
+
+        let write_ptr: usize = tensor.call_method0(intern!(py, "data_ptr"))?.extract()?;
+        Ok(Self { tensor, write_ptr })
     }
-
-    let write_ptr: usize = tensor.call_method0(intern!(py, "data_ptr"))?.extract()?;
-    Ok(PinnedCpuDest { tensor, write_ptr })
 }
 
 /// Whether this torch build exposes `torch.mps._host_alias_storage`

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1847,10 +1847,22 @@ fn torch_storage_shape(dtype: Dtype, logical_shape: &[usize]) -> PyResult<Vec<us
     Ok(shape)
 }
 
-/// Pre-allocated MPS destination ready for a `pread` write. `write_ptr` is the
-/// host-aliased CPU pointer to the MPS tensor's MTLBuffer; `host_alias` keeps
-/// that alias storage alive across the writes — drop only after the trailing
-/// `mps.synchronize()`.
+/// Pre-allocated MPS destination ready for a `pread` write.
+///
+/// - `tensor`: the MPS tensor returned to the user; its underlying storage
+///   owns the MTLBuffer.
+/// - `write_ptr`: a host-mapped address into that MTLBuffer (obtained via
+///   `torch.mps._host_alias_storage().data_ptr()`). Valid for as long as
+///   the MTLBuffer lives — i.e., as long as `tensor` lives — since shared-
+///   storage MTLBuffers expose a stable CPU pointer for their full
+///   lifetime.
+/// - `host_alias`: the intermediate CPU-storage Python wrapper produced by
+///   `_host_alias_storage`. Held defensively across the writes; not
+///   strictly required for `write_ptr` to remain valid (the MTLBuffer is
+///   already pinned by `tensor`), but cheap insurance against any
+///   side-effect of dropping the CPU view mid-write. Independent of the
+///   trailing `mps.synchronize()`, which exists to flush CPU writes to
+///   subsequent MPS reads.
 #[cfg(target_os = "macos")]
 struct MpsDest<'py> {
     tensor: PyBound<'py, PyAny>,

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1018,8 +1018,6 @@ impl Open {
         info: &TensorInfo,
         file: &Arc<File>,
     ) -> PyResult<Py<PyAny>> {
-        use std::os::unix::fs::FileExt;
-
         let (begin, end) = info.data_offsets;
         let nbytes = end - begin;
         let file_offset = (self.offset + begin) as u64;
@@ -1027,7 +1025,7 @@ impl Open {
         let array: Py<PyAny> = Python::attach(|py| -> PyResult<Py<PyAny>> {
             let pyarray = PyByteArray::new_with(py, nbytes, |dst| {
                 if !dst.is_empty() {
-                    file.read_exact_at(dst, file_offset).map_err(|e| {
+                    read_exact_at(file, dst, file_offset).map_err(|e| {
                         SafetensorError::new_err(format!(
                             "Could not read tensor {name} from file: {e}"
                         ))
@@ -1053,8 +1051,6 @@ impl Open {
     /// pinned host buffer is dropped right after the transfer so peak host
     /// residency stays at one tensor.
     fn get_tensor_pinned_cuda(&self, name: &str, info: &TensorInfo) -> PyResult<Py<PyAny>> {
-        use std::os::unix::fs::FileExt;
-
         let (begin, end) = info.data_offsets;
         let nbytes = end - begin;
 
@@ -1085,7 +1081,7 @@ impl Open {
                             let buf = unsafe {
                                 std::slice::from_raw_parts_mut(write_ptr as *mut u8, nbytes)
                             };
-                            file.read_exact_at(buf, file_offset)
+                            read_exact_at(file, buf, file_offset)
                         });
                         read_result.map_err(|e| {
                             SafetensorError::new_err(format!("pread failed for tensor {name}: {e}"))
@@ -1551,17 +1547,15 @@ impl PySafeSlice {
                 self.slice_bytes_to_tensor(slices, data)
             }
             Storage::ReadFile(file) => {
-                use std::os::unix::fs::FileExt;
                 let (begin, end) = self.info.data_offsets;
                 let nbytes = end - begin;
                 let mut data = vec![0u8; nbytes];
                 if nbytes > 0 {
-                    file.read_exact_at(&mut data, (self.offset + begin) as u64)
-                        .map_err(|e| {
-                            SafetensorError::new_err(format!(
-                                "Could not read tensor bytes for slicing: {e}"
-                            ))
-                        })?;
+                    read_exact_at(file, &mut data, (self.offset + begin) as u64).map_err(|e| {
+                        SafetensorError::new_err(format!(
+                            "Could not read tensor bytes for slicing: {e}"
+                        ))
+                    })?;
                 }
                 self.slice_bytes_to_tensor(slices, &data)
             }
@@ -1746,6 +1740,30 @@ struct PreadJob {
     write_ptr: usize,
 }
 
+fn read_exact_at(file: &File, buf: &mut [u8], offset: u64) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::FileExt;
+        file.read_exact_at(buf, offset)
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::FileExt;
+        let mut written = 0;
+        while written < buf.len() {
+            let n = file.seek_read(&mut buf[written..], offset + written as u64)?;
+            if n == 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "read_exact_at: early EOF",
+                ));
+            }
+            written += n;
+        }
+        Ok(())
+    }
+}
+
 /// Run a set of pread(2) jobs in parallel without holding the GIL.
 ///
 /// Caller must ensure each `(write_ptr, nbytes)` names a distinct, mutable,
@@ -1757,7 +1775,6 @@ fn parallel_pread(
     file: &File,
     jobs: &[PreadJob],
 ) -> Result<(), (String, std::io::Error)> {
-    use std::os::unix::fs::FileExt;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     py.detach(|| {
@@ -1783,7 +1800,7 @@ fn parallel_pread(
                         let buf = unsafe {
                             std::slice::from_raw_parts_mut(job.write_ptr as *mut u8, job.nbytes)
                         };
-                        file.read_exact_at(buf, job.file_offset)
+                        read_exact_at(file, buf, job.file_offset)
                             .map_err(|e| (job.name.clone(), e))?;
                     }
                 }));

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1733,6 +1733,7 @@ fn get_module<'a>(
 }
 
 /// One pread(2) job: read `nbytes` from `file_offset` into `write_ptr`.
+#[allow(dead_code)]
 struct PreadJob {
     name: String,
     file_offset: u64,
@@ -1770,6 +1771,7 @@ fn read_exact_at(file: &File, buf: &mut [u8], offset: u64) -> std::io::Result<()
 /// allocated buffer that outlives this call (the GIL is released for the
 /// duration). The number of workers is capped at 8: beyond that, NVMe and
 /// Apple SSD reads should be I/O-bound rather than CPU-bound.
+#[allow(dead_code)]
 fn parallel_pread(
     py: Python<'_>,
     file: &File,

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -329,6 +329,40 @@ fn slice_to_indexer(
     }
 }
 
+/// Storage backend used to serve tensor bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Backend {
+    Mmap,
+    /// Keeps the file handle open and serves each `get_tensor` /
+    /// `get_slice` via `pread(2)`, dispatching on `(framework, device)` to
+    /// write directly into a destination buffer chosen for performance.
+    ReadFile,
+}
+
+impl fmt::Display for Backend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match *self {
+            Backend::Mmap => "mmap",
+            Backend::ReadFile => "read_file",
+        })
+    }
+}
+
+impl<'a, 'py> FromPyObject<'a, 'py> for Backend {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
+        let name: String = ob.extract()?;
+        match &name[..] {
+            "mmap" => Ok(Backend::Mmap),
+            "read_file" => Ok(Backend::ReadFile),
+            name => Err(SafetensorError::new_err(format!(
+                "backend {name:?} is invalid (expected one of: \"mmap\", \"read_file\")"
+            ))),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Framework {
     Pytorch,
@@ -500,6 +534,10 @@ enum Storage {
     // Paddle can handle the whole lifecycle.
     // https://www.paddlepaddle.org.cn/documentation/docs/en/develop/api/paddle/MmapStorage_en.html
     Paddle(OnceLock<Py<PyAny>>),
+    /// Holds an open file handle and
+    /// serves each tensor via `pread(2)` into a fresh per-tensor host
+    /// buffer, with framework/device-specific buffer choices for performance.
+    ReadFile(Arc<File>),
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd)]
@@ -555,7 +593,12 @@ struct Open {
 }
 
 impl Open {
-    fn new(filename: PathBuf, framework: Framework, device: Option<Device>) -> PyResult<Self> {
+    fn new(
+        filename: PathBuf,
+        framework: Framework,
+        device: Option<Device>,
+        backend: Backend,
+    ) -> PyResult<Self> {
         let file = File::open(&filename).map_err(|_| {
             PyFileNotFoundError::new_err(format!(
                 "No such file or directory: {}",
@@ -599,6 +642,17 @@ impl Open {
 
             Ok(())
         })?;
+
+        if backend == Backend::ReadFile {
+            return Ok(Self {
+                filename,
+                metadata,
+                offset,
+                framework,
+                device,
+                storage: Arc::new(Storage::ReadFile(Arc::new(file))),
+            });
+        }
 
         let storage = match &framework {
             Framework::Paddle => Python::attach(|py| -> PyResult<Storage> {
@@ -753,9 +807,18 @@ impl Open {
         let info = self.metadata.info(name).ok_or_else(|| {
             SafetensorError::new_err(format!("File does not contain tensor {name}",))
         })?;
-        // let info = tensors.get(name).ok_or_else(|| {
-        //     SafetensorError::new_err(format!("File does not contain tensor {name}",))
-        // })?;
+
+        // Pytorch + CUDA: write into a pinned CPU tensor and `.to(cuda)` for
+        // async DMA, regardless of backend. The byte source differs per
+        // Storage variant (mmap region / pread / torch storage's data_ptr),
+        // but the destination + transfer step are identical.
+        // TODO: investigate the equivalent for Paddle + GPU using
+        // `paddle.empty(..., pin_memory=True)` once we have hardware to test.
+        if self.framework == Framework::Pytorch {
+            if let Device::Cuda(_) = self.device {
+                return self.get_tensor_pinned_cuda(name, info);
+            }
+        }
 
         match &self.storage.as_ref() {
             Storage::Mmap(mmap) => {
@@ -945,22 +1008,144 @@ impl Open {
                     Ok(tensor.into_pyobject(py)?.into())
                 })
             }
+            Storage::ReadFile(file) => self.get_tensor_read_file(name, info, file),
         }
+    }
+
+    fn get_tensor_read_file(
+        &self,
+        name: &str,
+        info: &TensorInfo,
+        file: &Arc<File>,
+    ) -> PyResult<Py<PyAny>> {
+        use std::os::unix::fs::FileExt;
+
+        let (begin, end) = info.data_offsets;
+        let nbytes = end - begin;
+        let file_offset = (self.offset + begin) as u64;
+
+        let array: Py<PyAny> = Python::attach(|py| -> PyResult<Py<PyAny>> {
+            let pyarray = PyByteArray::new_with(py, nbytes, |dst| {
+                if !dst.is_empty() {
+                    file.read_exact_at(dst, file_offset).map_err(|e| {
+                        SafetensorError::new_err(format!(
+                            "Could not read tensor {name} from file: {e}"
+                        ))
+                    })?;
+                }
+                Ok(())
+            })?;
+            Ok(pyarray.into_any().into())
+        })?;
+        create_tensor(
+            &self.framework,
+            info.dtype,
+            &info.shape,
+            array,
+            &self.device,
+        )
+    }
+
+    /// Pytorch + CUDA fast path used regardless of backend: allocate a
+    /// `pin_memory=True` CPU tensor, fill it from whichever source the
+    /// `Storage` variant exposes, then `.to(cuda)` for async DMA. Avoids
+    /// CUDA's internal bounce buffer that pageable sources incur, and the
+    /// pinned host buffer is dropped right after the transfer so peak host
+    /// residency stays at one tensor.
+    fn get_tensor_pinned_cuda(&self, name: &str, info: &TensorInfo) -> PyResult<Py<PyAny>> {
+        use std::os::unix::fs::FileExt;
+
+        let (begin, end) = info.data_offsets;
+        let nbytes = end - begin;
+
+        Python::attach(|py| -> PyResult<Py<PyAny>> {
+            let torch = get_module(py, &TORCH_MODULE)?;
+            let dest = prepare_torch_pinned_cpu_dest(py, torch, info.dtype, &info.shape, nbytes)?;
+
+            if nbytes > 0 {
+                let write_ptr = dest.write_ptr;
+                match self.storage.as_ref() {
+                    Storage::Mmap(mmap) => {
+                        let src_off = self.offset + begin;
+                        let src = &mmap[src_off..src_off + nbytes];
+                        py.detach(|| {
+                            // SAFETY: write_ptr/nbytes name `dest.tensor`'s
+                            // pinned storage; src is the live mmap region.
+                            let dst = unsafe {
+                                std::slice::from_raw_parts_mut(write_ptr as *mut u8, nbytes)
+                            };
+                            dst.copy_from_slice(src);
+                        });
+                    }
+                    Storage::ReadFile(file) => {
+                        let file_offset = (self.offset + begin) as u64;
+                        let read_result: std::io::Result<()> = py.detach(|| {
+                            // SAFETY: write_ptr/nbytes name `dest.tensor`'s
+                            // pinned storage.
+                            let buf = unsafe {
+                                std::slice::from_raw_parts_mut(write_ptr as *mut u8, nbytes)
+                            };
+                            file.read_exact_at(buf, file_offset)
+                        });
+                        read_result.map_err(|e| {
+                            SafetensorError::new_err(format!("pread failed for tensor {name}: {e}"))
+                        })?;
+                    }
+                    Storage::Torch(storage) => {
+                        let storage_obj: &Py<PyAny> = storage
+                            .get()
+                            .ok_or_else(|| SafetensorError::new_err("Could not find storage"))?;
+                        let storage_obj = storage_obj.bind(py);
+                        let src_data_ptr: usize = storage_obj
+                            .call_method0(intern!(py, "data_ptr"))?
+                            .extract()?;
+                        let src_addr = src_data_ptr + self.offset + begin;
+                        py.detach(|| {
+                            // SAFETY: src_addr is the data_ptr of the torch
+                            // UntypedStorage held alive by `self.storage`,
+                            // valid for `self.offset+begin..+nbytes`.
+                            // write_ptr/nbytes name `dest.tensor`'s pinned
+                            // storage.
+                            unsafe {
+                                std::ptr::copy_nonoverlapping(
+                                    src_addr as *const u8,
+                                    write_ptr as *mut u8,
+                                    nbytes,
+                                );
+                            }
+                        });
+                    }
+                    Storage::Paddle(_) => {
+                        // Paddle has its own CUDA path via Storage::Paddle.
+                        unreachable!("Storage::Paddle does not route through pinned CUDA path");
+                    }
+                }
+            }
+
+            let cuda_device: Py<PyAny> = self.device.clone().into_pyobject(py)?.into();
+            let kwargs = PyDict::new(py);
+            let cuda_tensor = dest
+                .tensor
+                .call_method("to", (cuda_device,), Some(&kwargs))?;
+            Ok(cuda_tensor.into_pyobject(py)?.into())
+        })
     }
 
     /// Returns every tensor in the file as a `{name: Tensor}` dict.
     ///
-    /// Default behavior is a sequential loop over `get_tensor`; specific
-    /// framework/device combinations can take an internal fast path (e.g.
-    /// MPS with `torch.mps._host_alias_storage` allocates all tensors
-    /// on-device and fills them with parallel `pread(2)` calls).
+    /// Default behavior is a sequential loop over `get_tensor`. Pytorch + MPS
+    /// (with `torch.mps._host_alias_storage` available) takes an internal
+    /// fast path: bulk-allocate MPS tensors, parallel `pread(2)` straight
+    /// into their host-aliased MTLBuffers. The bulk path is safe on MPS
+    /// because the MPS tensor *is* the destination — there's no separate
+    /// staging buffer, total memory stays at 1× model.
     pub fn get_tensors(&self) -> PyResult<Py<PyDict>> {
         #[cfg(target_os = "macos")]
         if self.framework == Framework::Pytorch
             && self.device == Device::Mps
             && mps_host_alias_available()?
         {
-            return self.get_tensors_mps_fast();
+            return self.get_tensors_parallel_mps();
         }
 
         Python::attach(|py| -> PyResult<Py<PyDict>> {
@@ -977,20 +1162,7 @@ impl Open {
     /// their host-aliased MTLBuffers. Requires `torch.mps._host_alias_storage`
     /// (pytorch/pytorch#180961); caller must have verified.
     #[cfg(target_os = "macos")]
-    fn get_tensors_mps_fast(&self) -> PyResult<Py<PyDict>> {
-        use std::os::unix::fs::FileExt;
-        use std::sync::atomic::{AtomicUsize, Ordering};
-
-        // Only populated for non-empty tensors; zero-byte tensors are
-        // allocated as torch.empty and skipped entirely
-        struct Job {
-            name: String,
-            file_offset: u64,
-            nbytes: usize,
-            // Host-writable MTLBuffer pointer
-            write_ptr: usize,
-        }
-
+    fn get_tensors_parallel_mps(&self) -> PyResult<Py<PyDict>> {
         let file = File::open(&self.filename).map_err(|e| {
             PyFileNotFoundError::new_err(format!("Could not open {}: {e}", self.filename.display()))
         })?;
@@ -998,119 +1170,37 @@ impl Open {
         Python::attach(|py| -> PyResult<Py<PyDict>> {
             let torch = get_module(py, &TORCH_MODULE)?;
             let mps_mod = torch.getattr(intern!(py, "mps"))?;
-            let host_alias_fn = mps_mod.getattr(intern!(py, "_host_alias_storage"))?;
-            let mps_device: Py<PyAny> = "mps".into_pyobject(py)?.into();
 
             let keys = self.metadata.offset_keys();
             let mut entries: Vec<(String, PyBound<'_, PyAny>)> = Vec::with_capacity(keys.len());
             // Aliases pin the source MPS storages; keep alive across parallel writes.
             let mut host_aliases: Vec<PyBound<'_, PyAny>> = Vec::with_capacity(keys.len());
-            let mut jobs: Vec<Job> = Vec::with_capacity(keys.len());
+            let mut jobs: Vec<PreadJob> = Vec::with_capacity(keys.len());
 
             for name in keys {
                 let info = self.metadata.info(&name).ok_or_else(|| {
                     SafetensorError::new_err(format!("Missing tensor info for {name}"))
                 })?;
-                let dtype_obj: Py<PyAny> = get_pydtype(torch, info.dtype, false)?;
-
-                // F4 stores two elements per byte; torch shape halves the last dim.
-                let mut torch_shape = info.shape.clone();
-                if info.dtype == Dtype::F4 {
-                    let n = torch_shape.len();
-                    if n == 0 || torch_shape[n - 1] % 2 != 0 {
-                        return Err(SafetensorError::new_err(format!(
-                            "f4_x2 dtype requires the last dim be divisible by 2 in torch: got {:?}",
-                            info.shape,
-                        )));
-                    }
-                    torch_shape[n - 1] /= 2;
-                }
-                let shape_obj: Py<PyAny> = torch_shape.into_pyobject(py)?.into();
-
-                let kwargs = [
-                    (intern!(py, "dtype"), dtype_obj),
-                    (intern!(py, "device"), mps_device.clone_ref(py)),
-                ]
-                .into_py_dict(py)?;
-                let tensor = torch.call_method("empty", (shape_obj,), Some(&kwargs))?;
-
                 let (begin, end) = info.data_offsets;
                 let nbytes = end - begin;
 
-                if nbytes > 0 {
-                    let mps_storage = tensor.call_method0(intern!(py, "untyped_storage"))?;
-                    let cpu_alias = host_alias_fn.call1((mps_storage,))?;
-                    let write_ptr: usize =
-                        cpu_alias.call_method0(intern!(py, "data_ptr"))?.extract()?;
-                    if write_ptr == 0 {
-                        return Err(SafetensorError::new_err(format!(
-                            "torch.mps._host_alias_storage returned a null data_ptr for tensor \
-                             {name} (non-shared-storage MPS allocation?)",
-                        )));
-                    }
-                    host_aliases.push(cpu_alias);
-                    jobs.push(Job {
+                let dest = prepare_mps_dest(py, torch, &name, info.dtype, &info.shape, nbytes)?;
+                if let Some(alias) = dest.host_alias {
+                    host_aliases.push(alias);
+                    jobs.push(PreadJob {
                         name: name.clone(),
                         file_offset: (self.offset + begin) as u64,
                         nbytes,
-                        write_ptr,
+                        write_ptr: dest.write_ptr,
                     });
                 }
-                entries.push((name, tensor));
+                entries.push((name, dest.tensor));
             }
 
             // Drain in-flight GPU work before writing through the CPU alias.
             mps_mod.call_method0(intern!(py, "synchronize"))?;
 
-            let read_result: Result<(), (String, std::io::Error)> = py.detach(|| {
-                let jobs = &jobs;
-                let file = &file;
-                let next = AtomicUsize::new(0);
-                // Cap: beyond P-core count reads are SSD-bound on Apple silicon.
-                const MAX_WORKERS: usize = 8;
-                let n_workers = std::thread::available_parallelism()
-                    .map_or(4, |n| n.get())
-                    .min(MAX_WORKERS)
-                    .min(jobs.len());
-
-                std::thread::scope(|s| -> Result<(), (String, std::io::Error)> {
-                    let mut handles = Vec::with_capacity(n_workers);
-                    for _ in 0..n_workers {
-                        let next = &next;
-                        handles.push(s.spawn(move || -> Result<(), (String, std::io::Error)> {
-                            loop {
-                                let i = next.fetch_add(1, Ordering::Relaxed);
-                                if i >= jobs.len() {
-                                    return Ok(());
-                                }
-                                let job = &jobs[i];
-                                // SAFETY: each job's (write_ptr, nbytes) comes from a
-                                // distinct torch.empty allocation on MPS, so the target
-                                // ranges are disjoint; the tensors outlive py.detach.
-                                let buf = unsafe {
-                                    std::slice::from_raw_parts_mut(
-                                        job.write_ptr as *mut u8,
-                                        job.nbytes,
-                                    )
-                                };
-                                file.read_exact_at(buf, job.file_offset)
-                                    .map_err(|e| (job.name.clone(), e))?;
-                            }
-                        }));
-                    }
-                    for h in handles {
-                        h.join().map_err(|_| {
-                            (
-                                "<worker panic>".to_string(),
-                                std::io::Error::other("worker panicked"),
-                            )
-                        })??;
-                    }
-                    Ok(())
-                })
-            });
-
-            if let Err((name, e)) = read_result {
+            if let Err((name, e)) = parallel_pread(py, &file, &jobs) {
                 return Err(SafetensorError::new_err(format!(
                     "pread failed for tensor {name}: {e}"
                 )));
@@ -1195,9 +1285,14 @@ impl safe_open {
 #[pymethods]
 impl safe_open {
     #[new]
-    #[pyo3(signature = (filename, framework, device=Some(Device::Cpu)))]
-    fn new(filename: PathBuf, framework: Framework, device: Option<Device>) -> PyResult<Self> {
-        let inner = Some(Open::new(filename, framework, device)?);
+    #[pyo3(signature = (filename, framework, device=Some(Device::Cpu), *, backend=Backend::Mmap))]
+    fn new(
+        filename: PathBuf,
+        framework: Framework,
+        device: Option<Device>,
+        backend: Backend,
+    ) -> PyResult<Self> {
+        let inner = Some(Open::new(filename, framework, device, backend)?);
         Ok(Self { inner })
     }
 
@@ -1339,6 +1434,73 @@ impl fmt::Display for Disp {
     }
 }
 
+impl PySafeSlice {
+    fn slice_bytes_to_tensor(
+        &self,
+        slices: &PyBound<'_, PyAny>,
+        data: &[u8],
+    ) -> PyResult<Py<PyAny>> {
+        let pyslices = slices;
+        let parsed: Slice = pyslices.extract()?;
+        let is_list = pyslices.is_instance_of::<PyList>();
+        let parsed: Vec<SliceIndex> = match parsed {
+            Slice::Slice(slice) => vec![slice],
+            Slice::Slices(slices) => {
+                if slices.is_empty() && is_list {
+                    vec![SliceIndex::Slice(PySlice::new(pyslices.py(), 0, 0, 0))]
+                } else if is_list {
+                    return Err(SafetensorError::new_err(
+                        "Non empty lists are not implemented",
+                    ));
+                } else {
+                    slices
+                }
+            }
+        };
+
+        let shape = self.info.shape.clone();
+        let tensor = TensorView::new(self.info.dtype, self.info.shape.clone(), data)
+            .map_err(|e| SafetensorError::new_err(format!("Error preparing tensor view: {e}")))?;
+        let indexers: Vec<TensorIndexer> = parsed
+            .into_iter()
+            .zip(shape)
+            .enumerate()
+            .map(slice_to_indexer)
+            .collect::<Result<_, _>>()?;
+
+        let iterator = tensor.sliced_data(&indexers).map_err(|e| {
+            SafetensorError::new_err(format!(
+                "Error during slicing {} with shape {:?}: {e}",
+                Disp(indexers),
+                self.info.shape,
+            ))
+        })?;
+        let newshape = iterator.newshape();
+        let length = iterator.remaining_byte_len();
+
+        let mut offset = 0;
+        Python::attach(|py| {
+            let array: Py<PyAny> = PyByteArray::new_with(py, length, |bytes: &mut [u8]| {
+                for slice in iterator {
+                    let len = slice.len();
+                    bytes[offset..offset + len].copy_from_slice(slice);
+                    offset += len;
+                }
+                Ok(())
+            })?
+            .into_any()
+            .into();
+            create_tensor(
+                &self.framework,
+                self.info.dtype,
+                &newshape,
+                array,
+                &self.device,
+            )
+        })
+    }
+}
+
 #[pymethods]
 impl PySafeSlice {
     /// Returns the shape of the full underlying tensor
@@ -1384,70 +1546,24 @@ impl PySafeSlice {
     pub fn __getitem__(&self, slices: &PyBound<'_, PyAny>) -> PyResult<Py<PyAny>> {
         match &self.storage.as_ref() {
             Storage::Mmap(mmap) => {
-                let pyslices = slices;
-                let slices: Slice = pyslices.extract()?;
-                let is_list = pyslices.is_instance_of::<PyList>();
-                let slices: Vec<SliceIndex> = match slices {
-                    Slice::Slice(slice) => vec![slice],
-                    Slice::Slices(slices) => {
-                        if slices.is_empty() && is_list {
-                            vec![SliceIndex::Slice(PySlice::new(pyslices.py(), 0, 0, 0))]
-                        } else if is_list {
-                            return Err(SafetensorError::new_err(
-                                "Non empty lists are not implemented",
-                            ));
-                        } else {
-                            slices
-                        }
-                    }
-                };
                 let data = &mmap[self.info.data_offsets.0 + self.offset
                     ..self.info.data_offsets.1 + self.offset];
-
-                let shape = self.info.shape.clone();
-
-                let tensor = TensorView::new(self.info.dtype, self.info.shape.clone(), data)
-                    .map_err(|e| {
-                        SafetensorError::new_err(format!("Error preparing tensor view: {e}"))
-                    })?;
-                let slices: Vec<TensorIndexer> = slices
-                    .into_iter()
-                    .zip(shape)
-                    .enumerate()
-                    .map(slice_to_indexer)
-                    .collect::<Result<_, _>>()?;
-
-                let iterator = tensor.sliced_data(&slices).map_err(|e| {
-                    SafetensorError::new_err(format!(
-                        "Error during slicing {} with shape {:?}: {e}",
-                        Disp(slices),
-                        self.info.shape,
-                    ))
-                })?;
-                let newshape = iterator.newshape();
-
-                let mut offset = 0;
-                let length = iterator.remaining_byte_len();
-                Python::attach(|py| {
-                    let array: Py<PyAny> =
-                        PyByteArray::new_with(py, length, |bytes: &mut [u8]| {
-                            for slice in iterator {
-                                let len = slice.len();
-                                bytes[offset..offset + slice.len()].copy_from_slice(slice);
-                                offset += len;
-                            }
-                            Ok(())
-                        })?
-                        .into_any()
-                        .into();
-                    create_tensor(
-                        &self.framework,
-                        self.info.dtype,
-                        &newshape,
-                        array,
-                        &self.device,
-                    )
-                })
+                self.slice_bytes_to_tensor(slices, data)
+            }
+            Storage::ReadFile(file) => {
+                use std::os::unix::fs::FileExt;
+                let (begin, end) = self.info.data_offsets;
+                let nbytes = end - begin;
+                let mut data = vec![0u8; nbytes];
+                if nbytes > 0 {
+                    file.read_exact_at(&mut data, (self.offset + begin) as u64)
+                        .map_err(|e| {
+                            SafetensorError::new_err(format!(
+                                "Could not read tensor bytes for slicing: {e}"
+                            ))
+                        })?;
+                }
+                self.slice_bytes_to_tensor(slices, &data)
             }
             Storage::Torch(storage) => Python::attach(|py| -> PyResult<Py<PyAny>> {
                 let torch = get_module(py, &TORCH_MODULE)?;
@@ -1620,6 +1736,184 @@ fn get_module<'a>(
         .ok_or_else(|| SafetensorError::new_err("Could not find module"))?
         .bind(py);
     Ok(module)
+}
+
+/// One pread(2) job: read `nbytes` from `file_offset` into `write_ptr`.
+struct PreadJob {
+    name: String,
+    file_offset: u64,
+    nbytes: usize,
+    write_ptr: usize,
+}
+
+/// Run a set of pread(2) jobs in parallel without holding the GIL.
+///
+/// Caller must ensure each `(write_ptr, nbytes)` names a distinct, mutable,
+/// allocated buffer that outlives this call (the GIL is released for the
+/// duration). The number of workers is capped at 8: beyond that, NVMe and
+/// Apple SSD reads should be I/O-bound rather than CPU-bound.
+fn parallel_pread(
+    py: Python<'_>,
+    file: &File,
+    jobs: &[PreadJob],
+) -> Result<(), (String, std::io::Error)> {
+    use std::os::unix::fs::FileExt;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    py.detach(|| {
+        let next = AtomicUsize::new(0);
+        const MAX_WORKERS: usize = 8;
+        let n_workers = std::thread::available_parallelism()
+            .map_or(4, |n| n.get())
+            .min(MAX_WORKERS)
+            .min(jobs.len().max(1));
+
+        std::thread::scope(|s| -> Result<(), (String, std::io::Error)> {
+            let mut handles = Vec::with_capacity(n_workers);
+            for _ in 0..n_workers {
+                let next = &next;
+                handles.push(s.spawn(move || -> Result<(), (String, std::io::Error)> {
+                    loop {
+                        let i = next.fetch_add(1, Ordering::Relaxed);
+                        if i >= jobs.len() {
+                            return Ok(());
+                        }
+                        let job = &jobs[i];
+                        // SAFETY: caller contract — distinct, alive, mutable buffers.
+                        let buf = unsafe {
+                            std::slice::from_raw_parts_mut(job.write_ptr as *mut u8, job.nbytes)
+                        };
+                        file.read_exact_at(buf, job.file_offset)
+                            .map_err(|e| (job.name.clone(), e))?;
+                    }
+                }));
+            }
+            for h in handles {
+                h.join().map_err(|_| {
+                    (
+                        "<worker panic>".to_string(),
+                        std::io::Error::other("worker panicked"),
+                    )
+                })??;
+            }
+            Ok(())
+        })
+    })
+}
+
+/// Storage shape for torch tensors. F4 packs two elements per byte, so the
+/// `torch.empty` shape halves the last dim relative to the logical shape
+/// recorded in the safetensors header.
+fn torch_storage_shape(dtype: Dtype, logical_shape: &[usize]) -> PyResult<Vec<usize>> {
+    let mut shape = logical_shape.to_vec();
+    if dtype == Dtype::F4 {
+        let n = shape.len();
+        if n == 0 || shape[n - 1] % 2 != 0 {
+            return Err(SafetensorError::new_err(format!(
+                "f4_x2 dtype requires the last dim be divisible by 2 in torch: got {logical_shape:?}",
+            )));
+        }
+        shape[n - 1] /= 2;
+    }
+    Ok(shape)
+}
+
+/// Pre-allocated MPS destination ready for a `pread` write. `write_ptr` is the
+/// host-aliased CPU pointer to the MPS tensor's MTLBuffer; `host_alias` keeps
+/// that alias storage alive across the writes — drop only after the trailing
+/// `mps.synchronize()`.
+#[cfg(target_os = "macos")]
+struct MpsDest<'py> {
+    tensor: PyBound<'py, PyAny>,
+    host_alias: Option<PyBound<'py, PyAny>>,
+    write_ptr: usize,
+}
+
+/// Allocate `torch.empty(...,device="mps")` and acquire a CPU-writable host
+/// alias to its storage.
+#[cfg(target_os = "macos")]
+fn prepare_mps_dest<'py>(
+    py: Python<'py>,
+    torch: &PyBound<'py, PyModule>,
+    name: &str,
+    dtype: Dtype,
+    logical_shape: &[usize],
+    nbytes: usize,
+) -> PyResult<MpsDest<'py>> {
+    let dtype_obj: Py<PyAny> = get_pydtype(torch, dtype, false)?;
+    let storage_shape = torch_storage_shape(dtype, logical_shape)?;
+    let shape_obj: Py<PyAny> = storage_shape.into_pyobject(py)?.into();
+    let device_obj: Py<PyAny> = "mps".into_pyobject(py)?.into();
+    let kwargs = [
+        (intern!(py, "dtype"), dtype_obj),
+        (intern!(py, "device"), device_obj),
+    ]
+    .into_py_dict(py)?;
+    let tensor = torch.call_method("empty", (shape_obj,), Some(&kwargs))?;
+
+    if nbytes == 0 {
+        return Ok(MpsDest {
+            tensor,
+            host_alias: None,
+            write_ptr: 0,
+        });
+    }
+
+    let mps_storage = tensor.call_method0(intern!(py, "untyped_storage"))?;
+    let mps_mod = torch.getattr(intern!(py, "mps"))?;
+    let host_alias_fn = mps_mod.getattr(intern!(py, "_host_alias_storage"))?;
+    let cpu_alias = host_alias_fn.call1((mps_storage,))?;
+    let write_ptr: usize = cpu_alias.call_method0(intern!(py, "data_ptr"))?.extract()?;
+    if write_ptr == 0 {
+        return Err(SafetensorError::new_err(format!(
+            "torch.mps._host_alias_storage returned a null data_ptr for tensor \
+             {name} (non-shared-storage MPS allocation?)",
+        )));
+    }
+    Ok(MpsDest {
+        tensor,
+        host_alias: Some(cpu_alias),
+        write_ptr,
+    })
+}
+
+/// Pre-allocated pinned-CPU torch destination.
+struct PinnedCpuDest<'py> {
+    tensor: PyBound<'py, PyAny>,
+    write_ptr: usize,
+}
+
+/// Allocate `torch.empty(...,device="cpu", pin_memory=True)` and extract the
+/// data pointer for direct pread.
+fn prepare_torch_pinned_cpu_dest<'py>(
+    py: Python<'py>,
+    torch: &PyBound<'py, PyModule>,
+    dtype: Dtype,
+    logical_shape: &[usize],
+    nbytes: usize,
+) -> PyResult<PinnedCpuDest<'py>> {
+    let dtype_obj: Py<PyAny> = get_pydtype(torch, dtype, false)?;
+    let storage_shape = torch_storage_shape(dtype, logical_shape)?;
+    let shape_obj: Py<PyAny> = storage_shape.into_pyobject(py)?.into();
+    let cpu_device: Py<PyAny> = "cpu".into_pyobject(py)?.into();
+    let pin: Py<PyAny> = PyBool::new(py, true).to_owned().into_any().into();
+    let kwargs = [
+        (intern!(py, "dtype"), dtype_obj),
+        (intern!(py, "device"), cpu_device),
+        (intern!(py, "pin_memory"), pin),
+    ]
+    .into_py_dict(py)?;
+    let tensor = torch.call_method("empty", (shape_obj,), Some(&kwargs))?;
+
+    if nbytes == 0 {
+        return Ok(PinnedCpuDest {
+            tensor,
+            write_ptr: 0,
+        });
+    }
+
+    let write_ptr: usize = tensor.call_method0(intern!(py, "data_ptr"))?.extract()?;
+    Ok(PinnedCpuDest { tensor, write_ptr })
 }
 
 /// Whether this torch build exposes `torch.mps._host_alias_storage`
@@ -1853,15 +2147,20 @@ impl _safe_open_handle {
 #[pymethods]
 impl _safe_open_handle {
     #[new]
-    #[pyo3(signature = (f, framework, device=Some(Device::Cpu)))]
-    fn new(f: Py<PyAny>, framework: Framework, device: Option<Device>) -> PyResult<Self> {
+    #[pyo3(signature = (f, framework, device=Some(Device::Cpu), *, backend=Backend::Mmap))]
+    fn new(
+        f: Py<PyAny>,
+        framework: Framework,
+        device: Option<Device>,
+        backend: Backend,
+    ) -> PyResult<Self> {
         let filename = Python::attach(|py| -> PyResult<PathBuf> {
             let _ = f.getattr(py, "fileno")?;
             let filename = f.getattr(py, "name")?;
             let filename: PathBuf = filename.extract(py)?;
             Ok(filename)
         })?;
-        let inner = Some(Open::new(filename, framework, device)?);
+        let inner = Some(Open::new(filename, framework, device, backend)?);
         Ok(Self { inner })
     }
 

--- a/bindings/python/tests/test_pread_backend.py
+++ b/bindings/python/tests/test_pread_backend.py
@@ -1,6 +1,6 @@
-"""Tests for `safe_open(..., backend="read_file")`.
+"""Tests for `safe_open(..., backend="pread")`.
 
-The `read_file` backend serves each tensor via `pread(2)` instead of mmap'ing
+The `pread` backend serves each tensor via `pread(2)` instead of mmap'ing
 the file, dropping each host buffer immediately after the device transfer so
 cumulative host residency stays bounded at one tensor.
 """
@@ -31,7 +31,7 @@ if hasattr(torch, "float8_e4m3fn"):
     SOURCE_TENSORS["fp8_e4m3fn"] = torch.zeros(8, dtype=torch.float8_e4m3fn)
 
 
-class ReadFileBackendTests(unittest.TestCase):
+class PreadBackendTests(unittest.TestCase):
     def setUp(self):
         self.tempdir = tempfile.TemporaryDirectory()
         self.path = os.path.join(self.tempdir.name, "tiny.safetensors")
@@ -54,7 +54,7 @@ class ReadFileBackendTests(unittest.TestCase):
 
     def test_safe_open_round_trip(self):
         with safe_open(
-            self.path, framework="pt", device="cpu", backend="read_file"
+            self.path, framework="pt", device="cpu", backend="pread"
         ) as f:
             self.assertEqual(f.metadata(), {"foo": "bar"})
             sd = {k: f.get_tensor(k) for k in f.keys()}
@@ -62,26 +62,26 @@ class ReadFileBackendTests(unittest.TestCase):
 
     def test_get_tensors_round_trip(self):
         with safe_open(
-            self.path, framework="pt", device="cpu", backend="read_file"
+            self.path, framework="pt", device="cpu", backend="pread"
         ) as f:
             sd = f.get_tensors()
         self._assert_state_dict_equal(sd)
 
     def test_load_file_round_trip(self):
-        sd = load_file_pt(self.path, backend="read_file")
+        sd = load_file_pt(self.path, backend="pread")
         self._assert_state_dict_equal(sd)
 
     def test_default_backend_unchanged(self):
-        # mmap and read_file must produce identical bytes.
+        # mmap and pread must produce identical bytes.
         with safe_open(self.path, framework="pt", device="cpu") as f:
             sd_mmap = f.get_tensors()
         with safe_open(
-            self.path, framework="pt", device="cpu", backend="read_file"
+            self.path, framework="pt", device="cpu", backend="pread"
         ) as f:
-            sd_read_file = f.get_tensors()
-        self.assertEqual(set(sd_mmap.keys()), set(sd_read_file.keys()))
+            sd_pread = f.get_tensors()
+        self.assertEqual(set(sd_mmap.keys()), set(sd_pread.keys()))
         for k in sd_mmap:
-            a, b = sd_mmap[k], sd_read_file[k]
+            a, b = sd_mmap[k], sd_pread[k]
             self.assertEqual(a.dtype, b.dtype, k)
             self.assertEqual(tuple(a.shape), tuple(b.shape), k)
             if a.numel() > 0:
@@ -89,7 +89,7 @@ class ReadFileBackendTests(unittest.TestCase):
 
     def test_get_slice(self):
         with safe_open(
-            self.path, framework="pt", device="cpu", backend="read_file"
+            self.path, framework="pt", device="cpu", backend="pread"
         ) as f:
             slice_obj = f.get_slice("fp32_2d")
             self.assertEqual(list(slice_obj.get_shape()), [3, 4])
@@ -111,7 +111,7 @@ class ReadFileBackendTests(unittest.TestCase):
 
         dst = Tiny()
         self.assertFalse(torch.equal(src.lin.weight, dst.lin.weight))
-        load_model(dst, path, backend="read_file")
+        load_model(dst, path, backend="pread")
         self.assertTrue(torch.equal(src.lin.weight, dst.lin.weight))
         self.assertTrue(torch.equal(src.lin.bias, dst.lin.bias))
 
@@ -128,7 +128,7 @@ class ReadFileBackendTests(unittest.TestCase):
             dst.write(src.read(n // 2))
         with self.assertRaises(Exception):
             with safe_open(
-                bad_path, framework="pt", device="cpu", backend="read_file"
+                bad_path, framework="pt", device="cpu", backend="pread"
             ) as f:
                 _ = f.get_tensors()
 
@@ -143,7 +143,7 @@ class ReadFileBackendTests(unittest.TestCase):
             f.write(b"\x00")
         with self.assertRaises(Exception):
             with safe_open(
-                bad_path, framework="pt", device="cpu", backend="read_file"
+                bad_path, framework="pt", device="cpu", backend="pread"
             ) as f:
                 _ = f.get_tensors()
 
@@ -157,7 +157,7 @@ class ReadFileBackendTests(unittest.TestCase):
         }
         save_np(np_data, np_path)
 
-        with safe_open(np_path, framework="numpy", backend="read_file") as f:
+        with safe_open(np_path, framework="numpy", backend="pread") as f:
             for k, expected in np_data.items():
                 got = f.get_tensor(k)
                 self.assertEqual(got.dtype, expected.dtype, k)

--- a/bindings/python/tests/test_pread_backend.py
+++ b/bindings/python/tests/test_pread_backend.py
@@ -53,17 +53,13 @@ class PreadBackendTests(unittest.TestCase):
                 )
 
     def test_safe_open_round_trip(self):
-        with safe_open(
-            self.path, framework="pt", device="cpu", backend="pread"
-        ) as f:
+        with safe_open(self.path, framework="pt", device="cpu", backend="pread") as f:
             self.assertEqual(f.metadata(), {"foo": "bar"})
             sd = {k: f.get_tensor(k) for k in f.keys()}
         self._assert_state_dict_equal(sd)
 
     def test_get_tensors_round_trip(self):
-        with safe_open(
-            self.path, framework="pt", device="cpu", backend="pread"
-        ) as f:
+        with safe_open(self.path, framework="pt", device="cpu", backend="pread") as f:
             sd = f.get_tensors()
         self._assert_state_dict_equal(sd)
 
@@ -75,9 +71,7 @@ class PreadBackendTests(unittest.TestCase):
         # mmap and pread must produce identical bytes.
         with safe_open(self.path, framework="pt", device="cpu") as f:
             sd_mmap = f.get_tensors()
-        with safe_open(
-            self.path, framework="pt", device="cpu", backend="pread"
-        ) as f:
+        with safe_open(self.path, framework="pt", device="cpu", backend="pread") as f:
             sd_pread = f.get_tensors()
         self.assertEqual(set(sd_mmap.keys()), set(sd_pread.keys()))
         for k in sd_mmap:
@@ -88,9 +82,7 @@ class PreadBackendTests(unittest.TestCase):
                 self.assertTrue(torch.equal(a.cpu(), b.cpu()), k)
 
     def test_get_slice(self):
-        with safe_open(
-            self.path, framework="pt", device="cpu", backend="pread"
-        ) as f:
+        with safe_open(self.path, framework="pt", device="cpu", backend="pread") as f:
             slice_obj = f.get_slice("fp32_2d")
             self.assertEqual(list(slice_obj.get_shape()), [3, 4])
             sub = slice_obj[:, 1:3]

--- a/bindings/python/tests/test_pread_backend.py
+++ b/bindings/python/tests/test_pread_backend.py
@@ -31,6 +31,18 @@ if hasattr(torch, "float8_e4m3fn"):
     SOURCE_TENSORS["fp8_e4m3fn"] = torch.zeros(8, dtype=torch.float8_e4m3fn)
 
 
+def _tensors_equal(a: torch.Tensor, b: torch.Tensor) -> bool:
+    # torch.equal is not implemented for sub-byte / fp8 dtypes on some builds,
+    # so reinterpret the underlying storage as uint8 and compare bytes.
+    try:
+        return torch.equal(a, b)
+    except RuntimeError:
+        return torch.equal(
+            a.contiguous().view(torch.uint8),
+            b.contiguous().view(torch.uint8),
+        )
+
+
 class PreadBackendTests(unittest.TestCase):
     def setUp(self):
         self.tempdir = tempfile.TemporaryDirectory()
@@ -47,10 +59,7 @@ class PreadBackendTests(unittest.TestCase):
             self.assertEqual(actual.dtype, expected.dtype, k)
             self.assertEqual(tuple(actual.shape), tuple(expected.shape), k)
             if expected.numel() > 0:
-                self.assertTrue(
-                    torch.equal(actual.cpu(), expected.cpu()),
-                    f"tensor {k!r} differs",
-                )
+                self.assertTrue(_tensors_equal(actual.cpu(), expected.cpu()), k)
 
     def test_safe_open_round_trip(self):
         with safe_open(self.path, framework="pt", device="cpu", backend="pread") as f:
@@ -79,7 +88,7 @@ class PreadBackendTests(unittest.TestCase):
             self.assertEqual(a.dtype, b.dtype, k)
             self.assertEqual(tuple(a.shape), tuple(b.shape), k)
             if a.numel() > 0:
-                self.assertTrue(torch.equal(a.cpu(), b.cpu()), k)
+                self.assertTrue(_tensors_equal(a.cpu(), b.cpu()), k)
 
     def test_get_slice(self):
         with safe_open(self.path, framework="pt", device="cpu", backend="pread") as f:

--- a/bindings/python/tests/test_read_file_backend.py
+++ b/bindings/python/tests/test_read_file_backend.py
@@ -1,0 +1,169 @@
+"""Tests for `safe_open(..., backend="read_file")`.
+
+The `read_file` backend serves each tensor via `pread(2)` instead of mmap'ing
+the file, dropping each host buffer immediately after the device transfer so
+cumulative host residency stays bounded at one tensor.
+"""
+
+import os
+import struct
+import tempfile
+import unittest
+
+import numpy as np
+import torch
+
+from safetensors import safe_open
+from safetensors.torch import load_file as load_file_pt
+from safetensors.torch import load_model, save_file, save_model
+
+
+SOURCE_TENSORS = {
+    "fp32_2d": torch.arange(12, dtype=torch.float32).reshape(3, 4).contiguous(),
+    "bf16_2d": torch.arange(8, dtype=torch.bfloat16).reshape(2, 4).contiguous(),
+    "fp16_3d": torch.arange(24, dtype=torch.float16).reshape(2, 3, 4).contiguous(),
+    "scalar_fp32": torch.tensor(7.5, dtype=torch.float32),
+    "empty_2d": torch.empty((0, 5), dtype=torch.float16),
+    "i64_1d": torch.arange(5, dtype=torch.int64),
+}
+
+if hasattr(torch, "float8_e4m3fn"):
+    SOURCE_TENSORS["fp8_e4m3fn"] = torch.zeros(8, dtype=torch.float8_e4m3fn)
+
+
+class ReadFileBackendTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self.tempdir.name, "tiny.safetensors")
+        save_file(SOURCE_TENSORS, self.path, metadata={"foo": "bar"})
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def _assert_state_dict_equal(self, sd):
+        self.assertEqual(set(sd.keys()), set(SOURCE_TENSORS.keys()))
+        for k, expected in SOURCE_TENSORS.items():
+            actual = sd[k]
+            self.assertEqual(actual.dtype, expected.dtype, k)
+            self.assertEqual(tuple(actual.shape), tuple(expected.shape), k)
+            if expected.numel() > 0:
+                self.assertTrue(
+                    torch.equal(actual.cpu(), expected.cpu()),
+                    f"tensor {k!r} differs",
+                )
+
+    def test_safe_open_round_trip(self):
+        with safe_open(
+            self.path, framework="pt", device="cpu", backend="read_file"
+        ) as f:
+            self.assertEqual(f.metadata(), {"foo": "bar"})
+            sd = {k: f.get_tensor(k) for k in f.keys()}
+        self._assert_state_dict_equal(sd)
+
+    def test_get_tensors_round_trip(self):
+        with safe_open(
+            self.path, framework="pt", device="cpu", backend="read_file"
+        ) as f:
+            sd = f.get_tensors()
+        self._assert_state_dict_equal(sd)
+
+    def test_load_file_round_trip(self):
+        sd = load_file_pt(self.path, backend="read_file")
+        self._assert_state_dict_equal(sd)
+
+    def test_default_backend_unchanged(self):
+        # mmap and read_file must produce identical bytes.
+        with safe_open(self.path, framework="pt", device="cpu") as f:
+            sd_mmap = f.get_tensors()
+        with safe_open(
+            self.path, framework="pt", device="cpu", backend="read_file"
+        ) as f:
+            sd_read_file = f.get_tensors()
+        self.assertEqual(set(sd_mmap.keys()), set(sd_read_file.keys()))
+        for k in sd_mmap:
+            a, b = sd_mmap[k], sd_read_file[k]
+            self.assertEqual(a.dtype, b.dtype, k)
+            self.assertEqual(tuple(a.shape), tuple(b.shape), k)
+            if a.numel() > 0:
+                self.assertTrue(torch.equal(a.cpu(), b.cpu()), k)
+
+    def test_get_slice(self):
+        with safe_open(
+            self.path, framework="pt", device="cpu", backend="read_file"
+        ) as f:
+            slice_obj = f.get_slice("fp32_2d")
+            self.assertEqual(list(slice_obj.get_shape()), [3, 4])
+            sub = slice_obj[:, 1:3]
+        expected = SOURCE_TENSORS["fp32_2d"][:, 1:3]
+        self.assertEqual(sub.dtype, expected.dtype)
+        self.assertEqual(tuple(sub.shape), tuple(expected.shape))
+        self.assertTrue(torch.equal(sub, expected))
+
+    def test_load_model(self):
+        class Tiny(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin = torch.nn.Linear(4, 3)
+
+        src = Tiny()
+        path = os.path.join(self.tempdir.name, "tiny_model.safetensors")
+        save_model(src, path)
+
+        dst = Tiny()
+        self.assertFalse(torch.equal(src.lin.weight, dst.lin.weight))
+        load_model(dst, path, backend="read_file")
+        self.assertTrue(torch.equal(src.lin.weight, dst.lin.weight))
+        self.assertTrue(torch.equal(src.lin.bias, dst.lin.bias))
+
+    def test_invalid_backend_string_raises(self):
+        with self.assertRaises(Exception):
+            safe_open(self.path, framework="pt", device="cpu", backend="not_a_backend")
+
+    def test_truncated_header_is_rejected(self):
+        bad_path = os.path.join(self.tempdir.name, "truncated.safetensors")
+        with open(self.path, "rb") as src, open(bad_path, "wb") as dst:
+            head = src.read(8)
+            dst.write(head)
+            n = struct.unpack("<Q", head)[0]
+            dst.write(src.read(n // 2))
+        with self.assertRaises(Exception):
+            with safe_open(
+                bad_path, framework="pt", device="cpu", backend="read_file"
+            ) as f:
+                _ = f.get_tensors()
+
+    def test_data_offset_overflow_is_rejected(self):
+        bad_path = os.path.join(self.tempdir.name, "lying.safetensors")
+        header = (
+            b'{"liar":{"dtype":"F32","shape":[1024,1024],"data_offsets":[0,4194304]}}'
+        )
+        with open(bad_path, "wb") as f:
+            f.write(struct.pack("<Q", len(header)))
+            f.write(header)
+            f.write(b"\x00")
+        with self.assertRaises(Exception):
+            with safe_open(
+                bad_path, framework="pt", device="cpu", backend="read_file"
+            ) as f:
+                _ = f.get_tensors()
+
+    def test_numpy_framework(self):
+        np_path = os.path.join(self.tempdir.name, "np.safetensors")
+        from safetensors.numpy import save_file as save_np
+
+        np_data = {
+            "a": np.arange(6, dtype=np.float32).reshape(2, 3),
+            "b": np.arange(8, dtype=np.int64).reshape(4, 2),
+        }
+        save_np(np_data, np_path)
+
+        with safe_open(np_path, framework="numpy", backend="read_file") as f:
+            for k, expected in np_data.items():
+                got = f.get_tensor(k)
+                self.assertEqual(got.dtype, expected.dtype, k)
+                self.assertEqual(got.shape, expected.shape, k)
+                np.testing.assert_array_equal(got, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add a `Backend` parameter to `safe_open` to offer an efficient enough fallback methods for devices where our current mmap implementation causes OOMs (unified memory devices when using PyTorch native mmap) or is slow, e.g. loading a model from an NFS. We now have two backends:
- `Backend::Mmap` (`"mmap"`): similar as before, default
- `Backend::ReadFile` (`"read_file"`): keep an open file handle and `pread(2)` into temp host buffers dropped after device transfer.

Independently of the backend, for cuda + pytorch we now load bytes into an intermediate cpu pinned memory buffer before sending to device. This should fix the OOM reported in #728 and #759 while leaving the option of using mmap backends for users on unified memory devices. I suspect the issue comes from how PyTorch manages its memory when opening files with mmap, #728 fix points in that direction at least because using `Storage::Mmap` seems to fix.

Closes #758, supersedes #728, #759