### PR TITLE
docs(spec): document JSON whitespace tolerance in header

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,11 @@ with safe_open("model.safetensors", framework="pt", device="cpu") as f:
 
 - 8 bytes: `N`, an unsigned little-endian 64-bit integer, containing the size of the header
 - N bytes: a JSON UTF-8 string representing the header.
-  - The header data MUST begin with a `{` character (0x7B).
-  - The header data MAY be trailing padded with whitespace (0x20).
+  - The header data, after stripping JSON whitespace, MUST begin with a `{` character (0x7B).
+  - The header data MAY be padded with JSON whitespace (any of 0x20 SPACE, 0x09 TAB, 0x0A LF, 0x0D CR) in
+    both leading and trailing positions. Implementations MUST tolerate either or both. Writers SHOULD use
+    trailing 0x20 padding when padding is needed (e.g. to align the data section to a power-of-two boundary).
+    The padding bytes are included in the `N` byte count.
   - The header is a dict like `{"TENSOR_NAME": {"dtype": "F16", "shape": [1, 16, 256], "data_offsets": [BEGIN, END]}, "NEXT_TENSOR_NAME": {...}, ...}`,
     - `data_offsets` point to the tensor data relative to the beginning of the byte buffer (i.e. not an absolute position in the file),
       with `BEGIN` as the starting offset and `END` as the one-past offset (so total tensor byte size = `END - BEGIN`).

--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -1549,6 +1549,31 @@ mod tests {
     }
 
     #[test]
+    /// Test that a non-empty header tolerates all four JSON whitespace bytes
+    /// (SPACE 0x20, TAB 0x09, LF 0x0A, CR 0x0D) in both leading and trailing
+    /// positions, and that the tensor data still round-trips intact. This
+    /// locks the contract advertised in the README format section so that
+    /// alternative implementations can rely on it.
+    fn test_whitespace_padded_header_with_tensor() {
+        // Header (58 bytes): leading \t\n, body {"t":{"dtype":"I32","shape":[1],"data_offsets":[0,4]}}, trailing \r ' '.
+        // 2 (leading) + 54 (body) + 2 (trailing) = 58 bytes.
+        let header_json: &[u8] =
+            b"\x09\x0A{\"t\":{\"dtype\":\"I32\",\"shape\":[1],\"data_offsets\":[0,4]}}\x0D\x20";
+        assert_eq!(header_json.len(), 58);
+        let mut serialized: Vec<u8> = Vec::new();
+        serialized.extend_from_slice(&(header_json.len() as u64).to_le_bytes());
+        serialized.extend_from_slice(header_json);
+        serialized.extend_from_slice(&[0x01u8, 0x02, 0x03, 0x04]);
+
+        let loaded = SafeTensors::deserialize(&serialized).unwrap();
+        assert_eq!(loaded.names(), vec!["t"]);
+        let tensor = loaded.tensor("t").unwrap();
+        assert_eq!(tensor.dtype(), Dtype::I32);
+        assert_eq!(tensor.shape(), vec![1]);
+        assert_eq!(tensor.data(), &[0x01u8, 0x02, 0x03, 0x04]);
+    }
+
+    #[test]
     fn test_zero_sized_tensor() {
         let serialized = b"<\x00\x00\x00\x00\x00\x00\x00{\"test\":{\"dtype\":\"I32\",\"shape\":[2,0],\"data_offsets\":[0, 0]}}";
         let loaded = SafeTensors::deserialize(serialized).unwrap();


### PR DESCRIPTION
## Summary

The README format specification (lines 78-79) and the canonical Rust implementation disagree about which JSON whitespace bytes a safetensors header may contain, and where. This PR aligns the README with the implementation's actual contract and adds a Rust regression test that pins the round-trip for non-trivial payloads.

## Spec vs. implementation divergence

`README.md` lines 78-79 currently say:

> The header data MUST begin with a `{` character (0x7B).
> The header data MAY be trailing padded with whitespace (0x20).

The implementation diverges from both clauses:

1. **Position.** PR #686 ("refactor: support reading padded/trailing whitespace header", commit 96305fc) explicitly added support for leading whitespace, motivated by data-section page alignment. The regression test `test_whitespace_leading_padded_header` (`safetensors/src/tensor.rs:1545`) deserializes `\x09\x0A{}\x0D\x20` successfully, meaning the header does **not** have to begin with `{`.
2. **Byte set.** Both `test_whitespace_padded_header` (line 1535) and `test_whitespace_leading_padded_header` (line 1545) use all four JSON whitespace bytes (0x20 SPACE, 0x09 TAB, 0x0A LF, 0x0D CR), not just 0x20. The implementation delegates to `serde_json`, which accepts any JSON whitespace anywhere the JSON grammar permits.

Both clauses in the spec therefore under-specify what every alternative implementation must accept to read files produced by the canonical writer (or by other compliant alternative writers). Lock the contract in the spec.

## Fix

`README.md` is updated to:

- Document that the body, after stripping JSON whitespace, MUST begin with `{`.
- Document that JSON whitespace (0x20, 0x09, 0x0A, 0x0D) MAY appear in both leading and trailing positions, and that implementations MUST tolerate either or both.
- Keep 0x20 trailing as the writer recommendation, so existing writers stay valid and alternative writers have an unambiguous default.
- Reaffirm that the padding is counted in the `N` byte length prefix.

`safetensors/src/tensor.rs` gains `test_whitespace_padded_header_with_tensor`, which builds an `I32[1]` tensor with a header padded by `\t\n` leading and `\r ` trailing, then checks that `dtype`, `shape`, and tensor bytes round-trip. The two existing whitespace tests only cover `{}` (zero-tensor) headers, so this closes the obvious gap for alternative-implementation conformance.

## Substrate context

Surfaced while porting safetensors to Zig at `safetensors-zig` (independent implementation, AGPL-3.0). The Zig port reads the README as ground truth; when we ran behavioral tests against files emitted by the canonical writer we hit fully-spec-conformant readers rejecting files that the canonical Python/Rust reader happily accepts. PR #686's commit message acknowledges the gap ("trailing whitespace are already ignored by serde, this won't break the format") but did not update the spec.

## Test coverage

- `cargo test test_whitespace` in `safetensors/`:
  - `test_whitespace_padded_header` (existing): empty header with trailing JSON whitespace.
  - `test_whitespace_leading_padded_header` (existing): empty header with leading JSON whitespace.
  - `test_whitespace_padded_header_with_tensor` (new): non-empty I32[1] tensor with leading `\t\n` and trailing `\r ` padding; checks dtype, shape, and tensor bytes round-trip.

## CI gate verification

- `cargo fmt --check` in `safetensors/`: clean.
- `cargo test` in `safetensors/`: all tests pass (3 whitespace tests including the new one + full pre-existing suite).

## Test plan

- [ ] `cd safetensors && cargo fmt --check`
- [ ] `cd safetensors && cargo test`
- [ ] Review README diff for accuracy and tone consistency with surrounding format section.
