### PR TITLE
fix: best-effort set_len, ignore ENOTSUP on preallocation

### DIFF
--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -312,7 +312,15 @@ fn buffered_write_to_file<V: View>(
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     let temp = tempfile::NamedTempFile::new_in(parent)?;
 
-    temp.as_file().set_len(total_size as u64)?;
+    // Preallocation is best-effort: `set_len` is only an optimization, the
+    // sequential `write_all` below still produces a correctly-sized file.
+    // Some filesystems (e.g. certain FUSE backends) reject truncate/preallocation
+    // with ENOTSUP; ignore that specific case instead of failing the whole save.
+    if let Err(e) = temp.as_file().set_len(total_size as u64) {
+        if e.kind() != std::io::ErrorKind::Unsupported {
+            return Err(e.into());
+        }
+    }
 
     // Serialize tensors to a file using direct I/O (bypassing page cache) using F_NOCACHE.
     // This yields ~30% performance improvement.


### PR DESCRIPTION
set_len (ftruncate) before writing is only a preallocation optimization; the sequential write_all still produces a correctly-sized file. Some filesystems (e.g. certain FUSE backends) reject truncate/preallocation with ENOTSUP, which made save_file fail for files larger than the backend's truncate limit. Ignore ErrorKind::Unsupported from set_len and fall through to the normal write; all other errors are still propagated.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue) or description of the problem this PR solves.

## AI model use

We do accept PRs that were developed together with an AI model, but we ask
that you to fill out this section.

- [ ] No AI model was used when making this PR.
- [ ] An AI model assisted me in developing this PR.
- [x] Development of this PR was done by an AI model.

If you ticked one of the last two options, please state the model and model
version that you used:
Opus 4.8 via cursor
If you ticked the last option, please list the prompt(s) that you used:
On filesystems whose ftruncate returns ENOTSUP (some FUSE backends), this makes save_file fail even though the sequential write_all would produce a correct file. Make the preallocation best-effort: ignore io::ErrorKind::Unsupported from set_len and fall through to the write, but still propagate all other errors.
