### PR TITLE
fix: sort __metadata__ keys for deterministic serialization

### DIFF
--- a/bindings/python/tests/test_simple.py
+++ b/bindings/python/tests/test_simple.py
@@ -1,4 +1,5 @@
 import importlib
+import json
 import os
 import tempfile
 import threading
@@ -105,6 +106,19 @@ class TestCase(unittest.TestCase):
         )
         self.assertEqual(out1[8:].index(b"\x00") + 8, 104)
         self.assertEqual((out1[8:].index(b"\x00") + 8) % 8, 0)
+
+    def test_serialization_metadata_deterministic(self):
+        data = np.zeros((2, 2), dtype=np.int32)
+        metadata = {str(i): str(i) for i in range(16)}
+        out1 = save({"test1": data}, metadata=metadata)
+        # Metadata keys are sorted at serialization time, so identical
+        # content always produces byte-identical files.
+        for _ in range(10):
+            self.assertEqual(save({"test1": data}, metadata=metadata), out1)
+        n = int.from_bytes(out1[:8], "little")
+        header = json.loads(out1[8 : 8 + n])
+        keys = list(header["__metadata__"].keys())
+        self.assertEqual(keys, sorted(keys))
 
     def test_serialization_no_big_endian(self):
         # Big endian tensor

--- a/safetensors/src/lib.rs
+++ b/safetensors/src/lib.rs
@@ -19,6 +19,7 @@ mod lib {
     #[cfg(not(feature = "std"))]
     mod no_stds {
         pub use alloc::borrow::Cow;
+        pub use alloc::collections::BTreeMap;
         pub use alloc::string::{String, ToString};
         pub use alloc::vec::Vec;
         pub use hashbrown::HashMap;
@@ -26,7 +27,7 @@ mod lib {
     #[cfg(feature = "std")]
     mod stds {
         pub use std::borrow::Cow;
-        pub use std::collections::HashMap;
+        pub use std::collections::{BTreeMap, HashMap};
         pub use std::string::{String, ToString};
         pub use std::vec::Vec;
     }

--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -1,5 +1,5 @@
 //! Module Containing the most important structures
-use crate::lib::{Cow, HashMap, String, ToString, Vec};
+use crate::lib::{BTreeMap, Cow, HashMap, String, ToString, Vec};
 use crate::slice::{InvalidSlice, SliceIterator, TensorIndexer};
 use core::fmt::Display;
 use core::str::Utf8Error;
@@ -585,7 +585,10 @@ impl Serialize for Metadata {
         let mut map = serializer.serialize_map(Some(self.tensors.len() + length))?;
 
         if let Some(metadata) = &self.metadata {
-            map.serialize_entry("__metadata__", metadata)?;
+            // Sort the keys so that identical content always serializes to
+            // identical bytes (`HashMap` iteration order is random).
+            let metadata: BTreeMap<&String, &String> = metadata.iter().collect();
+            map.serialize_entry("__metadata__", &metadata)?;
         }
 
         for (name, info) in names.iter().zip(&self.tensors) {
@@ -1155,6 +1158,35 @@ mod tests {
             ]
         );
         let _parsed = SafeTensors::deserialize(&out).unwrap();
+    }
+
+    #[test]
+    fn test_deterministic_metadata_serialization() {
+        let tensors: HashMap<String, TensorView> = HashMap::new();
+        let make_metadata = || -> Option<HashMap<String, String>> {
+            Some(
+                (0..16)
+                    .map(|i| (format!("k{i}"), format!("v{i}")))
+                    .collect(),
+            )
+        };
+
+        // Identical content must serialize to identical bytes, even though
+        // `HashMap` iteration order is random.
+        let out = serialize(&tensors, make_metadata()).unwrap();
+        for _ in 0..10 {
+            assert_eq!(serialize(&tensors, make_metadata()).unwrap(), out);
+        }
+
+        // Metadata keys appear in the header in sorted order.
+        let header = core::str::from_utf8(&out[N_LEN..]).unwrap();
+        let mut keys: Vec<String> = (0..16).map(|i| format!("\"k{i}\"")).collect();
+        keys.sort();
+        let positions: Vec<usize> = keys
+            .iter()
+            .map(|key| header.find(key.as_str()).unwrap())
+            .collect();
+        assert!(positions.windows(2).all(|w| w[0] < w[1]));
     }
 
     #[test]


### PR DESCRIPTION
# What does this PR do?

Fixes #584.

`impl Serialize for Metadata` writes the user metadata `HashMap` in its random per-instance iteration order, which is what makes repeated identical saves byte-different. This collects the entries into a `BTreeMap<&String, &String>` view at serialization time, so the header is canonical and checksums are reproducible. No new dependencies, and the no_std build keeps working via `alloc::collections::BTreeMap`.

On sorted vs insertion order (discussed in the thread): insertion order is already lost before serialization — `Metadata.metadata` is a `HashMap`, as is the Python `dict` -> PyO3 boundary and the `HashMetadata` deserialization helper — so preserving it would require changing `Metadata`'s public API. Lexicographic order gets the determinism the issue asks for without that churn.

One side note: `safe_open(...).metadata()` may still *display* keys in arbitrary order because reading goes back through a `HashMap`; the on-disk bytes are now stable, which is what checksum/fixture workflows need.

Tested with a Rust unit test (same 16-key metadata serialized from independently built maps must be byte-identical and sorted in the header) and a matching Python regression test in `test_simple.py`; both fail on main and pass with this change. Full `cargo test`, `cargo clippy -- -D warnings`, `cargo build --no-default-features`, and `pytest tests/test_simple.py` pass.

## AI model use

We do accept PRs that were developed together with an AI model, but we ask
that you to fill out this section.

- [ ] No AI model was used when making this PR.
- [x] An AI model assisted me in developing this PR.
- [ ] Development of this PR was done by an AI model.

If you ticked one of the last two options, please state the model and model
version that you used:

Claude Code (Anthropic Claude, Opus 4.8).

If you ticked the last option, please list the prompt(s) that you used:
