### PR TITLE
Build and upload 3.14t wheels in python release workflow

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -109,7 +109,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
-          python-version: 3.x
+          python-version: |
+            3.x
+            3.14t
           architecture: ${{ matrix.platform.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
-          python-version: 3.x
+          python-version: 3.14
       - name: Build wheels
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
         with:
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
-          python-version: 3.x
+          python-version: 3.14
       - name: Build wheels
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
         with:
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: |
-            3.x
+            3.14
             3.14t
           architecture: ${{ matrix.platform.target }}
       - name: Build wheels
@@ -138,7 +138,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
-          python-version: 3.x
+          python-version: 3.14
       - name: Build wheels
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
         with:

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -54,7 +54,7 @@ jobs:
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --manifest-path bindings/python/Cargo.toml --locked
+          args: --release --out dist --manifest-path bindings/python/Cargo.toml  --locked --interpreter '3.13 3.14t'
           sccache: 'true'
           manylinux: auto
       - name: Upload wheels
@@ -85,7 +85,7 @@ jobs:
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --manifest-path bindings/python/Cargo.toml --locked
+          args: --release --out dist --manifest-path bindings/python/Cargo.toml --locked --interpreter '3.13 3.14t'
           sccache: 'true'
           manylinux: musllinux_1_2
       - name: Upload wheels
@@ -115,7 +115,7 @@ jobs:
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
         with:
           target: ${{ matrix.platform.target == 'arm64' && 'aarch64-pc-windows-msvc' || matrix.platform.target }}
-          args: --release --out dist --manifest-path bindings/python/Cargo.toml --locked
+          args: --release --out dist --manifest-path bindings/python/Cargo.toml --locked --interpreter '3.13 3.14t'
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
@@ -141,7 +141,7 @@ jobs:
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --manifest-path bindings/python/Cargo.toml --locked
+          args: --release --out dist --manifest-path bindings/python/Cargo.toml --locked --interpreter '3.13 3.14t'
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -49,12 +49,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
+          # just need a host interpreter to run manylinux, 3.14t is already
+          # installed in the manylinux image
           python-version: 3.14
       - name: Build wheels
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --manifest-path bindings/python/Cargo.toml  --locked --interpreter '3.13 3.14t'
+          args: --release --out dist --manifest-path bindings/python/Cargo.toml --locked --interpreter ${{ matrix.python_interpreter }}
           sccache: 'true'
           manylinux: auto
       - name: Upload wheels
@@ -80,6 +82,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
+          # just need a host interpreter to run manylinux, 3.14t is already
+          # installed in the manylinux image
           python-version: 3.14
       - name: Build wheels
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
@@ -105,19 +109,18 @@ jobs:
             target: x86
           - runner: windows-11-arm
             target: arm64
+        python_interpreter: ['3.14', '3.14t']
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
-          python-version: |
-            3.14
-            3.14t
+          python-version: ${{ matrix.python_interpreter }}
           architecture: ${{ matrix.platform.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
         with:
           target: ${{ matrix.platform.target == 'arm64' && 'aarch64-pc-windows-msvc' || matrix.platform.target }}
-          args: --release --out dist --manifest-path bindings/python/Cargo.toml --locked --interpreter '3.13 3.14t'
+          args: --release --out dist --manifest-path bindings/python/Cargo.toml --locked --interpreter ${{ matrix.python_interpreter }}
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
@@ -138,12 +141,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
-          python-version: 3.14
+          python-version: ${{ matrix.python_interpreter }}
       - name: Build wheels
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --manifest-path bindings/python/Cargo.toml --locked --interpreter '3.13 3.14t'
+          args: --release --out dist --manifest-path bindings/python/Cargo.toml --locked --interpreter ${{ matrix.python_interpreter }}
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -45,13 +45,12 @@ jobs:
           - runner: ubuntu-latest
             arch: riscv64
             target: riscv64gc-unknown-linux-gnu
+        python_interpreter: ['3.14', '3.14t']
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
-          # just need a host interpreter to run manylinux, 3.14t is already
-          # installed in the manylinux image
-          python-version: 3.14
+          python-version: ${{ matrix.python_interpreter }}
       - name: Build wheels
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
         with:
@@ -78,18 +77,17 @@ jobs:
             target: aarch64
           - runner: ubuntu-latest
             target: armv7
+        python_interpreter: ['3.14', '3.14t']
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
-          # just need a host interpreter to run manylinux, 3.14t is already
-          # installed in the manylinux image
-          python-version: 3.14
+          python-version: ${{ matrix.python_interpreter }}
       - name: Build wheels
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --manifest-path bindings/python/Cargo.toml --locked --interpreter '3.13 3.14t'
+          args: --release --out dist --manifest-path bindings/python/Cargo.toml --locked --interpreter ${{ matrix.python_interpreter }}
           sccache: 'true'
           manylinux: musllinux_1_2
       - name: Upload wheels
@@ -137,6 +135,7 @@ jobs:
             target: x86_64
           - runner: macos-14
             target: aarch64
+        python_interpreter: ['3.14', '3.14t']
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6


### PR DESCRIPTION
# What does this PR do?

Safetensors now uploads 3.14t wheels on all supported platforms.

Fixes #572.

# Implementation notes

Note that at the moment `3.x` is equivalent to `3.14`. I decided to switch out to using a specific Python version because maturin requires specifying a specific interpreter, and mismatches can break the Windows build.

For Python 3.15 it will be necessary to also add a 3.15 or 3.15t interpreter, to generate an `abi3.abi3t` wheel that supports Python 3.15 and newer.

## AI model use

We do accept PRs that were developed together with an AI model, but we ask
that you to fill out this section.

- [x] No AI model was used when making this PR.
- [ ] An AI model assisted me in developing this PR.
- [ ] Development of this PR was done by an AI model.

If you ticked one of the last two options, please state the model and model
version that you used:

If you ticked the last option, please list the prompt(s) that you used:
