### PR TITLE
docs: fix typos in tensor.rs rustdoc comments

### DIFF
--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -18,7 +18,7 @@ pub enum SafeTensorError {
     InvalidHeader(Utf8Error),
     /// The header does contain a valid string, but it is not valid JSON.
     InvalidHeaderDeserialization(serde_json::Error),
-    /// The header is large than 100Mo which is considered too large (Might evolve in the future).
+    /// The header is larger than 100MB which is considered too large (Might evolve in the future).
     HeaderTooLarge,
     /// The header is smaller than 8 bytes
     HeaderTooSmall,
@@ -35,7 +35,7 @@ pub enum SafeTensorError {
     IoError(std::io::Error),
     /// JSON error
     JsonError(serde_json::Error),
-    /// The follow tensor cannot be created because the buffer size doesn't match shape + dtype
+    /// The following tensor cannot be created because the buffer size doesn't match shape + dtype
     InvalidTensorView(Dtype, Vec<usize>, usize),
     /// The metadata is invalid because the data offsets of the tensor does not
     /// fully cover the buffer part of the file. The last offset **must** be
@@ -264,7 +264,7 @@ where
     ))
 }
 
-/// Serialize to an owned byte buffer the dictionnary of tensors.
+/// Serialize to an owned byte buffer the dictionary of tensors.
 pub fn serialize<
     S: AsRef<str> + Ord + core::fmt::Display,
     V: View,
@@ -341,7 +341,7 @@ fn buffered_write_to_file<V: View>(
     Ok(())
 }
 
-/// Serialize to a regular file the dictionnary of tensors.
+/// Serialize to a regular file the dictionary of tensors.
 /// Writing directly to file reduces the need to allocate the whole amount to
 /// memory.
 #[cfg(feature = "std")]
@@ -526,7 +526,7 @@ impl<'data> SafeTensors<'data> {
     }
 }
 
-/// The stuct representing the header of safetensor files which allow
+/// The struct representing the header of safetensor files which allow
 /// indexing into the raw byte-buffer array and how to interpret it.
 #[derive(Debug, Clone)]
 pub struct Metadata {
@@ -809,7 +809,7 @@ pub struct TensorInfo {
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
 #[non_exhaustive]
 pub enum Dtype {
-    /// Boolan type
+    /// Boolean type
     BOOL,
     /// MXF4 <https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf>_
     F4,


### PR DESCRIPTION
# What does this PR do?

Fixes several typos in public doc comments in `safetensors/src/tensor.rs`.
The crate sets `#![deny(missing_docs)]`, so these comments are published
verbatim to docs.rs as part of the API surface:

- `SafeTensorError::HeaderTooLarge`: "large than 100Mo" → "larger than 100MB"
  (`MAX_HEADER_SIZE` is `100_000_000` bytes)
- `SafeTensorError::InvalidTensorView`: "The follow tensor" → "The following tensor"
- `serialize`: "the dictionnary of tensors" → "the dictionary of tensors"
- `serialize_to_file`: "the dictionnary of tensors" → "the dictionary of tensors"
- `Metadata`: "The stuct representing" → "The struct representing"
- `Dtype::BOOL`: "Boolan type" → "Boolean type"

Comment-only change, no behavior change. `cargo doc --no-deps` builds clean.

## AI model use

We do accept PRs that were developed together with an AI model, but we ask
that you to fill out this section.

- [ ] No AI model was used when making this PR.
- [x] An AI model assisted me in developing this PR.
- [ ] Development of this PR was done by an AI model.

If you ticked one of the last two options, please state the model and model
version that you used:

Claude (Opus 4.8), via Claude Code.
