### PR TITLE
Fix get_slice for PyTorch fp4 tensors

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -394,6 +394,31 @@ fn parse_indexers(slices: &PyBound<'_, PyAny>, shape: &[usize]) -> PyResult<Vec<
     Ok(indexers)
 }
 
+fn validate_f4_slice_index(slices: &PyBound<'_, PyAny>, logical_shape: &[usize]) -> PyResult<()> {
+    let indexers = parse_indexers(slices, logical_shape)?;
+    if let Some(indexer) = indexers.get(logical_shape.len().saturating_sub(1)) {
+        match indexer {
+            TensorIndexer::Narrow(Bound::Unbounded, Bound::Unbounded, step)
+                if *step == NonZeroUsize::MIN => {}
+            _ => {
+                return Err(SafetensorError::new_err(
+                    "Slicing the last dimension of F4 tensors is not supported",
+                ));
+            }
+        }
+    }
+
+    safetensors::slice::slice_byte_ranges(Dtype::F4, logical_shape, &indexers).map_err(|e| {
+        SafetensorError::new_err(format!(
+            "Error during slicing {:?} with shape {:?}: {e}",
+            indexers,
+            logical_shape,
+        ))
+    })?;
+
+    Ok(())
+}
+
 /// Storage backend used to serve tensor bytes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Backend {
@@ -1697,6 +1722,10 @@ impl PySafeSlice {
     }
 
     pub fn __getitem__(&self, slices: &PyBound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        if self.info.dtype == Dtype::F4 {
+            validate_f4_slice_index(slices, &self.info.shape)?;
+        }
+
         #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
         if self.device == Device::Mps
             && self.framework == Framework::Pytorch
@@ -1732,7 +1761,12 @@ impl PySafeSlice {
                 let torch_uint8: Py<PyAny> = get_pydtype(torch, Dtype::U8, false)?;
                 let kwargs = [(intern!(py, "dtype"), torch_uint8)].into_py_dict(py)?;
                 let view_kwargs = [(intern!(py, "dtype"), dtype)].into_py_dict(py)?;
-                let shape = self.info.shape.to_vec();
+                let logical_shape = self.info.shape.to_vec();
+                let shape = if self.info.dtype == Dtype::F4 {
+                    torch_storage_shape(self.info.dtype, &logical_shape)?
+                } else {
+                    logical_shape.clone()
+                };
                 let shape: Py<PyAny> = shape.into_pyobject(py)?.into();
 
                 let start = (self.info.data_offsets.0 + self.offset) as isize;
@@ -1757,7 +1791,7 @@ impl PySafeSlice {
                     .call((storage_slice,), Some(&kwargs))?
                     .getattr(intern!(py, "view"))?
                     .call((), Some(&view_kwargs))?;
-                if byteorder == "big" {
+                if byteorder == "big" && self.info.dtype != Dtype::F4 {
                     // Important, do NOT use inplace otherwise the slice itself
                     // is byteswapped, meaning multiple calls will fails
                     let inplace_kwargs =
@@ -2229,9 +2263,14 @@ fn create_tensor<'a>(
                 (get_module(py, &NUMPY_MODULE)?, true)
             }
         };
-        let dtype: Py<PyAny> = get_pydtype(module, dtype, is_numpy)?;
+        let dtype_code = dtype;
+        let dtype: Py<PyAny> = get_pydtype(module, dtype_code, is_numpy)?;
         let count: usize = shape.iter().product();
-        let shape = shape.to_vec();
+        let shape = if framework == &Framework::Pytorch {
+            torch_storage_shape(dtype_code, shape)?
+        } else {
+            shape.to_vec()
+        };
         let tensor = if count == 0 {
             // Torch==1.10 does not allow frombuffer on empty buffers so we create
             // the tensor manually.

--- a/bindings/python/tests/test_pt_comparison.py
+++ b/bindings/python/tests/test_pt_comparison.py
@@ -181,6 +181,28 @@ class TorchTestCase(unittest.TestCase):
         # TODO RuntimeError: "eq_cpu" not implemented for 'Float4_e2m1fn_x2'
         # self.assertEqual(reloaded["test2"], test2)
 
+    def test_get_slice_fp4(self):
+        if not hasattr(torch, "float4_e2m1fn_x2"):
+            return  # torch.float4_e2m1fn_x2 requires 2.8
+
+        data = {
+            "test": torch.empty((2, 4), device="cpu", dtype=torch.float4_e2m1fn_x2),
+        }
+        local = "./tests/data/out_safe_pt_mmap_fp4_slice.safetensors"
+
+        save_file(data, local)
+        with safe_open(local, framework="pt", device="cpu") as f:
+            tensor_slice = f.get_slice("test")
+            self.assertEqual(tensor_slice.get_dtype(), "F4")
+            self.assertEqual(tensor_slice.get_shape(), [2, 8])
+
+            reloaded = tensor_slice[:]
+            self.assertEqual(reloaded.dtype, torch.float4_e2m1fn_x2)
+            self.assertEqual(tuple(reloaded.shape), (2, 4))
+            self.assertTrue(reloaded.view(torch.uint8).equal(data["test"].view(torch.uint8)))
+            with self.assertRaisesRegex(Exception, "last dimension"):
+                tensor_slice[:, :2]
+
     def test_zero_sized(self):
         data = {
             "test": torch.zeros((2, 0), dtype=torch.float),


### PR DESCRIPTION
# Fix get_slice for PyTorch fp4 tensors

Previosly using get_slice on a packed fp4 tensor would fail because the shape of underlying storage wasn't allocated correctly. But get_tensor would work. The errors looked like

```
RuntimeError shape '[2, 8]' is invalid for input of size 8
```

This PR allows slicing of the fp4 tensors on any dimension except last (because the last dimension is packed). We could potentially support limited slicing of the last dimension (if it's contiguous and aligned to 2), but it's more involved so skipping for now

## AI model use

We do accept PRs that were developed together with an AI model, but we ask
that you to fill out this section.

- [ ] No AI model was used when making this PR.
- [x] An AI model assisted me in developing this PR.
- [ ] Development of this PR was done by an AI model.

If you ticked one of the last two options, please state the model and model
version that you used: GPT5.5/Cursor

If you ticked the last option, please list the prompt(s) that you used:
