### PR TITLE
fix(release): move to pypi trusted publisher OIDC

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -185,8 +185,6 @@ jobs:
       - name: Publish to PyPI
         if: "startsWith(github.ref, 'refs/tags/')"
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad  # v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN_DIST}}
         with:
           command: upload
           args: --non-interactive --skip-existing wheels-*/*

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -182,9 +182,8 @@ Sometimes a release or RC has a problem that needs fixing before GA (e.g. a CI m
 
 ## Secrets
 
-The release workflows use two repository secrets:
+The release workflows use one repository secrets:
 
-- `PYPI_TOKEN_DIST` — PyPI API token for the `safetensors` project
 - `CRATES_TOKEN` — crates.io API token
 
 If a workflow fails with an auth error, the token has likely expired. Rotate it in the respective registry and update the repo secret. Worth checking before publishing the release.


### PR DESCRIPTION
Created a trusted publisher for the repo on PyPi, no need for tokens anymore!