### PR TITLE
Reject TensorView shape overflows

### DIFF
--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -752,9 +752,15 @@ impl<'data> TensorView<'data> {
         shape: Vec<usize>,
         data: &'data [u8],
     ) -> Result<Self, SafeTensorError> {
-        let n_elements: usize = shape.iter().product();
+        let n_elements: usize = shape
+            .iter()
+            .copied()
+            .try_fold(1usize, usize::checked_mul)
+            .ok_or(SafeTensorError::ValidationOverflow)?;
 
-        let nbits = n_elements * dtype.bitsize();
+        let nbits = n_elements
+            .checked_mul(dtype.bitsize())
+            .ok_or(SafeTensorError::ValidationOverflow)?;
         if nbits % 8 != 0 {
             return Err(SafeTensorError::MisalignedSlice);
         }
@@ -1127,6 +1133,14 @@ mod tests {
             attn_0,
             Err(SafeTensorError::InvalidTensorView(Dtype::F4, _shape, _size))
         ));
+    }
+
+    #[test]
+    fn test_tensorview_new_rejects_shape_overflow() {
+        let data: Vec<u8> = vec![];
+        let shape = vec![usize::MAX / 2 + 1, 2];
+        let attn_0 = TensorView::new(Dtype::F32, shape, &data);
+        assert!(matches!(attn_0, Err(SafeTensorError::ValidationOverflow)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- use checked multiplication when `TensorView::new` computes shape element counts and dtype bit counts
- return `SafeTensorError::ValidationOverflow` instead of accepting wrapped sizes
- add a regression for a huge shape that previously wrapped to a zero-byte buffer in release builds

## Why

`TensorView::new` is a public constructor used by serialization paths. The metadata reader already validates tensor shapes with checked arithmetic, but manually constructed views used unchecked multiplication before comparing the expected byte size with `data.len()`. In release builds, a sufficiently large shape could wrap to a tiny expected buffer length and be accepted.

## Validation

- `cargo test --manifest-path safetensors\Cargo.toml test_tensorview_new_rejects_shape_overflow`
- `cargo test --manifest-path safetensors\Cargo.toml test_serialization`
- `git diff --check`