### PR TITLE
Add pluggable device-transfer hook for custom devices

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = { version = "0.28", features = ["abi3", "abi3-py310"] }
 memmap2 = "0.9"
+once_cell = "1.19"
 serde_json = "1.0"
 
 [dependencies.safetensors]

--- a/bindings/python/py_src/safetensors/__init__.py
+++ b/bindings/python/py_src/safetensors/__init__.py
@@ -8,4 +8,6 @@ from ._safetensors_rust import (  # noqa: F401
     _safe_open_handle,
     serialize,
     serialize_file,
+    _register_device_transfer_hook,
+    _is_custom_device,
 )

--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -1,3 +1,14 @@
+"""
+PyTorch bindings for safetensors.
+
+This module provides PyTorch-specific functionality for loading and saving
+tensors in the safetensors format. Custom device support is provided through
+the device transfer hook mechanism in the Rust core.
+
+Third-party device packages should call _register_device_transfer_hook() during
+import to enable loading tensors directly to their custom devices.
+"""
+
 import os
 import sys
 from collections import defaultdict
@@ -10,7 +21,120 @@ from safetensors import (
     safe_open,
     serialize,
     serialize_file,
+    _is_custom_device,
 )
+
+def _device_type(device) -> str:
+    """Return the device type string from a str or torch.device."""
+    if isinstance(device, torch.device):
+        return device.type
+    if isinstance(device, int):
+        return "cuda"
+    # Handles "spyre", "spyre:0", "cuda:1", etc.
+    return str(device).split(":")[0]
+
+def _resolve_parent(model, name):
+    """Resolve the parent module and attribute name for a dotted parameter/buffer name.
+
+    Args:
+        model: The root model
+        name: Dotted name like "layer.0.weight"
+
+    Returns:
+        (parent_module, attr_name) tuple
+
+    Raises:
+        AttributeError: If the parent module path doesn't exist
+    """
+    parts = name.rsplit(".", 1)
+    if len(parts) == 2:
+        parent = model.get_submodule(parts[0])
+        attr_name = parts[1]
+    else:
+        parent = model
+        attr_name = parts[0]
+    return parent, attr_name
+
+
+def _assign_tensors_to_model(model, state_dict, strict=True):
+    """Assign tensors from state_dict directly to model parameters/buffers."""
+    missing_keys = []
+    unexpected_keys = list(state_dict.keys())
+
+    # Assign parameters
+    for name, param in model.named_parameters():
+        if name in state_dict:
+            ckpt_tensor = state_dict[name]
+
+            # Validate shape and dtype before assignment to catch mismatches early
+            if ckpt_tensor.shape != param.shape:
+                raise RuntimeError(
+                    f"size mismatch for {name}: "
+                    f"copying a param with shape {ckpt_tensor.shape} from checkpoint, "
+                    f"the shape in current model is {param.shape}."
+                )
+            if ckpt_tensor.dtype != param.dtype:
+                raise RuntimeError(
+                    f"dtype mismatch for {name}: "
+                    f"checkpoint has {ckpt_tensor.dtype}, "
+                    f"model expects {param.dtype}."
+                )
+
+            try:
+                parent, attr_name = _resolve_parent(model, name)
+            except AttributeError:
+                missing_keys.append(name)
+                continue
+
+            # Remove from unexpected only after submodule lookup succeeds 
+            if name in unexpected_keys:
+                unexpected_keys.remove(name)
+
+            parent._parameters[attr_name] = torch.nn.Parameter(
+                ckpt_tensor, requires_grad=param.requires_grad
+            )
+        else:
+            missing_keys.append(name)
+
+    # Assign buffers
+    for name, buf in model.named_buffers():
+        if name in state_dict:
+            ckpt_tensor = state_dict[name]
+
+            # Validate shape and dtype before assignment to catch mismatches early
+            if ckpt_tensor.shape != buf.shape:
+                raise RuntimeError(
+                    f"size mismatch for {name}: "
+                    f"copying a buffer with shape {ckpt_tensor.shape} from checkpoint, "
+                    f"the shape in current model is {buf.shape}."
+                )
+            if ckpt_tensor.dtype != buf.dtype:
+                raise RuntimeError(
+                    f"dtype mismatch for {name}: "
+                    f"checkpoint has {ckpt_tensor.dtype}, "
+                    f"model expects {buf.dtype}."
+                )
+
+            try:
+                parent, attr_name = _resolve_parent(model, name)
+            except AttributeError:
+                missing_keys.append(name)
+                continue
+
+            if name in unexpected_keys:
+                unexpected_keys.remove(name)
+
+            parent._buffers[attr_name] = ckpt_tensor
+        else:
+            missing_keys.append(name)
+
+    if strict and (missing_keys or unexpected_keys):
+        raise RuntimeError(
+            f"Error(s) in loading state_dict: missing keys {missing_keys}, "
+            f"unexpected keys {unexpected_keys}"
+        )
+
+    return missing_keys, unexpected_keys
 
 
 def storage_ptr(tensor: torch.Tensor) -> int:
@@ -197,6 +321,7 @@ def load_model(
     strict: bool = True,
     device: Union[str, int] = "cpu",
     *,
+    assign: Optional[bool] = None,
     backend: str = "mmap",
 ) -> Tuple[List[str], List[str]]:
     """
@@ -215,6 +340,13 @@ def load_model(
         device (`Union[str, int]`, *optional*, defaults to `cpu`):
             The device where the tensors need to be located after load.
             available options are all regular torch device locations.
+        assign (`Optional[bool]`, *optional*, defaults to `None`):
+            If True, assign tensors directly to parameters instead of copying
+            via load_state_dict(). This is required when loading to custom
+            devices with models that have meta device parameters, as copying
+            from a non-meta tensor to a meta tensor is a no-op.
+            Defaults to `None`, which auto-selects assign for custom devices.
+            Pass `True`/`False` explicitly to override the auto-detection.
         backend (`str`, *optional*, defaults to `"mmap"`):
             Storage backend used to serve tensor bytes. `"mmap"` (default)
             and `"pread"` uses `pread(2)` to read tensor bytes.
@@ -226,11 +358,23 @@ def load_model(
             the load.
     """
     state_dict = load_file(filename, device=device, backend=backend)
+    # For custom devices, load_state_dict's copy_() is a no-op on meta tensors,
+    # so we auto-select the assign path -- but only when the caller hasn't
+    # explicitly told us which path they want via `assign`. An explicit
+    # True/False always wins over the auto-detection.
+    dev_type = _device_type(device) if not isinstance(device, int) else "cuda"
+    if assign is None:
+        _assign = _is_custom_device(dev_type)
+    else:
+        _assign = assign
     model_state_dict = model.state_dict()
     to_removes = _remove_duplicate_names(
         model_state_dict, preferred_names=state_dict.keys()
     )
-    missing, unexpected = model.load_state_dict(state_dict, strict=False)
+    if _assign:
+        missing, unexpected = _assign_tensors_to_model(model, state_dict, strict=False)
+    else:
+        missing, unexpected = model.load_state_dict(state_dict, strict=False)
     missing = set(missing)
     for to_remove_group in to_removes.values():
         for to_remove in to_remove_group:

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1586,6 +1586,7 @@ impl Open {
                 offset: self.offset,
                 device: self.device.clone(),
                 storage: self.storage.clone(),
+                name: name.to_string(),
             })
         } else {
             Err(SafetensorError::new_err(format!(
@@ -1744,6 +1745,9 @@ struct PySafeSlice {
     offset: usize,
     device: Device,
     storage: Arc<Storage>,
+    /// Tensor key in the safetensors file.  Forwarded to the custom-device
+    /// hook so it receives the same name as Open::get_tensor() would pass.
+    name: String,
 }
 
 use std::fmt;
@@ -1885,6 +1889,139 @@ impl PySafeSlice {
             mps_tensor_from_buf(py, &self.framework, self.info.dtype, &newshape, buf)
         })
     }
+
+    /// Slice the tensor and transfer the result to a custom device via the
+    /// registered hook.
+    ///
+    /// Called by `__getitem__` whenever `self.device` is `Device::Custom`.
+    ///
+    /// # Strategy
+    ///
+    /// 1. Gather the post-slice bytes into a contiguous CPU buffer using
+    ///    `slice_bytes_to_tensor` -- the same helper used by the mmap/pread
+    ///    branches of `__getitem__`.  For mmap storage only the slice ranges
+    ///    are copied, not the whole tensor.
+    ///
+    /// 2. Call `hook(cpu_tensor, name, device)` to move the CPU tensor to
+    ///    the custom device -- exactly as `Open::get_tensor` does.
+    ///
+    /// Torch / Paddle storage is never created for custom devices because
+    /// `Open::new` skips the `UntypedStorage` construction path for
+    /// `Device::Custom`, so those arms are unreachable in practice.
+    fn slice_custom_device(&self, slices: &PyBound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        // Step 1 -- produce a contiguous CPU tensor for the requested slice.
+        // Step 1 -- produce a CPU tensor for the requested slice.
+        //
+        // We cannot use slice_bytes_to_tensor() here: it calls
+        // create_tensor(..., &self.device), which for a custom device would
+        // invoke the hook a second time (inside create_tensor) before we even
+        // reach Step 2.  That means the hook receives a Spyre tensor and tries
+        // to DMA it onto Spyre again, causing "Unsupported copy types: src on
+        // spyre dst on spyre".
+        //
+        // Instead, re-do the byte→tensor step explicitly with Device::Cpu so
+        // the hook in Step 2 always receives a plain CPU tensor.
+        let cpu_tensor: Py<PyAny> = match self.storage.as_ref() {
+            Storage::Mmap(mmap) => {
+                let data = &mmap[self.info.data_offsets.0 + self.offset
+                    ..self.info.data_offsets.1 + self.offset];
+                self.slice_bytes_to_cpu_tensor(slices, data)?
+            }
+            Storage::Pread(file) => {
+                let (begin, end) = self.info.data_offsets;
+                let nbytes = end - begin;
+                let mut data = vec![0u8; nbytes];
+                if nbytes > 0 {
+                    read_exact_at(file, &mut data, (self.offset + begin) as u64).map_err(
+                        |e| {
+                            SafetensorError::new_err(format!(
+                                "Could not read tensor bytes for slicing: {e}"
+                            ))
+                        },
+                    )?;
+                }
+                self.slice_bytes_to_cpu_tensor(slices, &data)?
+            }
+            // Unreachable: Open::new skips UntypedStorage construction for
+            // Device::Custom so Storage::Torch / Storage::Paddle are never
+            // created for custom devices.  Emit a clear error anyway.
+            Storage::Torch(_) | Storage::Paddle(_) => {
+                return Err(SafetensorError::new_err(
+                    "Custom device slicing with Torch/Paddle storage is not supported. \
+                     Use backend='pread' or open the file without a custom device.",
+                ));
+            }
+        };
+
+        // Step 2 -- invoke the registered hook to move the CPU tensor to the
+        // custom device.  The hook signature is (cpu_tensor, name, device).
+        let Device::Custom(device_type, _) = &self.device else {
+            unreachable!("slice_custom_device called for non-Custom device")
+        };
+        let hooks = DEVICE_HOOKS.read().unwrap();
+        let hook = hooks.get(device_type).ok_or_else(|| {
+           SafetensorError::new_err(format!(
+               "safetensors: device type '{device_type}' is not natively supported \
+                and no transfer hook has been registered for it. \
+                If you are using a third-party device package, make sure it is \
+                imported before calling safe_open (e.g., 'import torch_{device_type}')."
+           ))
+        })?;
+        Python::attach(|py| {
+            let device_obj: Py<PyAny> = self.device.clone().into_pyobject(py)?.into();
+            hook(cpu_tensor, &self.name, device_obj)
+        })
+    }
+
+    /// Like `slice_bytes_to_tensor` but always targets CPU.
+    ///
+    /// Used by `slice_custom_device` so the hook receives a plain CPU tensor
+    /// rather than one that has already been moved to the custom device by
+    /// `create_tensor` (which would cause a double-dispatch / copy error).
+fn slice_bytes_to_cpu_tensor(
+        &self,
+        slices: &PyBound<'_, PyAny>,
+        data: &[u8],
+    ) -> PyResult<Py<PyAny>> {
+        let indexers = parse_indexers(slices, &self.info.shape)?;
+
+        let tensor = TensorView::new(self.info.dtype, self.info.shape.clone(), data)
+            .map_err(|e| SafetensorError::new_err(format!("Error preparing tensor view: {e}")))?;
+
+        let iterator = tensor.sliced_data(&indexers).map_err(|e| {
+            SafetensorError::new_err(format!(
+                "Error during slicing {} with shape {:?}: {e}",
+                Disp(indexers),
+                self.info.shape,
+            ))
+        })?;
+        let newshape = iterator.newshape();
+        let length = iterator.remaining_byte_len();
+
+        let mut offset = 0;
+        Python::attach(|py| {
+            let array: Py<PyAny> = PyByteArray::new_with(py, length, |bytes: &mut [u8]| {
+                for slice in iterator {
+                    let len = slice.len();
+                    bytes[offset..offset + len].copy_from_slice(slice);
+                    offset += len;
+                }
+                Ok(())
+            })?
+            .into_any()
+            .into();
+            // Force CPU regardless of self.device so the caller (slice_custom_device)
+            // always gets a CPU tensor to hand to the registered hook.
+            create_tensor(
+                &self.framework,
+                self.info.dtype,
+                &newshape,
+                array,
+                &Device::Cpu,
+            )
+        })
+    }
+
 }
 
 #[pymethods]
@@ -1930,6 +2067,14 @@ impl PySafeSlice {
     }
 
     pub fn __getitem__(&self, slices: &PyBound<'_, PyAny>) -> PyResult<Py<PyAny>> {
+        // Custom device: gather the sliced bytes on CPU then dispatch to the
+        // registered hook.  Must come before the MPS guard because a custom
+        // device could in principle run on macOS/aarch64 and the MPS path
+        // would otherwise shadow it.
+        if matches!(self.device, Device::Custom(_, _)) {
+            return self.slice_custom_device(slices);
+        }
+
         #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
         if self.device == Device::Mps
             && self.framework == Framework::Pytorch

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -7,6 +7,7 @@ mod metal;
 
 use core::slice;
 use memmap2::{Mmap, MmapOptions};
+use once_cell::sync::Lazy;
 use pyo3::exceptions::{PyException, PyFileNotFoundError};
 use pyo3::prelude::*;
 use pyo3::sync::OnceLockExt;
@@ -24,6 +25,7 @@ use std::num::NonZeroUsize;
 use std::ops::Bound;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::RwLock;
 use std::sync::OnceLock;
 
 static TORCH_MODULE: OnceLock<Py<PyModule>> = OnceLock::new();
@@ -35,6 +37,90 @@ static PADDLE_MODULE: OnceLock<Py<PyModule>> = OnceLock::new();
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 static TORCH_MPS_DLPACK: OnceLock<bool> = OnceLock::new();
+
+// ---------------------------------------------------------------------------
+// Device Transfer Hook Registry
+// ---------------------------------------------------------------------------
+//
+// Global registry for custom device transfer hooks. Third-party device
+// packages (e.g., torch_spyre) register a Python callable that safetensors
+// invokes to transfer tensors from CPU to the custom device.
+//
+// The hook receives:
+//   - cpu_tensor: A framework tensor on CPU (torch.Tensor, jax.Array, etc.)
+//   - name: The tensor's key in the safetensors file
+//   - device: The target device (e.g., "spyre:1")
+//
+// And returns a tensor on the target device.
+
+type DeviceTransferHook = Arc<dyn Fn(Py<PyAny>, &str, Py<PyAny>) -> PyResult<Py<PyAny>> + Send + Sync>;
+
+static DEVICE_HOOKS: Lazy<RwLock<HashMap<String, DeviceTransferHook>>> =
+    Lazy::new(|| RwLock::new(HashMap::new()));
+
+/// Register a device transfer hook for a custom device type.
+///
+/// Args:
+///     device_type (str): The device type string (e.g., "spyre")
+///     hook (callable): A Python callable with signature
+///         (cpu_tensor, name: str, device) -> tensor
+///    overwrite (bool, optional): If `True`, silently replace an existing
+///         hook for `device_type` instead of raising. Defaults to `False`.
+///         Intended for interactive use (e.g. re-running a notebook cell)
+///         where re-registration is expected; regular imports should not
+///         need it.
+///
+/// This function is called by third-party device packages during import.
+///
+/// Raises:
+///     SafetensorError: if a hook is already registered for `device_type`
+///         and `overwrite` is `False`. Registering a second hook for the
+///         same device type without noticing is a likely source of subtle
+///         bugs (whichever package imports last silently wins), so this is
+///         an error by default rather than a silent overwrite.
+#[pyfunction]
+#[pyo3(signature = (device_type, hook, overwrite=false))]
+fn _register_device_transfer_hook(
+    device_type: String,
+    hook: Py<PyAny>,
+    overwrite: bool,
+) -> PyResult<()> {
+    Python::attach(|py| {
+        // Validate that hook is callable
+        if !hook.bind(py).is_callable() {
+            return Err(SafetensorError::new_err(format!(
+                "Hook for device type '{device_type}' must be callable"
+            )));
+        }
+
+        let hook_fn: DeviceTransferHook = Arc::new(move |tensor: Py<PyAny>, name: &str, device: Py<PyAny>| {
+            Python::attach(|py| {
+                hook.call1(py, (tensor, name, device))
+            })
+        });
+
+        let mut hooks = DEVICE_HOOKS.write().unwrap();
+        if !overwrite && hooks.contains_key(&device_type) {
+            return Err(SafetensorError::new_err(format!(
+                "safetensors: a device transfer hook is already registered for \
+                 device type '{device_type}'. This usually means two packages \
+                 (or two versions of the same package) both tried to register \
+                 a hook for '{device_type}'; whichever registers last would \
+                 otherwise silently win, which can produce a mismatched \
+                 transfer path with no error. Pass overwrite=True to \
+                 _register_device_transfer_hook if replacing the existing \
+                 hook is intentional."
+            )));
+        }
+        hooks.insert(device_type, hook_fn);
+        Ok(())
+    })
+}
+
+#[pyfunction]
+fn _is_custom_device(device_type: &str) -> bool {
+    DEVICE_HOOKS.read().unwrap().contains_key(device_type)
+}
 
 /// Describes a single tensor passed to [`serialize`] / [`serialize_file`].
 ///
@@ -491,6 +577,7 @@ enum Device {
     Mlu(usize),
     Musa(usize),
     Hpu(usize),
+    Custom(String, Option<usize>),
     /// User didn't specify accelerator, torch
     /// is responsible for choosing.
     Anonymous(usize),
@@ -498,7 +585,7 @@ enum Device {
 
 impl fmt::Display for Device {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
+        match self {
             Device::Cpu => write!(f, "cpu"),
             Device::Mps => write!(f, "mps"),
             Device::Cuda(index) => write!(f, "cuda:{index}"),
@@ -508,6 +595,8 @@ impl fmt::Display for Device {
             Device::Xla(index) => write!(f, "xla:{index}"),
             Device::Mlu(index) => write!(f, "mlu:{index}"),
             Device::Hpu(index) => write!(f, "hpu:{index}"),
+            Device::Custom(device_type, Some(index)) => write!(f, "{device_type}:{index}"),
+            Device::Custom(device_type, None) => write!(f, "{device_type}"),
             Device::Anonymous(index) => write!(f, "{index}"),
         }
     }
@@ -553,9 +642,30 @@ impl<'a, 'py> FromPyObject<'a, 'py> for Device {
                 name if name.starts_with("xla:") => parse_device(name).map(Device::Xla),
                 name if name.starts_with("mlu:") => parse_device(name).map(Device::Mlu),
                 name if name.starts_with("hpu:") => parse_device(name).map(Device::Hpu),
-                name => Err(SafetensorError::new_err(format!(
-                    "device {name} is invalid"
-                ))),
+                name => {
+                    // Parse as custom device: "device_type" or "device_type:index"
+                    // Validate device string format: must be alphanumeric + underscore
+                    let parts: Vec<_> = name.split(':').collect();
+                    if parts.is_empty() || parts[0].is_empty() {
+                        return Err(SafetensorError::new_err(format!("device {name} is invalid")));
+                    }
+                    let device_type = parts[0];
+                    if !device_type.chars().all(|c| c.is_alphanumeric() || c == '_') {
+                        return Err(SafetensorError::new_err(format!(
+                            "device {name} is invalid: device type must be alphanumeric"
+                        )));
+                    }
+                    let index = if parts.len() == 2 {
+                        Some(parts[1].parse().map_err(|_| {
+                            SafetensorError::new_err(format!("device {name} has invalid index"))
+                        })?)
+                    } else if parts.len() > 2 {
+                        return Err(SafetensorError::new_err(format!("device {name} is invalid")));
+                    } else {
+                        None
+                    };
+                    Ok(Device::Custom(device_type.to_string(), index))
+                }
             }
         } else if let Ok(number) = ob.extract::<usize>() {
             Ok(Device::Anonymous(number))
@@ -583,6 +693,8 @@ impl<'py> IntoPyObject<'py> for Device {
             Device::Xla(n) => format!("xla:{n}").into_pyobject(py).map(|x| x.into_any()),
             Device::Mlu(n) => format!("mlu:{n}").into_pyobject(py).map(|x| x.into_any()),
             Device::Hpu(n) => format!("hpu:{n}").into_pyobject(py).map(|x| x.into_any()),
+            Device::Custom(device_type, Some(n)) => format!("{device_type}:{n}").into_pyobject(py).map(|x| x.into_any()),
+            Device::Custom(device_type, None) => device_type.into_pyobject(py).map(|x| x.into_any()),
             Device::Anonymous(n) => n.into_pyobject(py).map(|x| x.into_any()),
         }
     }
@@ -674,9 +786,24 @@ impl Open {
             && framework != Framework::Pytorch
             && framework != Framework::Paddle
         {
-            return Err(SafetensorError::new_err(format!(
-                "Device {device} is not supported for framework {framework}",
-            )));
+            // Allow custom devices for all frameworks
+            if !matches!(device, Device::Custom(_, _)) {
+                return Err(SafetensorError::new_err(format!(
+                    "Device {device} is not supported for framework {framework}",
+                )));
+            }
+        }
+        // Custom device — validate hook is registered at open time, not lazily at get_tensor
+        if let Device::Custom(device_type, _) = &device {
+            let hooks = DEVICE_HOOKS.read().unwrap();
+            if !hooks.contains_key(device_type) {
+                return Err(SafetensorError::new_err(format!(
+                    "safetensors: device type '{device_type}' is not natively supported \
+                     and no transfer hook has been registered for it. \
+                     If you are using a third-party device package, make sure it is \
+                     imported before calling safe_open (e.g., 'import torch_{device_type}')."
+                )));
+            }
         }
 
         // SAFETY: Mmap is used to prevent allocating in Rust
@@ -764,7 +891,7 @@ impl Open {
 
                 // Untyped storage only exists for versions over 1.11.0
                 // Same for torch.asarray which is necessary for zero-copy tensor
-                if version >= Version::new(1, 11, 0) {
+                if version >= Version::new(1, 11, 0) && !matches!(device, Device::Custom(_, _)) {
                     // storage = torch.ByteStorage.from_file(filename, shared=False,
                     // size=size).untyped()
                     let py_filename: Py<PyAny> = filename
@@ -870,6 +997,22 @@ impl Open {
         let info = self.metadata.info(name).ok_or_else(|| {
             SafetensorError::new_err(format!("File does not contain tensor {name}",))
         })?;
+        // Check if device needs a custom hook
+        if let Device::Custom(device_type, _) = &self.device {
+            let hooks = DEVICE_HOOKS.read().unwrap();
+            if let Some(hook) = hooks.get(device_type) {
+                // Load tensor bytes for the hook
+                let cpu_tensor = self.get_tensor_bytes_for_hook(name, info)?;
+                // Invoke hook to transfer to custom device
+                return Python::attach(|py| {
+                    let device_obj = self.device.clone().into_pyobject(py)?.into();
+                    hook(cpu_tensor, name, device_obj)
+                });
+            } else {
+                // Unreachable: Open::new rejects custom devices with no registered hook.
+                unreachable!("custom device '{device_type}' has no hook but passed Open::new")
+            }
+        }
 
         // Pytorch + CUDA: write into a pinned CPU tensor and `.to(cuda)` for
         // async DMA, regardless of backend. The byte source differs per
@@ -1081,6 +1224,96 @@ impl Open {
                 })
             }
             Storage::Pread(file) => self.get_tensor_pread(name, info, file),
+        }
+    }
+    /// Prepare a tensor for transfer via a custom device hook.
+    ///
+    /// Returns a CPU tensor ready to be passed to the registered hook:
+    /// - **mmap**: zero-copy `PyMemoryView` into the OS page-cache (no heap alloc)
+    /// - **pread**: single copy from disk into a pre-allocated buffer
+    fn get_tensor_bytes_for_hook(&self, name: &str, info: &TensorInfo) -> PyResult<Py<PyAny>> {
+        match &self.storage.as_ref() {
+            Storage::Mmap(mmap) => {
+                let data =
+                    &mmap[info.data_offsets.0 + self.offset..info.data_offsets.1 + self.offset];
+
+                let array: Py<PyAny> = Python::attach(|py| -> PyResult<Py<PyAny>> {
+                    // Zero-copy: expose the mmap slice as a read-only Python
+                    // memoryview via the CPython C API.  torch.frombuffer
+                    // (called inside create_tensor) accepts any
+                    // buffer-protocol object and reads from the mmap address
+                    // directly, with no heap allocation.
+                    //
+                    // PyMemoryView_FromMemory(ptr, len, PyBUF_READ) creates a
+                    // memoryview that borrows the pointer without copying.
+                    //
+                    // SAFETY:
+                    //  - data is a sub-slice of self.storage (the Mmap), kept
+                    //    alive by Arc<Storage> for the full duration of this
+                    //    call and until the synchronous hook returns.
+                    //  - PyBUF_READ marks the view read-only; mutation raises
+                    //    TypeError on the Python side.
+                    //  - The raw pointer is checked for null before use.
+                    use pyo3::ffi;
+                    // PyBUF_READ = 0x100 marks the view read-only.
+                    // Defined inline since pyo3::ffi does not re-export it
+                    // in all versions.
+                    const PY_BUF_READ: std::os::raw::c_int = 0x100;
+                    let ptr = unsafe {
+                        ffi::PyMemoryView_FromMemory(
+                            data.as_ptr() as *mut i8,
+                            data.len() as isize,
+                            PY_BUF_READ,
+                        )
+                    };
+                    if ptr.is_null() {
+                        return Err(pyo3::PyErr::fetch(py));
+                    }
+                    // SAFETY: ptr is a valid non-null PyObject* from CPython.
+                    Ok(unsafe { PyBound::from_owned_ptr(py, ptr).unbind() })
+                })?;
+
+                create_tensor(
+                    &self.framework,
+                    info.dtype,
+                    &info.shape,
+                    array,
+                    &Device::Cpu,
+                )
+            }
+            Storage::Torch(_) | Storage::Paddle(_) => {
+                // Torch/Paddle storage backs its bytes in a Python-managed
+                // UntypedStorage / MmapStorage.  Extracting raw bytes from
+                // those without framework-specific Python calls is non-trivial;
+                // a follow-up can add those paths if needed.
+                Err(SafetensorError::new_err(
+                    "Custom device hooks with Torch/Paddle storage are not yet supported. \
+                     Use backend='pread' or open the file without a custom device.",
+                ))
+            }
+            Storage::Pread(file) => {
+                // Pread has no mmap to point into.  `PyByteArray::new_with`
+                // writes the pread bytes directly into a pre-allocated Python
+                // buffer — one copy from disk, no second copy.
+                let (begin, end) = info.data_offsets;
+                let nbytes = end - begin;
+                let file_offset = (self.offset + begin) as u64;
+
+                let array: Py<PyAny> = Python::attach(|py| -> PyResult<Py<PyAny>> {
+                    let pyarray = PyByteArray::new_with(py, nbytes, |dst| {
+                        if !dst.is_empty() {
+                            read_exact_at(file, dst, file_offset).map_err(|e| {
+                                SafetensorError::new_err(format!(
+                                    "Could not read tensor {name} from file: {e}"
+                                ))
+                            })?;
+                        }
+                        Ok(())
+                    })?;
+                    Ok(pyarray.into_any().into())
+                })?;
+                create_tensor(&self.framework, info.dtype, &info.shape, array, &Device::Cpu)
+            }
         }
     }
 
@@ -2512,6 +2745,8 @@ fn _safetensors_rust(m: &PyBound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(serialize, m)?)?;
     m.add_function(wrap_pyfunction!(serialize_file, m)?)?;
     m.add_function(wrap_pyfunction!(deserialize, m)?)?;
+    m.add_function(wrap_pyfunction!(_register_device_transfer_hook, m)?)?;
+    m.add_function(wrap_pyfunction!(_is_custom_device, m)?)?;
     m.add_class::<TensorSpec>()?;
     m.add_class::<safe_open>()?;
     m.add_class::<_safe_open_handle>()?;

--- a/bindings/python/tests/test_pt_comparison.py
+++ b/bindings/python/tests/test_pt_comparison.py
@@ -14,6 +14,18 @@ try:
 except Exception:
     npu_present = False
 
+try:
+    import torch_spyre  # noqa — registers Spyre device + safetensors hook
+
+    # Boot the runtime so the RuntimeContext exists before any DMA call.
+    # safe_open() itself does not start the runtime; the first device
+    # allocation does.  Doing it here means the skip-guard below is the
+    # only Spyre-specific logic outside the test body.
+    torch.empty(0, dtype=torch.float16, device="spyre")
+    spyre_present = True
+except Exception:
+    spyre_present = False
+
 
 class TorchTestCase(unittest.TestCase):
     def test_serialization(self):
@@ -360,6 +372,89 @@ class TorchTestCase(unittest.TestCase):
                 whole = f.get_tensor("emb")
                 self.assertEqual(whole.device.type, "mps")
                 self.assertTrue(torch.equal(whole.cpu(), data["emb"]))
+
+    @unittest.skipIf(not spyre_present, "Spyre is not available")
+    def test_spyre_slice(self):
+        # Exercises PySafeSlice::__getitem__ -> slice_custom_device hook dispatch.
+        #
+        # get_slice(key)[...] must:
+        #   1. land on the Spyre device (not silently fall back to CPU), and
+        #   2. produce the same values as the equivalent CPU slice.
+        #
+        # Covers: leading-dim slab, strided column, 1-D slice, full-tensor
+        # equivalence with get_tensor, and a partial-row slice -- on both the
+        # mmap and pread backends.
+        data = {
+            # 2-D weight: exercises leading-dim and column slices
+            "emb": torch.arange(32 * 16, dtype=torch.float16).reshape(32, 16),
+            # 1-D vector: exercises 1-D slice
+            "vec": torch.arange(10, dtype=torch.float16),
+        }
+        local = "./tests/data/out_safe_pt_mmap_small_spyre_slice.safetensors"
+        save_file(data, local)
+
+        for backend in ("mmap", "pread"):
+            with safe_open(local, framework="pt", device="spyre", backend=backend) as f:
+                # contiguous leading-dim slab
+                contiguous = f.get_slice("emb")[8:20, :]
+                self.assertEqual(
+                    contiguous.device.type, "spyre",
+                    f"leading-dim slab ({backend}): expected spyre, got "
+                    f"{contiguous.device.type} -- __getitem__ did not dispatch "
+                    f"to the Spyre hook",
+                )
+                self.assertTrue(
+                    torch.equal(contiguous.cpu(), data["emb"][8:20, :]),
+                    f"leading-dim slab value mismatch ({backend})",
+                )
+
+                # strided column slice (multi-segment gather)
+                strided = f.get_slice("emb")[:, 4:12]
+                self.assertEqual(
+                    strided.device.type, "spyre",
+                    f"column slice ({backend}): expected spyre, got "
+                    f"{strided.device.type}",
+                )
+                self.assertTrue(
+                    torch.equal(strided.cpu(), data["emb"][:, 4:12]),
+                    f"column slice value mismatch ({backend})",
+                )
+
+                # 1-D slice
+                vec = f.get_slice("vec")[2:7]
+                self.assertEqual(
+                    vec.device.type, "spyre",
+                    f"1d slice ({backend}): expected spyre, got {vec.device.type}",
+                )
+                self.assertTrue(
+                    torch.equal(vec.cpu(), data["vec"][2:7]),
+                    f"1d slice value mismatch ({backend})",
+                )
+
+                # full-tensor slice must equal get_tensor, both on Spyre
+                via_slice = f.get_slice("emb")[:]
+                via_tensor = f.get_tensor("emb")
+                self.assertEqual(via_slice.device.type, "spyre",
+                                 f"full slice ({backend}): not on spyre")
+                self.assertEqual(via_tensor.device.type, "spyre",
+                                 f"get_tensor ({backend}): not on spyre")
+                self.assertTrue(
+                    torch.equal(via_slice.cpu(), via_tensor.cpu()),
+                    f"get_slice(emb)[:] != get_tensor(emb) ({backend})",
+                )
+
+                # partial row slice
+                half = data["emb"].shape[0] // 2
+                partial = f.get_slice("emb")[:half, :]
+                self.assertEqual(
+                    partial.device.type, "spyre",
+                    f"partial row slice ({backend}): expected spyre, got "
+                    f"{partial.device.type}",
+                )
+                self.assertTrue(
+                    torch.equal(partial.cpu(), data["emb"][:half, :]),
+                    f"partial row slice value mismatch ({backend})",
+                )
 
     @unittest.skipIf(not npu_present, "Npu is not available")
     def test_npu(self):


### PR DESCRIPTION
# What does this PR do?
Add custom device support into the Rust core. Introduces a global 
DEVICE_HOOKS registry in lib.rs that third-party device packages 
(e.g. torch_spyre) populate at import time via _register_device_transfer_hook().

- Add Device::Custom(String, Option<usize>) variant with full
  FromPyObject / IntoPyObject / Display support
- Validate hook registration eagerly at Open::new time rather than
  lazily at get_tensor()
- Skip torch.UntypedStorage.from_file for custom devices so Storage::Mmap
  is used, enabling the zero-copy hook path
- Add get_tensor_bytes_for_hook(): zero-copy PyMemoryView (mmap backend)
  or single-copy pread into pre-allocated buffer (pread backend)
- Add _is_custom_device() Rust query so load_model() can auto-select
  the assign path for custom devices without a Python-side mirror dict
- Add _assign_tensors_to_model() with shape/dtype validation and correct
  unexpected_keys accounting for tied weights
- numpy/paddle/flax/tf bindings benefit automatically since hook
  dispatch lives in the Rust core, not torch.py

With these changes safe_open, load_file and load_model works with
device=spyre
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue) or description of the problem this PR solves.

## AI model use

We do accept PRs that were developed together with an AI model, but we ask
that you to fill out this section.

- [ ] No AI model was used when making this PR.
- [ ] An AI model assisted me in developing this PR.
- [ ] Development of this PR was done by an AI model.

If you ticked one of the last two options, please state the model and model
version that you used:

If you ticked the last option, please list the prompt(s) that you used:
