### PR TITLE
Avoid stride overflow for empty tensor slice requests

### DIFF
--- a/safetensors/src/slice.rs
+++ b/safetensors/src/slice.rs
@@ -283,6 +283,13 @@ impl<'data> SliceIterator<'data> {
         if n_slice > n_shape {
             return Err(InvalidSlice::TooManySlices);
         }
+        if slices.is_empty() {
+            return Ok(Self {
+                view,
+                indices: vec![(0, view.data().len())],
+                newshape: view.shape().to_vec(),
+            });
+        }
         let mut newshape = Vec::with_capacity(view.shape().len());
 
         // Minimum span is the span of 1 item;
@@ -715,5 +722,16 @@ mod tests {
             ),
             Err(InvalidSlice::TooManySlices)
         );
+    }
+
+    #[test]
+    fn test_zero_sized_tensor_with_large_dim_does_not_panic() {
+        let data = [];
+        let tensor = TensorView::new(Dtype::U8, vec![0, usize::MAX], &data).unwrap();
+        let mut iterator = SliceIterator::new(&tensor, &[]).unwrap();
+        assert_eq!(iterator.newshape(), vec![0, usize::MAX]);
+        assert_eq!(iterator.remaining_byte_len(), 0);
+        assert_eq!(iterator.next(), Some(&data[..]));
+        assert_eq!(iterator.next(), None);
     }
 }


### PR DESCRIPTION
## Summary

`SliceIterator::new` used to walk the tensor shape even when no slice indexers were provided. For zero-sized tensors with a very large dimension, that no-op slice path could overflow in debug builds while accumulating row-major stride state before falling back to the full tensor buffer.

This returns the full-buffer iterator immediately when `slices` is empty. It preserves the existing no-op slice behavior and avoids doing stride arithmetic that is not needed for that case.

## Validation

- `cargo fmt --check --manifest-path safetensors/Cargo.toml`
- `cargo test --manifest-path safetensors/Cargo.toml slice::tests::test_zero_sized_tensor_with_large_dim_does_not_panic -- --exact`
- `cargo test --manifest-path safetensors/Cargo.toml`
- `cargo test --release --manifest-path safetensors/Cargo.toml slice::tests::test_zero_sized_tensor_with_large_dim_does_not_panic -- --exact`
- `cargo test --manifest-path safetensors/Cargo.toml --all-features`
- `git diff --check -- safetensors/src/slice.rs`

No linked issue; this came out of a local slice-path audit.