### PR TITLE
feat: add support for strided slicing

### DIFF
--- a/bindings/python/py_src/safetensors/__init__.pyi
+++ b/bindings/python/py_src/safetensors/__init__.pyi
@@ -207,6 +207,47 @@ class safe_open:
         """
         pass
 
+    def get_strided_slice(self, name, dim, intervals):
+        """
+        Read `N` disjoint intervals along a single dimension and pack them
+        into one contiguous tensor — equivalent to
+        `torch.cat([f.get_slice(name)[..., a_i:b_i, ...] for (a_i, b_i) in intervals], dim=dim)`
+        but without materializing the per-interval tensors or the cat. The
+        destination is allocated once on the configured framework/device;
+        for PyTorch + CUDA, the dest is pinned-CPU and the result is
+        `.to(cuda)`'d in one async DMA.
+
+        Intended for tensor-parallel `_StridedShard` loading where fused
+        weights are split into interleaved stripes per rank.
+
+        Args:
+            name (`str`):
+                The name of the tensor to read from.
+            dim (`int`):
+                The axis along which intervals are taken; all other axes
+                are passed through in full.
+            intervals (`List[Tuple[int, int]]`):
+                Half-open `(start, stop)` ranges on `dim`; the output is
+                their concatenation in the given order. Intervals must be
+                non-empty and within `[0, shape[dim])`; overlap is allowed
+                but duplicates data.
+
+        Returns:
+            (`Tensor`):
+                A tensor whose shape matches the input tensor with `dim`
+                replaced by `sum(b - a for (a, b) in intervals)`.
+
+        Example:
+        ```python
+        from safetensors import safe_open
+
+        with safe_open("model.safetensors", framework="pt", device=0) as f:
+            local = f.get_strided_slice("gate_up_proj", dim=0, intervals=[(0, 64), (256, 320)])
+
+        ```
+        """
+        pass
+
     def get_tensor(self, name):
         """
         Returns a full tensor

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1057,7 +1057,7 @@ impl Open {
 
         Python::attach(|py| -> PyResult<Py<PyAny>> {
             let torch = get_module(py, &TORCH_MODULE)?;
-            let dest = PinnedCpuDest::new(py, torch, info.dtype, &info.shape, nbytes)?;
+            let dest = TorchCpuDest::new(py, torch, info.dtype, &info.shape, nbytes, true)?;
 
             if nbytes > 0 {
                 let write_ptr = dest.write_ptr;
@@ -1219,19 +1219,20 @@ impl Open {
         let mut out_shape = info.shape.clone();
         out_shape[dim] = intervals.iter().map(|(a, b)| b - a).sum();
 
+        // Pytorch: allocate a torch tensor directly (no intermediate
+        // PyByteArray, no zero-init). Pin when the target is CUDA so the
+        // trailing `.to(cuda)` becomes an async DMA without a bounce buffer.
         if self.framework == Framework::Pytorch {
-            if let Device::Cuda(_) = self.device {
-                return self.get_strided_slice_pinned_cuda(
-                    name,
-                    info,
-                    &out_shape,
-                    total_bytes,
-                    outer_count,
-                    row_stride,
-                    &interval_byte_offset,
-                    &strip_size,
-                );
-            }
+            return self.get_strided_slice_torch(
+                name,
+                info,
+                &out_shape,
+                total_bytes,
+                outer_count,
+                row_stride,
+                &interval_byte_offset,
+                &strip_size,
+            );
         }
 
         let array: Py<PyAny> = Python::attach(|py| -> PyResult<Py<PyAny>> {
@@ -1338,10 +1339,15 @@ impl Open {
         Ok(())
     }
 
-    /// Pytorch + CUDA fast path for `get_strided_slice`: pinned CPU dest sized
-    /// to the cat output, filled strip-by-strip, then `.to(cuda)` once.
+    /// Pytorch fast path for `get_strided_slice`: allocate a CPU torch
+    /// tensor sized to the cat output (pinned iff the target device is
+    /// CUDA), fill it strip-by-strip, then `.to(device)` if the eventual
+    /// target isn't CPU. Mirrors `get_tensor_pinned_cuda` but works for
+    /// CPU and MPS targets too — `torch.empty` doesn't zero-initialize the
+    /// way `PyByteArray::new_with` does, so this is the strictly cheaper
+    /// allocation strategy for PyTorch consumers.
     #[allow(clippy::too_many_arguments)]
-    fn get_strided_slice_pinned_cuda(
+    fn get_strided_slice_torch(
         &self,
         name: &str,
         info: &TensorInfo,
@@ -1352,13 +1358,15 @@ impl Open {
         interval_byte_offset: &[usize],
         strip_size: &[usize],
     ) -> PyResult<Py<PyAny>> {
+        let pin_memory = matches!(self.device, Device::Cuda(_));
         Python::attach(|py| -> PyResult<Py<PyAny>> {
             let torch = get_module(py, &TORCH_MODULE)?;
-            let dest = PinnedCpuDest::new(py, torch, info.dtype, out_shape, total_bytes)?;
+            let dest =
+                TorchCpuDest::new(py, torch, info.dtype, out_shape, total_bytes, pin_memory)?;
 
             if total_bytes > 0 {
                 let write_ptr = dest.write_ptr;
-                // SAFETY: write_ptr/total_bytes name `dest.tensor`'s pinned
+                // SAFETY: write_ptr/total_bytes name `dest.tensor`'s
                 // storage, which we just allocated and hold via `dest`.
                 let dst =
                     unsafe { std::slice::from_raw_parts_mut(write_ptr as *mut u8, total_bytes) };
@@ -1373,12 +1381,14 @@ impl Open {
                 )?;
             }
 
-            let cuda_device: Py<PyAny> = self.device.clone().into_pyobject(py)?.into();
-            let kwargs = PyDict::new(py);
-            let cuda_tensor = dest
-                .tensor
-                .call_method("to", (cuda_device,), Some(&kwargs))?;
-            Ok(cuda_tensor.into_pyobject(py)?.into())
+            let tensor = if matches!(self.device, Device::Cpu) {
+                dest.tensor
+            } else {
+                let device: Py<PyAny> = self.device.clone().into_pyobject(py)?.into();
+                let kwargs = PyDict::new(py);
+                dest.tensor.call_method("to", (device,), Some(&kwargs))?
+            };
+            Ok(tensor.into_pyobject(py)?.into())
         })
     }
 
@@ -2219,27 +2229,32 @@ impl<'py> MpsDest<'py> {
     }
 }
 
-/// Pre-allocated pinned-CPU torch destination.
-struct PinnedCpuDest<'py> {
+/// Pre-allocated CPU torch destination intended for direct fills via
+/// `write_ptr`. Optionally pinned when the eventual target is CUDA (so
+/// `.to(cuda)` becomes an async DMA without a bounce buffer).
+struct TorchCpuDest<'py> {
     tensor: PyBound<'py, PyAny>,
     write_ptr: usize,
 }
 
-impl<'py> PinnedCpuDest<'py> {
-    /// Allocate `torch.empty(...,device="cpu", pin_memory=True)` and extract
-    /// the data pointer for direct pread.
+impl<'py> TorchCpuDest<'py> {
+    /// Allocate `torch.empty(..., device="cpu", pin_memory=pin_memory)` and
+    /// extract the data pointer. Skipping `pin_memory` matters off the CUDA
+    /// fast path because `torch.empty` doesn't zero-initialize, unlike
+    /// `PyByteArray::new_with` which wipes the buffer before our callback.
     fn new(
         py: Python<'py>,
         torch: &PyBound<'py, PyModule>,
         dtype: Dtype,
         logical_shape: &[usize],
         nbytes: usize,
+        pin_memory: bool,
     ) -> PyResult<Self> {
         let dtype_obj: Py<PyAny> = get_pydtype(torch, dtype, false)?;
         let storage_shape = torch_storage_shape(dtype, logical_shape)?;
         let shape_obj: Py<PyAny> = storage_shape.into_pyobject(py)?.into();
         let cpu_device: Py<PyAny> = "cpu".into_pyobject(py)?.into();
-        let pin: Py<PyAny> = PyBool::new(py, true).to_owned().into_any().into();
+        let pin: Py<PyAny> = PyBool::new(py, pin_memory).to_owned().into_any().into();
         let kwargs = [
             (intern!(py, "dtype"), dtype_obj),
             (intern!(py, "device"), cpu_device),

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -2,7 +2,7 @@
 //! Dummy doc
 use core::slice;
 use memmap2::{Mmap, MmapOptions};
-use pyo3::exceptions::{PyException, PyFileNotFoundError};
+use pyo3::exceptions::{PyException, PyFileNotFoundError, PyNotImplementedError};
 use pyo3::prelude::*;
 use pyo3::sync::OnceLockExt;
 use pyo3::types::IntoPyDict;
@@ -1128,6 +1128,260 @@ impl Open {
         })
     }
 
+    /// Read `N` disjoint intervals along a single tensor dimension and pack
+    /// them into one contiguous output tensor — equivalent to
+    /// `torch.cat([slice_i for i in intervals], dim=dim)` but without the
+    /// intermediate per-slice tensors or the final cat.
+    ///
+    /// Used by tensor-parallel `_StridedShard` loading where a fused weight
+    /// (e.g. `gate_up_proj`) is split into interleaved stripes per rank: each
+    /// rank wants the concatenation of N rectangular sub-volumes from a
+    /// single tensor on disk.
+    pub fn get_strided_slice(
+        &self,
+        name: &str,
+        dim: usize,
+        intervals: Vec<(usize, usize)>,
+    ) -> PyResult<Py<PyAny>> {
+        let info = self.metadata.info(name).ok_or_else(|| {
+            SafetensorError::new_err(format!("File does not contain tensor {name}"))
+        })?;
+
+        if dim >= info.shape.len() {
+            return Err(SafetensorError::new_err(format!(
+                "dim {dim} out of range for tensor {name} with shape {:?}",
+                info.shape
+            )));
+        }
+        if intervals.is_empty() {
+            return Err(SafetensorError::new_err(
+                "get_strided_slice requires at least one interval".to_string(),
+            ));
+        }
+        let dim_size = info.shape[dim];
+        for (i, &(a, b)) in intervals.iter().enumerate() {
+            if a >= b {
+                return Err(SafetensorError::new_err(format!(
+                    "interval {i} = ({a}, {b}) is empty or reversed"
+                )));
+            }
+            if b > dim_size {
+                return Err(SafetensorError::new_err(format!(
+                    "interval {i} = ({a}, {b}) exceeds dim {dim} size {dim_size}"
+                )));
+            }
+        }
+
+        if matches!(self.storage.as_ref(), Storage::Paddle(_)) {
+            return Err(PyNotImplementedError::new_err(
+                "get_strided_slice does not support the Paddle storage backend yet",
+            ));
+        }
+
+        // Strip layout: in row-major, each "outer group" (combination of
+        // dims < `dim`) contributes one fixed-size row spanning the whole
+        // (dim, inner_dims) sub-volume. A row's worth of bytes is
+        // `dim_size * inner_count * dtype_bits / 8`; an interval (a, b) on
+        // `dim` carves out a contiguous slice of that row of size
+        // `(b - a) * inner_count * dtype_bits / 8`, starting `a *
+        // inner_count * dtype_bits / 8` bytes into the row. (For sub-byte
+        // dtypes any of these may not be byte-aligned; reject in that case.)
+        let dtype_bits = info.dtype.bitsize();
+        let inner_count: usize = info.shape[dim + 1..].iter().product();
+        let outer_count: usize = info.shape[..dim].iter().product();
+        let bits_per_dim_unit = inner_count * dtype_bits;
+        let row_bits = dim_size * bits_per_dim_unit;
+        if row_bits % 8 != 0 {
+            return Err(SafetensorError::new_err(format!(
+                "dim {dim} is not byte-aligned for dtype {:?}",
+                info.dtype
+            )));
+        }
+        let row_stride = row_bits / 8;
+
+        let mut interval_byte_offset: Vec<usize> = Vec::with_capacity(intervals.len());
+        let mut strip_size: Vec<usize> = Vec::with_capacity(intervals.len());
+        for (i, &(a, b)) in intervals.iter().enumerate() {
+            let start_bits = a * bits_per_dim_unit;
+            let span_bits = (b - a) * bits_per_dim_unit;
+            if start_bits % 8 != 0 || span_bits % 8 != 0 {
+                return Err(SafetensorError::new_err(format!(
+                    "interval {i} = ({a}, {b}) on dim {dim} is not byte-aligned for dtype {:?}",
+                    info.dtype
+                )));
+            }
+            interval_byte_offset.push(start_bits / 8);
+            strip_size.push(span_bits / 8);
+        }
+        let strip_total_per_row: usize = strip_size.iter().sum();
+        let total_bytes = outer_count * strip_total_per_row;
+
+        let mut out_shape = info.shape.clone();
+        out_shape[dim] = intervals.iter().map(|(a, b)| b - a).sum();
+
+        if self.framework == Framework::Pytorch {
+            if let Device::Cuda(_) = self.device {
+                return self.get_strided_slice_pinned_cuda(
+                    name,
+                    info,
+                    &out_shape,
+                    total_bytes,
+                    outer_count,
+                    row_stride,
+                    &interval_byte_offset,
+                    &strip_size,
+                );
+            }
+        }
+
+        let array: Py<PyAny> = Python::attach(|py| -> PyResult<Py<PyAny>> {
+            let pyarray = PyByteArray::new_with(py, total_bytes, |dst| {
+                self.fill_strided_dst(
+                    name,
+                    info,
+                    outer_count,
+                    row_stride,
+                    &interval_byte_offset,
+                    &strip_size,
+                    dst,
+                )
+            })?;
+            Ok(pyarray.into_any().into())
+        })?;
+
+        create_tensor(&self.framework, info.dtype, &out_shape, array, &self.device)
+    }
+
+    /// Fill `dst` with strips packed in row-major order: for each outer-dim
+    /// position, copy/pread one strip from each interval in input order.
+    /// `dst.len()` must equal the sum of all strip byte counts.
+    fn fill_strided_dst(
+        &self,
+        name: &str,
+        info: &TensorInfo,
+        outer_count: usize,
+        row_stride: usize,
+        interval_byte_offset: &[usize],
+        strip_size: &[usize],
+        dst: &mut [u8],
+    ) -> PyResult<()> {
+        let (begin, _end) = info.data_offsets;
+        let src_base_in_tensor = self.offset + begin;
+        let mut cursor = 0usize;
+
+        match self.storage.as_ref() {
+            Storage::Mmap(mmap) => {
+                for g in 0..outer_count {
+                    let row_base = src_base_in_tensor + g * row_stride;
+                    for (off, &n) in interval_byte_offset.iter().zip(strip_size) {
+                        let s = row_base + off;
+                        dst[cursor..cursor + n].copy_from_slice(&mmap[s..s + n]);
+                        cursor += n;
+                    }
+                }
+            }
+            Storage::Pread(file) => {
+                let base = src_base_in_tensor as u64;
+                for g in 0..outer_count {
+                    let row_base = base + (g * row_stride) as u64;
+                    for (off, &n) in interval_byte_offset.iter().zip(strip_size) {
+                        let strip_offset = row_base + *off as u64;
+                        read_exact_at(file, &mut dst[cursor..cursor + n], strip_offset).map_err(
+                            |err| {
+                                SafetensorError::new_err(format!(
+                                    "pread failed for tensor {name} strip at file offset {strip_offset}: {err}"
+                                ))
+                            },
+                        )?;
+                        cursor += n;
+                    }
+                }
+            }
+            Storage::Torch(storage) => {
+                Python::attach(|py| -> PyResult<()> {
+                    let storage_obj: &Py<PyAny> = storage
+                        .get()
+                        .ok_or_else(|| SafetensorError::new_err("Could not find storage"))?;
+                    let storage_obj = storage_obj.bind(py);
+                    let src_data_ptr: usize = storage_obj
+                        .call_method0(intern!(py, "data_ptr"))?
+                        .extract()?;
+                    let src_base = src_data_ptr + src_base_in_tensor;
+                    py.detach(|| {
+                        for g in 0..outer_count {
+                            let row_base = src_base + g * row_stride;
+                            for (off, &n) in interval_byte_offset.iter().zip(strip_size) {
+                                // SAFETY: row_base + off..+n lives inside the torch
+                                // UntypedStorage held alive by `self.storage`,
+                                // which is Arc-rooted in this Open for the
+                                // duration of this call. dst is a borrow into
+                                // the caller's buffer; both regions are
+                                // disjoint by construction (dst is freshly
+                                // allocated, src is the file-backed storage).
+                                unsafe {
+                                    std::ptr::copy_nonoverlapping(
+                                        (row_base + off) as *const u8,
+                                        dst.as_mut_ptr().add(cursor),
+                                        n,
+                                    );
+                                }
+                                cursor += n;
+                            }
+                        }
+                    });
+                    Ok(())
+                })?;
+            }
+            Storage::Paddle(_) => unreachable!("paddle path filtered earlier"),
+        }
+        Ok(())
+    }
+
+    /// Pytorch + CUDA fast path for `get_strided_slice`: pinned CPU dest sized
+    /// to the cat output, filled strip-by-strip, then `.to(cuda)` once.
+    #[allow(clippy::too_many_arguments)]
+    fn get_strided_slice_pinned_cuda(
+        &self,
+        name: &str,
+        info: &TensorInfo,
+        out_shape: &[usize],
+        total_bytes: usize,
+        outer_count: usize,
+        row_stride: usize,
+        interval_byte_offset: &[usize],
+        strip_size: &[usize],
+    ) -> PyResult<Py<PyAny>> {
+        Python::attach(|py| -> PyResult<Py<PyAny>> {
+            let torch = get_module(py, &TORCH_MODULE)?;
+            let dest = PinnedCpuDest::new(py, torch, info.dtype, out_shape, total_bytes)?;
+
+            if total_bytes > 0 {
+                let write_ptr = dest.write_ptr;
+                // SAFETY: write_ptr/total_bytes name `dest.tensor`'s pinned
+                // storage, which we just allocated and hold via `dest`.
+                let dst = unsafe {
+                    std::slice::from_raw_parts_mut(write_ptr as *mut u8, total_bytes)
+                };
+                self.fill_strided_dst(
+                    name,
+                    info,
+                    outer_count,
+                    row_stride,
+                    interval_byte_offset,
+                    strip_size,
+                    dst,
+                )?;
+            }
+
+            let cuda_device: Py<PyAny> = self.device.clone().into_pyobject(py)?.into();
+            let kwargs = PyDict::new(py);
+            let cuda_tensor = dest
+                .tensor
+                .call_method("to", (cuda_device,), Some(&kwargs))?;
+            Ok(cuda_tensor.into_pyobject(py)?.into())
+        })
+    }
+
     /// Returns every tensor in the file as a `{name: Tensor}` dict.
     ///
     /// Default behavior is a sequential loop over `get_tensor`. Pytorch + MPS
@@ -1382,6 +1636,51 @@ impl safe_open {
     /// ```
     pub fn get_slice(&self, name: &str) -> PyResult<PySafeSlice> {
         self.inner()?.get_slice(name)
+    }
+
+    /// Read `N` disjoint intervals along a single dimension and pack them
+    /// into one contiguous tensor — equivalent to
+    /// `torch.cat([f.get_slice(name)[..., a_i:b_i, ...] for (a_i, b_i) in intervals], dim=dim)`
+    /// but without materializing the per-interval tensors or the cat. The
+    /// destination is allocated once on the configured framework/device; for
+    /// PyTorch + CUDA, the dest is pinned-CPU and the result is `.to(cuda)`'d
+    /// in one async DMA.
+    ///
+    /// Intended for tensor-parallel `_StridedShard` loading where fused
+    /// weights are split into interleaved stripes per rank.
+    ///
+    /// Args:
+    ///     name (`str`):
+    ///         The name of the tensor to read from.
+    ///     dim (`int`):
+    ///         The axis along which intervals are taken; all other axes are
+    ///         passed through in full.
+    ///     intervals (`List[Tuple[int, int]]`):
+    ///         Half-open `(start, stop)` ranges on `dim`; the output is their
+    ///         concatenation in the given order. Intervals must be non-empty
+    ///         and within `[0, shape[dim])`; overlap is allowed but
+    ///         duplicates data.
+    ///
+    /// Returns:
+    ///     (`Tensor`):
+    ///         A tensor whose shape matches the input tensor with `dim`
+    ///         replaced by `sum(b - a for (a, b) in intervals)`.
+    ///
+    /// Example:
+    /// ```python
+    /// from safetensors import safe_open
+    ///
+    /// with safe_open("model.safetensors", framework="pt", device=0) as f:
+    ///     # Interleaved tp shard of a fused gate_up_proj on TP=4 rank 0
+    ///     local = f.get_strided_slice("gate_up_proj", dim=0, intervals=[(0, 64), (256, 320)])
+    /// ```
+    pub fn get_strided_slice(
+        &self,
+        name: &str,
+        dim: usize,
+        intervals: Vec<(usize, usize)>,
+    ) -> PyResult<Py<PyAny>> {
+        self.inner()?.get_strided_slice(name, dim, intervals)
     }
 
     /// Start the context manager
@@ -2282,6 +2581,51 @@ impl _safe_open_handle {
     /// ```
     pub fn get_slice(&self, name: &str) -> PyResult<PySafeSlice> {
         self.inner()?.get_slice(name)
+    }
+
+    /// Read `N` disjoint intervals along a single dimension and pack them
+    /// into one contiguous tensor — equivalent to
+    /// `torch.cat([f.get_slice(name)[..., a_i:b_i, ...] for (a_i, b_i) in intervals], dim=dim)`
+    /// but without materializing the per-interval tensors or the cat. The
+    /// destination is allocated once on the configured framework/device; for
+    /// PyTorch + CUDA, the dest is pinned-CPU and the result is `.to(cuda)`'d
+    /// in one async DMA.
+    ///
+    /// Intended for tensor-parallel `_StridedShard` loading where fused
+    /// weights are split into interleaved stripes per rank.
+    ///
+    /// Args:
+    ///     name (`str`):
+    ///         The name of the tensor to read from.
+    ///     dim (`int`):
+    ///         The axis along which intervals are taken; all other axes are
+    ///         passed through in full.
+    ///     intervals (`List[Tuple[int, int]]`):
+    ///         Half-open `(start, stop)` ranges on `dim`; the output is their
+    ///         concatenation in the given order. Intervals must be non-empty
+    ///         and within `[0, shape[dim])`; overlap is allowed but
+    ///         duplicates data.
+    ///
+    /// Returns:
+    ///     (`Tensor`):
+    ///         A tensor whose shape matches the input tensor with `dim`
+    ///         replaced by `sum(b - a for (a, b) in intervals)`.
+    ///
+    /// Example:
+    /// ```python
+    /// from safetensors import safe_open
+    ///
+    /// with safe_open("model.safetensors", framework="pt", device=0) as f:
+    ///     # Interleaved tp shard of a fused gate_up_proj on TP=4 rank 0
+    ///     local = f.get_strided_slice("gate_up_proj", dim=0, intervals=[(0, 64), (256, 320)])
+    /// ```
+    pub fn get_strided_slice(
+        &self,
+        name: &str,
+        dim: usize,
+        intervals: Vec<(usize, usize)>,
+    ) -> PyResult<Py<PyAny>> {
+        self.inner()?.get_strided_slice(name, dim, intervals)
     }
 
     /// Start the context manager

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1255,6 +1255,7 @@ impl Open {
     /// Fill `dst` with strips packed in row-major order: for each outer-dim
     /// position, copy/pread one strip from each interval in input order.
     /// `dst.len()` must equal the sum of all strip byte counts.
+    #[allow(clippy::too_many_arguments)]
     fn fill_strided_dst(
         &self,
         name: &str,
@@ -1359,9 +1360,8 @@ impl Open {
                 let write_ptr = dest.write_ptr;
                 // SAFETY: write_ptr/total_bytes name `dest.tensor`'s pinned
                 // storage, which we just allocated and hold via `dest`.
-                let dst = unsafe {
-                    std::slice::from_raw_parts_mut(write_ptr as *mut u8, total_bytes)
-                };
+                let dst =
+                    unsafe { std::slice::from_raw_parts_mut(write_ptr as *mut u8, total_bytes) };
                 self.fill_strided_dst(
                     name,
                     info,

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1238,6 +1238,7 @@ impl Open {
         let array: Py<PyAny> = Python::attach(|py| -> PyResult<Py<PyAny>> {
             let pyarray = PyByteArray::new_with(py, total_bytes, |dst| {
                 self.fill_strided_dst(
+                    py,
                     name,
                     info,
                     outer_count,
@@ -1256,9 +1257,15 @@ impl Open {
     /// Fill `dst` with strips packed in row-major order: for each outer-dim
     /// position, copy/pread one strip from each interval in input order.
     /// `dst.len()` must equal the sum of all strip byte counts.
+    ///
+    /// Mmap and Torch sources go through `parallel_memcpy` (releases the
+    /// GIL, splits across cores) which is necessary to match `torch.cat`'s
+    /// parallel copy kernel on Linux. Pread stays serial — its per-call
+    /// cost is already dominated by I/O.
     #[allow(clippy::too_many_arguments)]
     fn fill_strided_dst(
         &self,
+        py: Python<'_>,
         name: &str,
         info: &TensorInfo,
         outer_count: usize,
@@ -1269,21 +1276,49 @@ impl Open {
     ) -> PyResult<()> {
         let (begin, _end) = info.data_offsets;
         let src_base_in_tensor = self.offset + begin;
-        let mut cursor = 0usize;
+
+        // Cumulative per-row destination offsets: strip i within a row starts
+        // at the sum of all preceding strips' sizes.
+        let mut strip_dst_cum: Vec<usize> = Vec::with_capacity(strip_size.len());
+        let mut acc = 0usize;
+        for &n in strip_size {
+            strip_dst_cum.push(acc);
+            acc += n;
+        }
+        let strip_total_per_row = acc;
+        let dst_base = dst.as_mut_ptr() as usize;
+
+        let build_jobs = |src_base: usize| -> Vec<MemcpyJob> {
+            let mut jobs = Vec::with_capacity(outer_count * interval_byte_offset.len());
+            for g in 0..outer_count {
+                let src_row = src_base + g * row_stride;
+                let dst_row = dst_base + g * strip_total_per_row;
+                for (i, (&off, &n)) in interval_byte_offset.iter().zip(strip_size).enumerate() {
+                    jobs.push(MemcpyJob {
+                        src_addr: src_row + off,
+                        dst_addr: dst_row + strip_dst_cum[i],
+                        nbytes: n,
+                    });
+                }
+            }
+            jobs
+        };
 
         match self.storage.as_ref() {
             Storage::Mmap(mmap) => {
-                for g in 0..outer_count {
-                    let row_base = src_base_in_tensor + g * row_stride;
-                    for (off, &n) in interval_byte_offset.iter().zip(strip_size) {
-                        let s = row_base + off;
-                        dst[cursor..cursor + n].copy_from_slice(&mmap[s..s + n]);
-                        cursor += n;
-                    }
-                }
+                // SAFETY of the addresses passed to parallel_memcpy:
+                // - src lives in the mmap held by self.storage (Arc-rooted,
+                //   alive for this call).
+                // - dst was just allocated by the caller and we own a
+                //   `&mut [u8]` over it; the parallel workers carve it into
+                //   disjoint sub-ranges.
+                let src_base = mmap.as_ptr() as usize + src_base_in_tensor;
+                let jobs = build_jobs(src_base);
+                parallel_memcpy(py, &jobs);
             }
             Storage::Pread(file) => {
                 let base = src_base_in_tensor as u64;
+                let mut cursor = 0usize;
                 for g in 0..outer_count {
                     let row_base = base + (g * row_stride) as u64;
                     for (off, &n) in interval_byte_offset.iter().zip(strip_size) {
@@ -1300,39 +1335,16 @@ impl Open {
                 }
             }
             Storage::Torch(storage) => {
-                Python::attach(|py| -> PyResult<()> {
-                    let storage_obj: &Py<PyAny> = storage
-                        .get()
-                        .ok_or_else(|| SafetensorError::new_err("Could not find storage"))?;
-                    let storage_obj = storage_obj.bind(py);
-                    let src_data_ptr: usize = storage_obj
-                        .call_method0(intern!(py, "data_ptr"))?
-                        .extract()?;
-                    let src_base = src_data_ptr + src_base_in_tensor;
-                    py.detach(|| {
-                        for g in 0..outer_count {
-                            let row_base = src_base + g * row_stride;
-                            for (off, &n) in interval_byte_offset.iter().zip(strip_size) {
-                                // SAFETY: row_base + off..+n lives inside the torch
-                                // UntypedStorage held alive by `self.storage`,
-                                // which is Arc-rooted in this Open for the
-                                // duration of this call. dst is a borrow into
-                                // the caller's buffer; both regions are
-                                // disjoint by construction (dst is freshly
-                                // allocated, src is the file-backed storage).
-                                unsafe {
-                                    std::ptr::copy_nonoverlapping(
-                                        (row_base + off) as *const u8,
-                                        dst.as_mut_ptr().add(cursor),
-                                        n,
-                                    );
-                                }
-                                cursor += n;
-                            }
-                        }
-                    });
-                    Ok(())
-                })?;
+                let storage_obj: &Py<PyAny> = storage
+                    .get()
+                    .ok_or_else(|| SafetensorError::new_err("Could not find storage"))?;
+                let storage_obj = storage_obj.bind(py);
+                let src_data_ptr: usize = storage_obj
+                    .call_method0(intern!(py, "data_ptr"))?
+                    .extract()?;
+                let src_base = src_data_ptr + src_base_in_tensor;
+                let jobs = build_jobs(src_base);
+                parallel_memcpy(py, &jobs);
             }
             Storage::Paddle(_) => unreachable!("paddle path filtered earlier"),
         }
@@ -1371,6 +1383,7 @@ impl Open {
                 let dst =
                     unsafe { std::slice::from_raw_parts_mut(write_ptr as *mut u8, total_bytes) };
                 self.fill_strided_dst(
+                    py,
                     name,
                     info,
                     outer_count,
@@ -2137,6 +2150,103 @@ fn parallel_pread(
             Ok(())
         })
     })
+}
+
+/// One in-memory memcpy job: copy `nbytes` from `src_addr` to `dst_addr`.
+#[derive(Clone, Copy)]
+struct MemcpyJob {
+    src_addr: usize,
+    dst_addr: usize,
+    nbytes: usize,
+}
+
+/// Run a set of in-memory memcpy jobs in parallel without holding the GIL.
+///
+/// Caller guarantees `src_addr..+nbytes` is readable and stays alive for the
+/// duration, and `dst_addr..+nbytes` ranges are mutable, disjoint, and stay
+/// alive. Used by the `get_strided_slice` fill paths to parallelize across
+/// the (typically few) strips into the destination buffer.
+///
+/// On Linux, fresh anonymous pages must be faulted in on first write, and
+/// the kernel mmap_lock serializes some of that. Parallelism still helps —
+/// memcpy bandwidth scales with cores up to the DRAM ceiling, and even the
+/// fault path benefits from concurrent zero-page fills.
+fn parallel_memcpy(py: Python<'_>, jobs: &[MemcpyJob]) {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    if jobs.is_empty() {
+        return;
+    }
+
+    py.detach(|| {
+        // For one big job, splitting it across threads still helps (parallel
+        // page-faulting and memcpy). Subdivide above this threshold.
+        const PARALLEL_THRESHOLD: usize = 4 * 1024 * 1024;
+        const MAX_CHUNK_BYTES: usize = 8 * 1024 * 1024;
+        const MAX_WORKERS: usize = 8;
+
+        let total_bytes: usize = jobs.iter().map(|j| j.nbytes).sum();
+        if total_bytes < PARALLEL_THRESHOLD {
+            for j in jobs {
+                // SAFETY: caller contract.
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        j.src_addr as *const u8,
+                        j.dst_addr as *mut u8,
+                        j.nbytes,
+                    );
+                }
+            }
+            return;
+        }
+
+        // Subdivide so workers stay busy when there are few input jobs.
+        let mut subdivided: Vec<MemcpyJob> = Vec::with_capacity(jobs.len());
+        for j in jobs {
+            let mut off = 0;
+            while off < j.nbytes {
+                let chunk = (j.nbytes - off).min(MAX_CHUNK_BYTES);
+                subdivided.push(MemcpyJob {
+                    src_addr: j.src_addr + off,
+                    dst_addr: j.dst_addr + off,
+                    nbytes: chunk,
+                });
+                off += chunk;
+            }
+        }
+        let jobs = &subdivided;
+
+        let next = AtomicUsize::new(0);
+        let n_workers = std::thread::available_parallelism()
+            .map_or(4, |n| n.get())
+            .min(MAX_WORKERS)
+            .min(jobs.len());
+
+        std::thread::scope(|s| {
+            let mut handles = Vec::with_capacity(n_workers);
+            for _ in 0..n_workers {
+                let next = &next;
+                handles.push(s.spawn(move || loop {
+                    let i = next.fetch_add(1, Ordering::Relaxed);
+                    if i >= jobs.len() {
+                        return;
+                    }
+                    let j = &jobs[i];
+                    // SAFETY: caller contract.
+                    unsafe {
+                        std::ptr::copy_nonoverlapping(
+                            j.src_addr as *const u8,
+                            j.dst_addr as *mut u8,
+                            j.nbytes,
+                        );
+                    }
+                }));
+            }
+            for h in handles {
+                let _ = h.join();
+            }
+        });
+    });
 }
 
 /// Storage shape for torch tensors. F4 packs two elements per byte, so the

--- a/bindings/python/tests/test_strided_slice.py
+++ b/bindings/python/tests/test_strided_slice.py
@@ -1,0 +1,138 @@
+"""Tests for `safe_open(...).get_strided_slice(name, dim, intervals)`.
+
+Equivalence with `torch.cat([f.get_slice(name)[..., a:b, ...] for (a, b) in intervals], dim=dim)`
+across the mmap and pread backends, plus input validation.
+"""
+
+import os
+import tempfile
+import unittest
+
+import torch
+
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+
+SOURCE_TENSORS = {
+    # Even shapes so f4-aligned intervals would also fit if we add fp4 later.
+    "w_2d": torch.arange(8 * 16, dtype=torch.float32).reshape(8, 16).contiguous(),
+    "w_3d": torch.arange(4 * 6 * 8, dtype=torch.float32).reshape(4, 6, 8).contiguous(),
+    "w_bf16": torch.arange(8 * 16, dtype=torch.bfloat16).reshape(8, 16).contiguous(),
+}
+
+
+def _reference_strided_slice(
+    tensor: torch.Tensor, dim: int, intervals: list[tuple[int, int]]
+) -> torch.Tensor:
+    pieces = []
+    for a, b in intervals:
+        idx = [slice(None)] * tensor.ndim
+        idx[dim] = slice(a, b)
+        pieces.append(tensor[tuple(idx)])
+    return torch.cat(pieces, dim=dim)
+
+
+class StridedSliceTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self.tempdir.name, "tiny.safetensors")
+        save_file(SOURCE_TENSORS, self.path)
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def _check(self, name, dim, intervals, backend):
+        with safe_open(self.path, framework="pt", device="cpu", backend=backend) as f:
+            got = f.get_strided_slice(name, dim=dim, intervals=intervals)
+        expected = _reference_strided_slice(SOURCE_TENSORS[name], dim, intervals)
+        self.assertEqual(got.dtype, expected.dtype, (name, dim, intervals, backend))
+        self.assertEqual(
+            tuple(got.shape), tuple(expected.shape), (name, dim, intervals, backend)
+        )
+        # Compare via uint8 view because bf16 doesn't support `equal` on all builds.
+        self.assertTrue(
+            torch.equal(
+                got.contiguous().view(torch.uint8),
+                expected.contiguous().view(torch.uint8),
+            ),
+            f"mismatch for {name=} {dim=} {intervals=} {backend=}",
+        )
+
+    def test_dim0_two_intervals(self):
+        # Like _StridedShard splitting a fused weight on the leading dim.
+        for backend in ("mmap", "pread"):
+            self._check("w_2d", dim=0, intervals=[(0, 2), (4, 6)], backend=backend)
+
+    def test_dim1_two_intervals(self):
+        for backend in ("mmap", "pread"):
+            self._check("w_2d", dim=1, intervals=[(0, 4), (8, 12)], backend=backend)
+
+    def test_dim_last_three_intervals(self):
+        for backend in ("mmap", "pread"):
+            self._check(
+                "w_3d", dim=2, intervals=[(0, 2), (3, 5), (6, 8)], backend=backend
+            )
+
+    def test_middle_dim_3d(self):
+        for backend in ("mmap", "pread"):
+            self._check("w_3d", dim=1, intervals=[(0, 1), (3, 5)], backend=backend)
+
+    def test_single_interval_matches_plain_slice(self):
+        for backend in ("mmap", "pread"):
+            self._check("w_2d", dim=0, intervals=[(2, 5)], backend=backend)
+
+    def test_full_range_single_interval(self):
+        for backend in ("mmap", "pread"):
+            self._check("w_2d", dim=1, intervals=[(0, 16)], backend=backend)
+
+    def test_bf16_dtype(self):
+        for backend in ("mmap", "pread"):
+            self._check("w_bf16", dim=0, intervals=[(1, 3), (5, 7)], backend=backend)
+
+    def test_interleaved_unsorted_intervals(self):
+        # Caller controls strip order; output is the cat in input order.
+        for backend in ("mmap", "pread"):
+            self._check("w_2d", dim=0, intervals=[(4, 6), (0, 2)], backend=backend)
+
+    # --- validation ---
+
+    def test_invalid_dim(self):
+        with safe_open(self.path, framework="pt", device="cpu") as f:
+            with self.assertRaises(Exception):
+                f.get_strided_slice("w_2d", dim=5, intervals=[(0, 1)])
+
+    def test_empty_intervals_list_rejected(self):
+        with safe_open(self.path, framework="pt", device="cpu") as f:
+            with self.assertRaises(Exception):
+                f.get_strided_slice("w_2d", dim=0, intervals=[])
+
+    def test_reversed_interval_rejected(self):
+        with safe_open(self.path, framework="pt", device="cpu") as f:
+            with self.assertRaises(Exception):
+                f.get_strided_slice("w_2d", dim=0, intervals=[(4, 2)])
+
+    def test_empty_interval_rejected(self):
+        with safe_open(self.path, framework="pt", device="cpu") as f:
+            with self.assertRaises(Exception):
+                f.get_strided_slice("w_2d", dim=0, intervals=[(3, 3)])
+
+    def test_out_of_range_interval_rejected(self):
+        with safe_open(self.path, framework="pt", device="cpu") as f:
+            with self.assertRaises(Exception):
+                f.get_strided_slice("w_2d", dim=0, intervals=[(0, 100)])
+
+    def test_unknown_tensor_rejected(self):
+        with safe_open(self.path, framework="pt", device="cpu") as f:
+            with self.assertRaises(Exception):
+                f.get_strided_slice("does_not_exist", dim=0, intervals=[(0, 1)])
+
+    def test_overlap_allowed_and_duplicates(self):
+        # Overlap is allowed and produces duplicated data — matches torch.cat
+        # of overlapping slices.
+        for backend in ("mmap", "pread"):
+            self._check("w_2d", dim=0, intervals=[(0, 3), (1, 4)], backend=backend)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Avoid the need to schedule multiple `get_slice` calls and concatenate the resulting tensors, useful for distributed loading patterns.

cf code in https://github.com/huggingface/transformers/pull/45028/changes#diff-d53b11aa21cc2aff5866078be811ee195227f696ccf28a44588f2a155ccfc800R217

namely the `_slice_and_cat` function would be removed. this avoids multiple allocations and unecessary memcpys

cc @3outeille @ArthurZucker 

Snippet:
```py
  import tempfile, torch
  from safetensors import safe_open
  from safetensors.torch import save_file

  shape = (4096, 1024)
  src = torch.arange(shape[0] * shape[1], dtype=torch.float32).reshape(shape).contiguous()
  with tempfile.NamedTemporaryFile(suffix=".safetensors", delete=False) as fp:
      path = fp.name
  save_file({"fused": src}, path)

  # _StridedShard(dim=0, split_factor=2) for rank 0 of TP=4: interleaved quarters.
  intervals = [(0, 512), (2048, 2560)]
  device = "cuda:0" if torch.cuda.is_available() else "cpu"

  with safe_open(path, framework="pt", device=device) as f:
      got = f.get_strided_slice("fused", dim=0, intervals=intervals)
      expected = torch.cat([f.get_slice("fused")[a:b, :] for a, b in intervals], dim=0)
      assert torch.equal(got.cpu(), expected.cpu())
      print(got.shape, got.dtype, got.device)
```