### PR TITLE
Avoid mutating metadata in save_model

### DIFF
--- a/bindings/python/py_src/safetensors/torch.py
+++ b/bindings/python/py_src/safetensors/torch.py
@@ -169,6 +169,9 @@ def save_model(
             could potentially change performance if the layout of the tensor
             was chosen specifically for that reason.
     """
+    if metadata is not None:
+        metadata = metadata.copy()
+
     state_dict = model.state_dict()
     to_removes = _remove_duplicate_names(state_dict)
 

--- a/bindings/python/tests/test_pt_model.py
+++ b/bindings/python/tests/test_pt_model.py
@@ -175,6 +175,23 @@ class TorchModelTestCase(unittest.TestCase):
         for k, v in model2.state_dict().items():
             torch.testing.assert_close(v, state_dict[k])
 
+    def test_save_does_not_mutate_metadata(self):
+        model = OnesModel()
+        metadata = {"format": "pt"}
+
+        save_model(model, "tmp_ones.safetensors", metadata=metadata)
+
+        self.assertEqual(metadata, {"format": "pt"})
+        with safe_open("tmp_ones.safetensors", framework="pt") as f:
+            self.assertEqual(
+                f.metadata(),
+                {
+                    "format": "pt",
+                    "b.bias": "a.bias",
+                    "b.weight": "a.weight",
+                },
+            )
+
     def test_workaround(self):
         model = Model()
         save_model(model, "tmp.safetensors")


### PR DESCRIPTION
`save_model` adds entries for tensor names dropped while handling shared storage. When callers supplied a metadata dictionary, those entries were added to the same dictionary and remained visible after the save completed.

Copy the metadata mapping before adding the internal shared-tensor entries. The file metadata is unchanged, while the caller's input remains intact.

A regression test covers both sides of the behavior: the input dictionary is unchanged and the saved file still contains the user metadata plus the generated tensor aliases.

Tests:

- `PYTHONPATH=bindings/python/py_src .venv/bin/python -m pytest bindings/python/tests/test_pt_model.py -q`
- `PYTHONPATH=bindings/python/py_src .venv/bin/python -m pytest bindings/python/tests/test_simple.py bindings/python/tests/test_pread_backend.py -q`
- `.venv/bin/ruff check bindings/python/py_src/safetensors/torch.py bindings/python/tests/test_pt_model.py`
- `.venv/bin/ruff format --check bindings/python/py_src/safetensors/torch.py bindings/python/tests/test_pt_model.py`

Rust tests were not run because the local machine does not have a Rust toolchain; this change only touches the Python adapter and its tests.
