### PR TITLE
fix: large tensors failing to load on 32-bit targets

### DIFF
--- a/safetensors/src/slice.rs
+++ b/safetensors/src/slice.rs
@@ -345,7 +345,11 @@ pub fn slice_byte_ranges(
     let mut newshape = Vec::with_capacity(n_shape);
 
     // Minimum span is the span of 1 item;
-    let mut span = dtype.bitsize();
+    // Bit-level quantities are kept in u64 so they cannot wrap on 32-bit
+    // targets. The byte offsets converted back below are bounded by the
+    // tensor's total byte size, which `TensorView::new`/`Metadata::validate`
+    // already proved fits usize, so the conversions cannot truncate.
+    let mut span = dtype.bitsize() as u64;
     let mut indices: Vec<(usize, usize)> = vec![];
     // Everything is row major.
     for (i, &dim) in shape.iter().enumerate().rev() {
@@ -380,32 +384,35 @@ pub fn slice_byte_ranges(
                 if step == 1 && start == 0 && stop == dim {
                     // Full range, nothing sliced yet; just grow the span.
                 } else if step == 1 {
-                    if start * span % 8 != 0 {
+                    if start as u64 * span % 8 != 0 {
                         return Err(InvalidSlice::MisalignedSlice);
                     }
-                    let offset = (start * span) / 8;
-                    if stop * span % 8 != 0 {
+                    let offset = (start as u64 * span / 8) as usize;
+                    if stop as u64 * span % 8 != 0 {
                         return Err(InvalidSlice::MisalignedSlice);
                     }
-                    let small_span = (stop * span) / 8 - offset;
+                    let small_span = (stop as u64 * span / 8) as usize - offset;
                     indices.push((offset, offset + small_span));
                 } else {
                     // Strided innermost dim: each kept element is its own run.
                     for n in (start..stop).step_by(step) {
-                        if n * span % 8 != 0 || (n + 1) * span % 8 != 0 {
+                        if n as u64 * span % 8 != 0 || (n as u64 + 1) * span % 8 != 0 {
                             return Err(InvalidSlice::MisalignedSlice);
                         }
-                        indices.push(((n * span) / 8, ((n + 1) * span) / 8));
+                        indices.push((
+                            (n as u64 * span / 8) as usize,
+                            ((n as u64 + 1) * span / 8) as usize,
+                        ));
                     }
                 }
             } else {
                 let capacity = (stop - start).div_ceil(step) * indices.len();
                 let mut newindices = Vec::with_capacity(capacity);
                 for n in (start..stop).step_by(step) {
-                    if n * span % 8 != 0 {
+                    if n as u64 * span % 8 != 0 {
                         return Err(InvalidSlice::MisalignedSlice);
                     }
-                    let offset = (n * span) / 8;
+                    let offset = (n as u64 * span / 8) as usize;
                     for (old_start, old_stop) in &indices {
                         newindices.push((old_start + offset, old_stop + offset));
                     }
@@ -413,7 +420,7 @@ pub fn slice_byte_ranges(
                 indices = newindices;
             }
         }
-        span *= dim;
+        span *= dim as u64;
     }
     if indices.is_empty() {
         // Empty `slices` (or all unbounded full-range slices): no slicing
@@ -423,7 +430,7 @@ pub fn slice_byte_ranges(
         if total_bits % 8 != 0 {
             return Err(InvalidSlice::MisalignedSlice);
         }
-        indices.push((0, total_bits / 8));
+        indices.push((0, (total_bits / 8) as usize));
     }
     let newshape = newshape.into_iter().rev().collect();
     Ok((indices, newshape))
@@ -445,6 +452,25 @@ impl<'data> Iterator for SliceIterator<'data> {
 mod tests {
     use super::*;
     use crate::tensor::{Dtype, TensorView};
+
+    #[test]
+    fn test_slice_byte_ranges_large_tensor() {
+        // 196_761_600 F32 elements is ~6.3e9 bits, more than a 32-bit usize
+        // holds; the byte offsets all fit. The bit-level intermediates must
+        // not wrap on 32-bit targets.
+        let (ranges, newshape) = slice_byte_ranges(
+            Dtype::F32,
+            &[196_761_600],
+            &[TensorIndexer::Narrow(
+                Bound::Included(196_000_000),
+                Bound::Excluded(196_000_004),
+                NonZeroUsize::MIN,
+            )],
+        )
+        .unwrap();
+        assert_eq!(ranges, vec![(784_000_000, 784_000_016)]);
+        assert_eq!(newshape, vec![4]);
+    }
 
     #[test]
     fn test_helpers() {

--- a/safetensors/src/tensor.rs
+++ b/safetensors/src/tensor.rs
@@ -596,6 +596,26 @@ impl Serialize for Metadata {
     }
 }
 
+/// Checked byte size of a tensor from its shape and dtype.
+///
+/// The element and bit counts are computed in u64 so that a tensor whose bit
+/// count exceeds usize::MAX on 32-bit targets is still accepted as long as
+/// its byte size fits in usize.
+fn checked_byte_size(shape: &[usize], dtype: Dtype) -> Result<usize, SafeTensorError> {
+    let nelements: u64 = shape
+        .iter()
+        .copied()
+        .try_fold(1u64, |acc, d| acc.checked_mul(d as u64))
+        .ok_or(SafeTensorError::ValidationOverflow)?;
+    let nbits = nelements
+        .checked_mul(dtype.bitsize() as u64)
+        .ok_or(SafeTensorError::ValidationOverflow)?;
+    if nbits % 8 != 0 {
+        return Err(SafeTensorError::MisalignedSlice);
+    }
+    usize::try_from(nbits / 8).map_err(|_| SafeTensorError::ValidationOverflow)
+}
+
 impl Metadata {
     /// Creates a new metadata structure.
     /// May fail if there is incorrect data in the Tensor Info.
@@ -639,22 +659,7 @@ impl Metadata {
 
             start = e;
 
-            let nelements: usize = info
-                .shape
-                .iter()
-                .copied()
-                .try_fold(1usize, usize::checked_mul)
-                .ok_or(SafeTensorError::ValidationOverflow)?;
-            let nbits = nelements
-                .checked_mul(info.dtype.bitsize())
-                .ok_or(SafeTensorError::ValidationOverflow)?;
-
-            if nbits % 8 != 0 {
-                return Err(SafeTensorError::MisalignedSlice);
-            }
-            let size = nbits
-                .checked_div(8)
-                .ok_or(SafeTensorError::ValidationOverflow)?;
+            let size = checked_byte_size(&info.shape, info.dtype)?;
 
             if e - s != size {
                 return Err(SafeTensorError::TensorInvalidInfo);
@@ -752,15 +757,7 @@ impl<'data> TensorView<'data> {
         shape: Vec<usize>,
         data: &'data [u8],
     ) -> Result<Self, SafeTensorError> {
-        let n_elements: usize = shape.iter().product();
-
-        let nbits = n_elements * dtype.bitsize();
-        if nbits % 8 != 0 {
-            return Err(SafeTensorError::MisalignedSlice);
-        }
-        let size = nbits
-            .checked_div(8)
-            .ok_or(SafeTensorError::ValidationOverflow)?;
+        let size = checked_byte_size(&shape, dtype)?;
 
         if data.len() != size {
             Err(SafeTensorError::InvalidTensorView(dtype, shape, data.len()))
@@ -1591,6 +1588,36 @@ mod tests {
             }
             _ => panic!("This should not be able to be deserialized"),
         }
+    }
+
+    #[test]
+    fn test_tensor_view_overflow_shapes() {
+        // The element count wraps to zero in unchecked usize arithmetic,
+        // which release builds previously accepted as an empty tensor.
+        let shape = vec![2, usize::MAX / 2 + 1];
+        match TensorView::new(Dtype::F32, shape, &[]) {
+            Err(SafeTensorError::ValidationOverflow) => {}
+            something => panic!("This should not be a valid view, got {something:?}"),
+        }
+        // The element count fits but the byte size is not addressable.
+        match TensorView::new(Dtype::F32, vec![usize::MAX], &[]) {
+            Err(SafeTensorError::ValidationOverflow) => {}
+            something => panic!("This should not be a valid view, got {something:?}"),
+        }
+    }
+
+    #[test]
+    fn test_validation_large_tensor_bit_count() {
+        // 196_761_600 F32 elements is ~6.3e9 bits, which overflows a 32-bit
+        // usize, while the byte size (787_046_400) fits. Validation must
+        // accept this on 32-bit targets such as wasm32.
+        let info = TensorInfo {
+            dtype: Dtype::F32,
+            shape: vec![196_761_600],
+            data_offsets: (0, 787_046_400),
+        };
+        let metadata = Metadata::new(None, vec![("embed".to_string(), info)]).unwrap();
+        assert_eq!(metadata.data_len(), 787_046_400);
     }
 
     #[test]


### PR DESCRIPTION
# What does this PR do?

Fixes #817. Also fixes #765 and #781, and the `TensorView::new` half of #808.

## Problem

On 32-bit targets (wasm32), `deserialize` rejects valid files with `ValidationOverflow` once a single tensor reaches 2^32 *bits*, even when its byte size fits `usize`. Example: a 196M-element F32 embedding table (~787MB) fails to load in the browser.

## Solution

Compute element/bit counts in `u64` and convert only the final byte size back with `usize::try_from`, in a shared `checked_byte_size` helper. This fixes the three places that do this arithmetic:

- `Metadata::validate` — the rejection from #817
- `TensorView::new` — was unchecked: huge shapes could wrap and be accepted in release builds (#765/#781)
- `slice_byte_ranges` — bit-level spans wrapped on 32-bit, producing wrong byte ranges

No new error variants; 64-bit behavior is unchanged.

## Testing

Verified on wasm32-wasip1: the 787MB tensor now deserializes and slices to the correct bytes (previously `ValidationOverflow`, and silently wrong slice offsets). New tests cover large-tensor validation, slice ranges, and the overflow rejections. `build --all-targets`, clippy `-D warnings`, `test`, and `test --no-default-features` all pass.
