### PR TITLE
fix(python): correct load_model return type annotation

### DIFF
--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -198,7 +198,7 @@ def load_model(
     device: Union[str, int] = "cpu",
     *,
     backend: str = "mmap",
-) -> Tuple[List[str], List[str]]:
+) -> Tuple[Set[str], List[str]]:
     """
     Loads a given filename onto a torch model.
     This method exists specifically to avoid tensor sharing issues which are
@@ -220,7 +220,7 @@ def load_model(
             and `"pread"` uses `pread(2)` to read tensor bytes.
 
     Returns:
-        `(missing, unexpected): (List[str], List[str])`
+        `(missing, unexpected): (Set[str], List[str])`
             `missing` are names in the model which were not modified during loading
             `unexpected` are names that are on the file, but weren't used during
             the load.


### PR DESCRIPTION
# What does this PR do?

Fixes the incorrect return type annotation on `load_model` in torch.py.

The annotation declared `Tuple[List[str], List[str]]`, but the actual return is `Tuple[Set[str], List[str]]`:
- `missing` is converted via `set(missing)` → Set
- `unexpected` is built with `.append()` → remains a List

Updated both the signature (line 201) and the docstring (line 223). Annotation-only change; no runtime behavior affected.

Note: issue #632 suggested `Tuple[Set, Set]`, but `unexpected` is a List, so the correct type is `Tuple[Set[str], List[str]]`.

Closes #632

## AI model use

- [ ] No AI model was used when making this PR.
- [x] An AI model assisted me in developing this PR.
- [ ] Development of this PR was done by an AI model.

Model used: Claude (via Claude Code)