### PR TITLE
feat: bump pyo3 to `0.29`

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -196,6 +196,9 @@ jobs:
   audit:
     name: Audit dependencies
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    working-directory: ./bindings/python
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -272,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "libc",
  "once_cell",
@@ -286,18 +286,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -317,13 +317,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -473,9 +472,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -10,7 +10,7 @@ name = "safetensors_rust"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.28", features = ["abi3", "abi3-py310"] }
+pyo3 = { version = "0.29", features = ["abi3", "abi3-py310"] }
 memmap2 = "0.9"
 serde_json = "1.0"
 

--- a/bindings/python/src/dlpack.rs
+++ b/bindings/python/src/dlpack.rs
@@ -1,8 +1,10 @@
 //! DLPack v0 producer + Python capsule wrapping.
 
-use std::ffi::{c_char, c_void};
+use std::ffi::{c_void, CStr};
+use std::ptr::NonNull;
 
 use pyo3::prelude::*;
+use pyo3::types::PyCapsule;
 
 use safetensors::Dtype;
 
@@ -70,7 +72,7 @@ pub struct DLManagedTensor {
     pub deleter: Option<unsafe extern "C" fn(*mut DLManagedTensor)>,
 }
 
-const CAPSULE_NAME: &[u8] = b"dltensor\0";
+const CAPSULE_NAME: &CStr = c"dltensor";
 
 /// Source of the `data` pointer [`to_capsule`] writes into the `DLTensor`.
 ///
@@ -221,7 +223,7 @@ pub(crate) fn to_capsule<B: AsDevicePtr>(
     shape: Vec<i64>,
     dtype: DLDataType,
     device: DLDevice,
-) -> PyResult<Py<PyAny>> {
+) -> PyResult<Py<PyCapsule>> {
     let ndim = shape.len() as i32;
     let data = device_buf.as_device_ptr();
 
@@ -251,21 +253,28 @@ pub(crate) fn to_capsule<B: AsDevicePtr>(
         deleter: Some(managed_tensor_deleter::<B>),
     }));
 
-    let name_ptr = CAPSULE_NAME.as_ptr() as *const c_char;
-    // SAFETY: for all the following unsafe calls, all data was produced by this function and is valid each the call.
-    // In case of failure, we clean up the managed tensor ourselves to avoid leaks, since the capsule destructor won't run.
-    let capsule_ptr = unsafe {
-        pyo3::ffi::PyCapsule_New(managed as *mut c_void, name_ptr, Some(capsule_destructor))
+    // `managed` came from `Box::into_raw`, so it is non-null.
+    let managed_ptr = NonNull::new(managed as *mut c_void).unwrap();
+    // SAFETY: `managed_ptr` points to a live `DLManagedTensor` produced above, and
+    // `capsule_destructor` reclaims it via the registered deleter.
+    let capsule = unsafe {
+        PyCapsule::new_with_pointer_and_destructor(
+            py,
+            managed_ptr,
+            CAPSULE_NAME,
+            Some(capsule_destructor),
+        )
     };
-    if capsule_ptr.is_null() {
+    // On failure the destructor was never registered, so reclaim the tensor ourselves.
+    let capsule = capsule.map_err(|e| {
         unsafe { managed_tensor_deleter::<B>(managed) };
-        return Err(PyErr::fetch(py));
-    }
-    Ok(unsafe { Bound::from_owned_ptr(py, capsule_ptr) }.unbind())
+        e
+    })?;
+    Ok(capsule.unbind())
 }
 
 unsafe extern "C" fn capsule_destructor(capsule: *mut pyo3::ffi::PyObject) {
-    let name_ptr = CAPSULE_NAME.as_ptr() as *const c_char;
+    let name_ptr = CAPSULE_NAME.as_ptr();
     if unsafe { pyo3::ffi::PyCapsule_IsValid(capsule, name_ptr) } == 0 {
         return;
     }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -11,7 +11,9 @@ use pyo3::exceptions::{PyException, PyFileNotFoundError};
 use pyo3::prelude::*;
 use pyo3::sync::OnceLockExt;
 use pyo3::types::IntoPyDict;
-use pyo3::types::{PyBool, PyByteArray, PyBytes, PyDict, PyEllipsis, PyList, PySlice, PyTuple};
+use pyo3::types::{
+    PyBool, PyByteArray, PyBytes, PyCapsule, PyDict, PyEllipsis, PyList, PySlice, PyTuple,
+};
 use pyo3::Bound as PyBound;
 use pyo3::{intern, PyErr};
 use safetensors::slice::TensorIndexer;
@@ -2132,7 +2134,7 @@ fn torch_supports_mps_dlpack() -> bool {
 fn ingest_dlpack_mps(
     py: Python<'_>,
     framework: &Framework,
-    capsule: Py<PyAny>,
+    capsule: Py<PyCapsule>,
 ) -> PyResult<Py<PyAny>> {
     match framework {
         Framework::Pytorch => {

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -11,9 +11,9 @@ use pyo3::exceptions::{PyException, PyFileNotFoundError};
 use pyo3::prelude::*;
 use pyo3::sync::OnceLockExt;
 use pyo3::types::IntoPyDict;
-use pyo3::types::{
-    PyBool, PyByteArray, PyBytes, PyCapsule, PyDict, PyEllipsis, PyList, PySlice, PyTuple,
-};
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+use pyo3::types::PyCapsule;
+use pyo3::types::{PyBool, PyByteArray, PyBytes, PyDict, PyEllipsis, PyList, PySlice, PyTuple};
 use pyo3::Bound as PyBound;
 use pyo3::{intern, PyErr};
 use safetensors::slice::TensorIndexer;


### PR DESCRIPTION
Required to fix the `cargo audit`. While reviewing the changelog, discovered that there was a proper `PyCapsule` type we could use instead of calling raw ffi `PyCapsule_New`.

Removes one `unsafe` block :)

cf https://pyo3.rs/v0.29.0/migration.html