### PR TITLE
Fix panic when slicing with a backwards range (start > stop)

### DIFF
--- a/safetensors/src/slice.rs
+++ b/safetensors/src/slice.rs
@@ -347,6 +347,9 @@ pub fn slice_byte_ranges(
     // Minimum span is the span of 1 item;
     let mut span = dtype.bitsize();
     let mut indices: Vec<(usize, usize)> = vec![];
+    // Whether some dimension selected zero elements, making the whole
+    // slice empty.
+    let mut is_empty = false;
     // Everything is row major.
     for (i, &dim) in shape.iter().enumerate().rev() {
         if i >= slices.len() {
@@ -372,6 +375,13 @@ pub fn slice_byte_ranges(
                     asked,
                     dim_size: dim,
                 });
+            }
+            // A backwards range (`start > stop`, e.g. `2:1`) selects
+            // nothing; clamp it to an empty range as numpy does instead
+            // of letting `stop - start` underflow below.
+            let stop = stop.max(start);
+            if start == stop {
+                is_empty = true;
             }
             if !matches!(slice, TensorIndexer::Select(_)) {
                 newshape.push((stop - start).div_ceil(step));
@@ -415,7 +425,13 @@ pub fn slice_byte_ranges(
         }
         span *= dim;
     }
-    if indices.is_empty() {
+    if is_empty {
+        // Some dimension selected zero elements, so the slice holds no
+        // bytes at all; drop any ranges accumulated before that
+        // dimension was reached so the fallback below cannot resurrect
+        // the full tensor.
+        indices = vec![];
+    } else if indices.is_empty() {
         // Empty `slices` (or all unbounded full-range slices): no slicing
         // happened, the whole tensor is the result. `span` ended as
         // bitsize * product(shape).
@@ -760,5 +776,58 @@ mod tests {
             ),
             Err(InvalidSlice::TooManySlices)
         );
+    }
+
+    #[test]
+    fn test_empty_and_backwards_range() {
+        let data: Vec<u8> = vec![0.0f32, 1.0, 2.0, 3.0, 4.0, 5.0]
+            .into_iter()
+            .flat_map(|f| f.to_le_bytes())
+            .collect();
+
+        let attn_0 = TensorView::new(Dtype::F32, vec![2, 3], &data).unwrap();
+
+        // Backwards range on the innermost dim (`arr[:, 2:1]` in numpy):
+        // used to underflow `stop - start` and panic; must be empty.
+        let mut iterator = SliceIterator::new(
+            &attn_0,
+            &[
+                TensorIndexer::Narrow(Bound::Unbounded, Bound::Unbounded, NonZeroUsize::MIN),
+                TensorIndexer::Narrow(Bound::Included(2), Bound::Excluded(1), NonZeroUsize::MIN),
+            ],
+        )
+        .unwrap();
+        assert_eq!(iterator.newshape(), vec![2, 0]);
+        assert_eq!(iterator.remaining_byte_len(), 0);
+        assert_eq!(iterator.by_ref().map(<[u8]>::len).sum::<usize>(), 0);
+
+        // Backwards range on the outer dim combined with a real slice on
+        // the inner dim (`arr[1:0, 1:3]`): the accumulated inner ranges
+        // must be discarded, not replaced by the full tensor.
+        let mut iterator = SliceIterator::new(
+            &attn_0,
+            &[
+                TensorIndexer::Narrow(Bound::Included(1), Bound::Excluded(0), NonZeroUsize::MIN),
+                TensorIndexer::Narrow(Bound::Included(1), Bound::Excluded(3), NonZeroUsize::MIN),
+            ],
+        )
+        .unwrap();
+        assert_eq!(iterator.newshape(), vec![0, 2]);
+        assert_eq!(iterator.remaining_byte_len(), 0);
+        assert_eq!(iterator.by_ref().map(<[u8]>::len).sum::<usize>(), 0);
+
+        // In-order empty range on the outer dim (`arr[1:1, 1:3]`): same
+        // invariant without any backwards bound.
+        let mut iterator = SliceIterator::new(
+            &attn_0,
+            &[
+                TensorIndexer::Narrow(Bound::Included(1), Bound::Excluded(1), NonZeroUsize::MIN),
+                TensorIndexer::Narrow(Bound::Included(1), Bound::Excluded(3), NonZeroUsize::MIN),
+            ],
+        )
+        .unwrap();
+        assert_eq!(iterator.newshape(), vec![0, 2]);
+        assert_eq!(iterator.remaining_byte_len(), 0);
+        assert_eq!(iterator.by_ref().map(<[u8]>::len).sum::<usize>(), 0);
     }
 }


### PR DESCRIPTION
# What does this PR do?

Fixes a panic (unsigned-integer underflow) when slicing a tensor with a backwards range, i.e. `start > stop`, such as `f.get_slice(name)[:, 2:1]`.

**Root cause.** `slice_byte_ranges` resolves each indexer to a `(start, stop)` element range and validates it only against the dimension size (`start >= dim || stop > dim`). It never enforces `start <= stop`, so an in-bounds backwards range like `2:1` on a dimension of size 3 slips through and reaches `(stop - start).div_ceil(step)`:

- **debug builds:** `thread panicked at src/slice.rs:377:31: attempt to subtract with overflow`
- **release builds** (the published wheels): the subtraction wraps to a garbage shape/byte ranges and panics later during byte-range indexing (`slice index starts at 8 but ends at 4` at `slice.rs:440`).

numpy treats a backwards slice as empty (`arr[2:1]` has shape `(0,)`), so this should yield an empty slice, not a crash.

**Fix.** Clamp `stop` to `start` after the bounds check, so a backwards range resolves to an empty selection (`newshape` gets a 0 dim, zero bytes yielded). This surfaced a second latent issue in the same path: when an empty selection on an *outer* dimension wipes the previously accumulated inner byte ranges, the `indices.is_empty()` fallback at the end of the function would return the **full tensor** instead of an empty one (already reproducible on `main` with the in-order empty range `arr[1:1, 1:3]`). The function now tracks emptiness explicitly and returns no byte ranges in that case.

Note: this is complementary to #809, which hardens the `*s + 1` *upper*-bound overflow in the same function but does not cover the backwards-range (`start > stop`) underflow.

**Tests.** Added `test_empty_and_backwards_range` covering: a backwards range on the innermost dim (`[:, 2:1]` — panicked before), a backwards range on an outer dim combined with a real inner slice (`[1:0, 1:3]` — fallback returned the full tensor), and an in-order empty range (`[1:1, 1:3]`). Verified the new test fails on `main` (`attempt to subtract with overflow` at `slice.rs:377:31`) and passes with the fix; full suite green in debug, release, and `--no-default-features`, plus `cargo clippy --all-targets -- -D warnings`.

## AI model use

We do accept PRs that were developed together with an AI model, but we ask
that you to fill out this section.

- [ ] No AI model was used when making this PR.
- [x] An AI model assisted me in developing this PR.
- [ ] Development of this PR was done by an AI model.

If you ticked one of the last two options, please state the model and model
version that you used:

A general-purpose AI coding assistant.

If you ticked the last option, please list the prompt(s) that you used:

