### PR TITLE
Return ValidationOverflow from TensorView size overflow

### DIFF
--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -752,9 +752,15 @@ impl<'data> TensorView<'data> {
         shape: Vec<usize>,
         data: &'data [u8],
     ) -> Result<Self, SafeTensorError> {
-        let n_elements: usize = shape.iter().product();
+        let n_elements: usize = shape
+            .iter()
+            .copied()
+            .try_fold(1usize, usize::checked_mul)
+            .ok_or(SafeTensorError::ValidationOverflow)?;
 
-        let nbits = n_elements * dtype.bitsize();
+        let nbits = n_elements
+            .checked_mul(dtype.bitsize())
+            .ok_or(SafeTensorError::ValidationOverflow)?;
         if nbits % 8 != 0 {
             return Err(SafeTensorError::MisalignedSlice);
         }
@@ -1591,6 +1597,16 @@ mod tests {
             }
             _ => panic!("This should not be able to be deserialized"),
         }
+    }
+
+    #[test]
+    fn test_tensor_view_validation_overflow() {
+        let data = [];
+        let view = TensorView::new(Dtype::U8, vec![usize::MAX, 2], &data);
+        assert!(matches!(view, Err(SafeTensorError::ValidationOverflow)));
+
+        let view = TensorView::new(Dtype::U64, vec![usize::MAX], &data);
+        assert!(matches!(view, Err(SafeTensorError::ValidationOverflow)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Use checked arithmetic in `TensorView::new` for the shape product and dtype bit-size multiplication.
- Return the existing `ValidationOverflow` error instead of panicking in debug builds or relying on wrapping arithmetic in release builds.
- Add regression coverage for both shape-product and dtype-size overflow cases.

## Validation
- `cargo fmt --check --manifest-path safetensors/Cargo.toml`
- `cargo test --manifest-path safetensors/Cargo.toml`
- `git diff --check -- safetensors/src/tensor.rs`
- `git diff -- safetensors/src/tensor.rs | gitleaks stdin --no-banner --redact --exit-code 1`